### PR TITLE
fixed new RNN format for torch 1.4.0

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -388,3 +388,37 @@ class LanguageModel(nn.Module):
         perplexity = math.exp(loss)
 
         return perplexity
+
+    def _apply(self, fn):
+        major, minor, build, *_ = (int(info)
+                                for info in torch.__version__.split('.'))
+
+        # fixed RNN change format for torch 1.4.0
+        if major >= 1 and minor >= 4:
+            for child_module in self.children():
+                if isinstance(child_module, torch.nn.RNNBase):
+                    _flat_weights_names = []
+                    num_direction = None
+
+                    if child_module.__dict__["bidirectional"]:
+                        num_direction = 2
+                    else:
+                        num_direction = 1
+                    for layer in range(child_module.__dict__["num_layers"]):
+                        for direction in range(num_direction):
+                            suffix = "_reverse" if direction == 1 else ""
+                            param_names = ["weight_ih_l{}{}", "weight_hh_l{}{}"]
+                            if child_module.__dict__["bias"]:
+                                param_names += ["bias_ih_l{}{}", "bias_hh_l{}{}"]
+                            param_names = [
+                                x.format(layer, suffix) for x in param_names
+                            ]
+                            _flat_weights_names.extend(param_names)
+
+                    setattr(child_module, "_flat_weights_names",
+                            _flat_weights_names)
+
+                child_module._apply(fn)
+
+        else:
+            super()._apply(fn)


### PR DESCRIPTION
fixed [issue #1358 ](https://github.com/flairNLP/flair/issues/1358), [issue #1359 ](https://github.com/flairNLP/flair/issues/1359).
[1.4.0 RNN](https://pytorch.org/docs/stable/_modules/torch/nn/modules/rnn.html)
[1.3.1 RNN](https://pytorch.org/docs/1.3.1/_modules/torch/nn/modules/rnn.html)

The problem is that torch's RNN has a new attribute, _flat_weights_names in 1.4.0.
So I checked the version and if the version is 1.4.0, try set _flat_weights_names attribute for RNN base layer.

I only tried using the "ner-fast" and "ner" model on Windows.
Maybe you can help me try more model on Unix.

If there are problems with other models, please let me know.
I will try to fix it.