### PR TITLE
GH-1270: fix memory issue in PooledFlairEmbeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2144,7 +2144,6 @@ class PooledFlairEmbeddings(TokenEmbeddings):
 
                 # update embedding
                 local_embedding = token._embeddings[self.context_embeddings.name]
-                local_embedding = local_embedding.to(flair.device)
 
                 # check token.text is empty or not
                 if token.text:


### PR DESCRIPTION
Issue #1270 reports a CUDA out of memory issue that appeared for PooledFlairEmbeddings in 0.4.4. The likely reason is that the new version stored the embedding memory on CUDA instead of normal memory. 

This PR fixes this so that embedding memory is stored on regular memory. 