### PR TITLE
GH-1266 Remove redundant cpu() and detach() calls

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2260,7 +2260,9 @@ class BertEmbeddings(TokenEmbeddings):
                                 sentence_index
                             ]
                         else:
-                            layer_output = all_encoder_layers[int(layer_index)][sentence_index]
+                            layer_output = all_encoder_layers[int(layer_index)][
+                                sentence_index
+                            ]
                         all_layers.append(layer_output[token_index])
 
                     if self.use_scalar_mix:
@@ -3199,6 +3201,7 @@ class NILCEmbeddings(WordEmbeddings):
 class IdentityImageEmbeddings(ImageEmbeddings):
     def __init__(self, transforms):
         import PIL as pythonimagelib
+
         self.PIL = pythonimagelib
         self.name = "Identity"
         self.transforms = transforms

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2260,11 +2260,7 @@ class BertEmbeddings(TokenEmbeddings):
                                 sentence_index
                             ]
                         else:
-                            layer_output = (
-                                all_encoder_layers[int(layer_index)]
-                                .detach()
-                                .cpu()[sentence_index]
-                            )
+                            layer_output = all_encoder_layers[int(layer_index)][sentence_index]
                         all_layers.append(layer_output[token_index])
 
                     if self.use_scalar_mix:


### PR DESCRIPTION
#1266 

Currently we call `.cpu()` and `detach()` in for loop on a per-token basis.  AFAIK, this is redundant because when we assign the embedding to the token, we will allocate it to the right device/detach it as necessary.

As I outlined in the issue and the associated [gist](https://gist.github.com/shoarora/a8aa6ac39ee814b667907ced4bfda6c9), this will dramatically improve runtime, as we'll move to `cpu()` _after_ we've aggregated all the desired embeddings.  

I didn't receive confirmation on my issue that this functionality works the way that I understand it.  Hopefully, I'm not missing a key piece of the implementation that actually makes this required.