### PR TITLE
GH-1270: explicitly send pools to CPU memory

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2143,7 +2143,7 @@ class PooledFlairEmbeddings(TokenEmbeddings):
             for token in sentence.tokens:
 
                 # update embedding
-                local_embedding = token._embeddings[self.context_embeddings.name]
+                local_embedding = token._embeddings[self.context_embeddings.name].cpu()
 
                 # check token.text is empty or not
                 if token.text:


### PR DESCRIPTION
Another attempt at solving #1270 - memory pools are explicitly sent to CPU so that the pools do not eat up CUDA memory.