### PR TITLE
relax version requirements for Colab installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ script:
   - pip freeze
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then pytest --runintegration; fi'
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then pytest; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then pip install black; black --check .; fi'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![alt text](resources/docs/flair_logo.svg)
+![alt text](resources/docs/flair_logo_2020.png)
 
 [![PyPI version](https://badge.fury.io/py/flair.svg)](https://badge.fury.io/py/flair)
 [![GitHub Issues](https://img.shields.io/github/issues/zalandoresearch/flair.svg)](https://github.com/zalandoresearch/flair/issues)

--- a/flair/visual/training_curves.py
+++ b/flair/visual/training_curves.py
@@ -6,17 +6,7 @@ from typing import Union, List
 import numpy as np
 import csv
 
-import matplotlib
 import math
-
-
-# change from Agg to TkAgg for interactive mode
-try:
-    # change from Agg to TkAgg for interactive mode
-    matplotlib.use("TkAgg")
-except:
-    pass
-
 
 import matplotlib.pyplot as plt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-python-dateutil==2.8.0
+python-dateutil>=2.8.1
 torch>=1.1.0
 gensim>=3.4.0
-pytest>=3.6.4
+pytest>=5.3.2
 tqdm>=4.26.0
 segtok>=1.5.7
 matplotlib>=2.2.3
 mpld3==0.3
-sklearn
+scikit-learn>=0.21.3
 sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.1.1

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Alan Akbik",
-    author_email="alan.akbik@zalando.de",
-    url="https://github.com/zalandoresearch/flair",
+    author_email="alan.akbik@gmail.com",
+    url="https://github.com/flairNLP/flair",
     packages=find_packages(exclude="tests"),  # same as name
     license="MIT",
     install_requires=required,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -42,6 +42,7 @@ def test_keep_batch_order():
 
     assert torch.norm(sentences_1[0].embedding - sentences_2[1].embedding) == 0.0
     assert torch.norm(sentences_1[0].embedding - sentences_2[1].embedding) == 0.0
+    del embeddings
 
 
 @pytest.mark.integration
@@ -58,6 +59,7 @@ def test_stacked_embeddings():
         token.clear_embeddings()
 
         assert len(token.get_embedding()) == 0
+    del embeddings
 
 
 @pytest.mark.integration
@@ -97,6 +99,7 @@ def test_fine_tunable_flair_embedding():
     sentence.clear_embeddings()
 
     assert len(sentence.get_embedding()) == 0
+    del embeddings
 
 
 @pytest.mark.integration
@@ -115,6 +118,7 @@ def test_document_lstm_embeddings():
     sentence.clear_embeddings()
 
     assert len(sentence.get_embedding()) == 0
+    del embeddings
 
 
 @pytest.mark.integration
@@ -133,6 +137,7 @@ def test_document_bidirectional_lstm_embeddings():
     sentence.clear_embeddings()
 
     assert len(sentence.get_embedding()) == 0
+    del embeddings
 
 
 @pytest.mark.integration
@@ -151,6 +156,7 @@ def test_document_pool_embeddings():
         sentence.clear_embeddings()
 
         assert len(sentence.get_embedding()) == 0
+        del embeddings
 
 
 @pytest.mark.integration
@@ -169,6 +175,7 @@ def test_document_pool_embeddings_nonlinear():
         sentence.clear_embeddings()
 
         assert len(sentence.get_embedding()) == 0
+        del embeddings
 
 
 def init_document_embeddings():
@@ -193,6 +200,7 @@ def load_and_apply_word_embeddings(emb_type: str):
         token.clear_embeddings()
 
         assert len(token.get_embedding()) == 0
+    del embeddings
 
 
 def load_and_apply_char_lm_embeddings(emb_type: str):
@@ -207,3 +215,4 @@ def load_and_apply_char_lm_embeddings(emb_type: str):
         token.clear_embeddings()
 
         assert len(token.get_embedding()) == 0
+    del embeddings

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -13,6 +13,8 @@ from flair.hyperparameter import (
 )
 import flair.datasets
 
+glove_embedding: WordEmbeddings = WordEmbeddings("glove")
+
 
 @pytest.mark.integration
 def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
@@ -27,16 +29,7 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
     search_space.add(
         Parameter.EMBEDDINGS,
         hp.choice,
-        options=[
-            StackedEmbeddings([WordEmbeddings("glove")]),
-            StackedEmbeddings(
-                [
-                    WordEmbeddings("glove"),
-                    FlairEmbeddings("news-forward-fast"),
-                    FlairEmbeddings("news-backward-fast"),
-                ]
-            ),
-        ],
+        options=[StackedEmbeddings([glove_embedding])],
     )
     search_space.add(Parameter.USE_CRF, hp.choice, options=[True, False])
     search_space.add(Parameter.DROPOUT, hp.uniform, low=0.25, high=0.75)
@@ -63,13 +56,12 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del optimizer, search_space
 
 
 @pytest.mark.integration
 def test_text_classifier_param_selector(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
-
-    glove_embedding: WordEmbeddings = WordEmbeddings("glove")
 
     search_space = SearchSpace()
 
@@ -97,3 +89,4 @@ def test_text_classifier_param_selector(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del param_selector, search_space

--- a/tests/test_language_model.py
+++ b/tests/test_language_model.py
@@ -35,6 +35,7 @@ def test_generate_text_with_small_temperatures():
     )
     assert text is not None
     assert len(text) >= 100
+    del language_model
 
 
 def test_compute_perplexity():
@@ -70,3 +71,4 @@ def test_compute_perplexity():
     print(f'"{ungrammatical}" - perplexity is {perplexity_ungramamtical_sentence}')
 
     assert perplexity_gramamtical_sentence < perplexity_ungramamtical_sentence
+    del language_model

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -18,6 +18,11 @@ from flair.samplers import ImbalancedClassificationDatasetSampler
 from flair.trainers import ModelTrainer
 from flair.trainers.language_model_trainer import LanguageModelTrainer, TextCorpus
 
+turian_embeddings = WordEmbeddings("turian")
+flair_embeddings = FlairEmbeddings("news-forward-fast")
+document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
+    [turian_embeddings], 128, 1, False, 64, False, False
+)
 
 @pytest.mark.integration
 def test_train_load_use_tagger(results_base_path, tasks_base_path):
@@ -26,11 +31,9 @@ def test_train_load_use_tagger(results_base_path, tasks_base_path):
     )
     tag_dictionary = corpus.make_tag_dictionary("ner")
 
-    embeddings = WordEmbeddings("turian")
-
     tagger: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=turian_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="ner",
         use_crf=False,
@@ -47,6 +50,7 @@ def test_train_load_use_tagger(results_base_path, tasks_base_path):
         shuffle=False,
     )
 
+    del trainer, tagger, tag_dictionary, corpus
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
     )
@@ -60,6 +64,7 @@ def test_train_load_use_tagger(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -67,11 +72,9 @@ def test_train_load_use_tagger_large(results_base_path, tasks_base_path):
     corpus = flair.datasets.UD_ENGLISH().downsample(0.05)
     tag_dictionary = corpus.make_tag_dictionary("pos")
 
-    embeddings = WordEmbeddings("turian")
-
     tagger: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=turian_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="pos",
         use_crf=False,
@@ -88,6 +91,7 @@ def test_train_load_use_tagger_large(results_base_path, tasks_base_path):
         shuffle=False,
     )
 
+    del trainer, tagger, tag_dictionary, corpus
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
     )
@@ -101,6 +105,7 @@ def test_train_load_use_tagger_large(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -110,11 +115,9 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
     )
     tag_dictionary = corpus.make_tag_dictionary("ner")
 
-    embeddings = FlairEmbeddings("news-forward-fast")
-
     tagger: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=flair_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="ner",
         use_crf=False,
@@ -131,6 +134,7 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
         shuffle=False,
     )
 
+    del trainer, tagger, tag_dictionary, corpus
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
     )
@@ -144,6 +148,7 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -153,11 +158,9 @@ def test_train_optimizer(results_base_path, tasks_base_path):
     )
     tag_dictionary = corpus.make_tag_dictionary("ner")
 
-    embeddings = WordEmbeddings("turian")
-
     tagger: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=turian_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="ner",
         use_crf=False,
@@ -174,6 +177,7 @@ def test_train_optimizer(results_base_path, tasks_base_path):
         shuffle=False,
     )
 
+    del trainer, tagger, tag_dictionary, corpus
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
     )
@@ -187,6 +191,7 @@ def test_train_optimizer(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -196,11 +201,9 @@ def test_train_optimizer_arguments(results_base_path, tasks_base_path):
     )
     tag_dictionary = corpus.make_tag_dictionary("ner")
 
-    embeddings = WordEmbeddings("turian")
-
     tagger: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=turian_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="ner",
         use_crf=False,
@@ -218,6 +221,7 @@ def test_train_optimizer_arguments(results_base_path, tasks_base_path):
         weight_decay=1e-3,
     )
 
+    del trainer, tagger, tag_dictionary, corpus
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
     )
@@ -231,6 +235,7 @@ def test_train_optimizer_arguments(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -240,11 +245,9 @@ def test_find_learning_rate(results_base_path, tasks_base_path):
     )
     tag_dictionary = corpus.make_tag_dictionary("ner")
 
-    embeddings = WordEmbeddings("turian")
-
     tagger: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=turian_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="ner",
         use_crf=False,
@@ -257,6 +260,7 @@ def test_find_learning_rate(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del trainer, tagger, tag_dictionary, corpus
 
 
 @pytest.mark.integration
@@ -269,6 +273,7 @@ def test_load_use_serialized_tagger():
     loaded_model.predict(sentence)
     loaded_model.predict([sentence, sentence_empty])
     loaded_model.predict([sentence_empty])
+    del loaded_model
 
     sentence.clear_embeddings()
     sentence_empty.clear_embeddings()
@@ -278,17 +283,13 @@ def test_load_use_serialized_tagger():
     loaded_model.predict(sentence)
     loaded_model.predict([sentence, sentence_empty])
     loaded_model.predict([sentence_empty])
+    del loaded_model
 
 
 @pytest.mark.integration
 def test_train_load_use_classifier(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
-
-    word_embedding: WordEmbeddings = WordEmbeddings("turian")
-    document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
-        [word_embedding], 128, 1, False, 64, False, False
-    )
 
     model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
 
@@ -303,6 +304,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
+    del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
 
     sentence = Sentence("I love Berlin")
@@ -314,17 +316,13 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
 def test_train_classifier_with_sampler(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
-
-    word_embedding: WordEmbeddings = WordEmbeddings("turian")
-    document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
-        [word_embedding], 32, 1, False, 64, False, False
-    )
 
     model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
 
@@ -344,21 +342,18 @@ def test_train_classifier_with_sampler(results_base_path, tasks_base_path):
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
+    del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
 def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
-
-    word_embedding: WordEmbeddings = WordEmbeddings("turian")
-    document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
-        [word_embedding], 128, 1, False, 64, False, False
-    )
 
     model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
 
@@ -373,6 +368,7 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
+    del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
 
     sentence = Sentence("I love Berlin")
@@ -384,20 +380,13 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
 def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "multi_class")
     label_dict = corpus.make_label_dictionary()
-
-    word_embedding: WordEmbeddings = WordEmbeddings("turian")
-    document_embeddings = DocumentRNNEmbeddings(
-        embeddings=[word_embedding],
-        hidden_size=32,
-        reproject_words=False,
-        bidirectional=False,
-    )
 
     model: TextClassifier = TextClassifier(
         document_embeddings, label_dict, multi_label=True
@@ -434,6 +423,7 @@ def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_pat
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
+    del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
 
     sentence = Sentence("I love Berlin")
@@ -445,6 +435,7 @@ def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_pat
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -452,12 +443,11 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
 
-    embedding: TokenEmbeddings = FlairEmbeddings("news-forward-fast")
-    document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
-        [embedding], 128, 1, False, 64, False, False
+    flair_document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
+       [flair_embeddings], 128, 1, False, 64, False, False
     )
 
-    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(flair_document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -470,6 +460,7 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
+    del trainer, model, corpus, flair_document_embeddings
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
 
     sentence = Sentence("I love Berlin")
@@ -481,6 +472,7 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -522,6 +514,7 @@ def test_train_language_model(results_base_path, resources_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path, ignore_errors=True)
+    del trainer, language_model, corpus, char_lm_embeddings
 
 
 @pytest.mark.integration
@@ -534,11 +527,9 @@ def test_train_load_use_tagger_multicorpus(results_base_path, tasks_base_path):
     corpus = MultiCorpus([corpus_1, corpus_2])
     tag_dictionary = corpus.make_tag_dictionary("ner")
 
-    embeddings = WordEmbeddings("turian")
-
     tagger: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=turian_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="ner",
         use_crf=False,
@@ -555,6 +546,7 @@ def test_train_load_use_tagger_multicorpus(results_base_path, tasks_base_path):
         shuffle=False,
     )
 
+    del trainer, tagger, corpus
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
     )
@@ -568,6 +560,7 @@ def test_train_load_use_tagger_multicorpus(results_base_path, tasks_base_path):
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del loaded_model
 
 
 @pytest.mark.integration
@@ -575,21 +568,22 @@ def test_train_resume_text_classification_training(results_base_path, tasks_base
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
 
-    embeddings: TokenEmbeddings = FlairEmbeddings("news-forward-fast")
-    document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
-        [embeddings], 128, 1, False
-    )
+    #document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
+    #    [flair_embeddings], 128, 1, False
+    #)
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
+    del trainer, model
     trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del trainer
 
 
 @pytest.mark.integration
@@ -602,11 +596,9 @@ def test_train_resume_sequence_tagging_training(results_base_path, tasks_base_pa
     corpus = MultiCorpus([corpus_1, corpus_2])
     tag_dictionary = corpus.make_tag_dictionary("ner")
 
-    embeddings = WordEmbeddings("turian")
-
     model: SequenceTagger = SequenceTagger(
         hidden_size=64,
-        embeddings=embeddings,
+        embeddings=turian_embeddings,
         tag_dictionary=tag_dictionary,
         tag_type="ner",
         use_crf=False,
@@ -615,12 +607,14 @@ def test_train_resume_sequence_tagging_training(results_base_path, tasks_base_pa
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
+    del trainer, model
     trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
 
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del trainer
 
 
 @pytest.mark.integration
@@ -654,6 +648,7 @@ def test_train_resume_language_model_training(
         max_epochs=2,
         checkpoint=True,
     )
+    del trainer, language_model
 
     trainer = LanguageModelTrainer.load_from_checkpoint(
         results_base_path / "checkpoint.pt", corpus
@@ -664,6 +659,7 @@ def test_train_resume_language_model_training(
 
     # clean up results directory
     shutil.rmtree(results_base_path)
+    del trainer
 
 
 @pytest.mark.integration
@@ -678,3 +674,5 @@ def test_keep_word_embeddings():
     loaded_model.predict(sentence, embedding_storage_mode="cpu")
     for token in sentence:
         assert len(token.embedding.cpu().numpy()) > 0
+
+    del loaded_model


### PR DESCRIPTION
Relax requirements so that installation on Google Colab works without having to restart the runtime. Also removes tkinter requirement since this does not work on systems that don't have it.

This PR temporarily removes black formatting requirement from travis to simplify PRs and see how this affects formatting. 

