### PR TITLE
Make load_big_file work with read-only file

### DIFF
--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -22,16 +22,16 @@ import flair
 logger = logging.getLogger("flair")
 
 
-def load_big_file(f):
+def load_big_file(f: str) -> mmap.mmap:
     """
     Workaround for loading a big pickle file. Files over 2GB cause pickle errors on certin Mac and Windows distributions.
     :param f:
     :return:
     """
     logger.info(f"loading file {f}")
-    with open(f, "r+b") as f_in:
+    with open(f, "rb") as f_in:
         # mmap seems to be much more memory efficient
-        bf = mmap.mmap(f_in.fileno(), 0)
+        bf = mmap.mmap(f_in.fileno(), 0, access=mmap.ACCESS_READ)
         f_in.close()
     return bf
 


### PR DESCRIPTION
Use "rb" rather than "r+b" and specify access=mmap.ACCESS_READ

I would like to be able to read model files on a read-only share but current code crashes with permissions problems - this fixes for me