### PR TITLE
Use a list of tokens obtained by any external tokenizer in Sentence class

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -273,7 +273,7 @@ class Sentence:
     A Sentence is a list of Tokens and is used to represent a sentence or text fragment.
     """
 
-    def __init__(self, text: str = None, use_tokenizer: bool = False, labels: Union[List[Label], List[str]] = None):
+    def __init__(self, text: str = None, use_tokenizer: bool = False, tokens_from_list: List[str] = None, labels: Union[List[Label], List[str]] = None):
 
         super(Sentence, self).__init__()
 
@@ -290,12 +290,17 @@ class Sentence:
             # tokenize the text first if option selected
             if use_tokenizer:
 
+                if tokens_from_list is not None and len(tokens_from_list) > 0:
+                # use a list of tokens obtained by any tokenizer of your choice
+                    tokens = tokens_from_list
+                
+                else:
                 # use segtok for tokenization
-                tokens = []
-                sentences = split_single(text)
-                for sentence in sentences:
-                    contractions = split_contractions(word_tokenizer(sentence))
-                    tokens.extend(contractions)
+                    tokens = []
+                    sentences = split_single(text)
+                    for sentence in sentences:
+                        contractions = split_contractions(word_tokenizer(sentence))
+                        tokens.extend(contractions)
 
                 # determine offsets for whitespace_after field
                 index = text.index


### PR DESCRIPTION
Related to this [discussion](https://github.com/zalandoresearch/flair/issues/563#issuecomment-476555364) and the possibility to use any tokenizer we want to use in the Sentence class. 

The current way to use an external tokenizer ( sentence = Sentence(' '.join(tokens_from_list)) ) is in my opinion not robust when we want to combine the SequenceTagger with other methods in a processing pipeline. Indeed, the indexes from original text and the text in the Sentence class will not be the same.

The ability to import tokens from a list in the Sentence class solves this problem and makes life easier for users 😃 .