### PR TITLE
set whitespace_after in UniversalDependenciesDataset

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -849,6 +849,9 @@ class UniversalDependenciesDataset(FlairDataset):
                     token.add_tag("pos", str(fields[4]))
                     token.add_tag("dependency", str(fields[7]))
 
+                    if 'SpaceAfter=No' in fields[9]:
+                        token.whitespace_after=False
+                    
                     for morph in str(fields[5]).split("|"):
                         if "=" not in morph:
                             continue

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -11,7 +11,6 @@ import json
 import urllib
 from tqdm import tqdm
 
-
 import torch.utils.data.dataloader
 from torch.utils.data import Dataset, random_split
 from torch.utils.data.dataset import Subset, ConcatDataset
@@ -34,17 +33,17 @@ log = logging.getLogger("flair")
 
 class ColumnCorpus(Corpus):
     def __init__(
-        self,
-        data_folder: Union[str, Path],
-        column_format: Dict[int, str],
-        train_file=None,
-        test_file=None,
-        dev_file=None,
-        tag_to_bioes=None,
-        comment_symbol: str = None,
-        in_memory: bool = True,
-        encoding: str = "utf-8",
-        document_separator_token: str = None,
+            self,
+            data_folder: Union[str, Path],
+            column_format: Dict[int, str],
+            train_file=None,
+            test_file=None,
+            dev_file=None,
+            tag_to_bioes=None,
+            comment_symbol: str = None,
+            in_memory: bool = True,
+            encoding: str = "utf-8",
+            document_separator_token: str = None,
     ):
         """
         Instantiates a Corpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
@@ -153,12 +152,12 @@ class ColumnCorpus(Corpus):
 
 class UniversalDependenciesCorpus(Corpus):
     def __init__(
-        self,
-        data_folder: Union[str, Path],
-        train_file=None,
-        test_file=None,
-        dev_file=None,
-        in_memory: bool = True,
+            self,
+            data_folder: Union[str, Path],
+            train_file=None,
+            test_file=None,
+            dev_file=None,
+            in_memory: bool = True,
     ):
         """
         Instantiates a Corpus from CoNLL-U column-formatted task data such as the UD corpora
@@ -209,15 +208,15 @@ class UniversalDependenciesCorpus(Corpus):
 
 class ClassificationCorpus(Corpus):
     def __init__(
-        self,
-        data_folder: Union[str, Path],
-        train_file=None,
-        test_file=None,
-        dev_file=None,
-        tokenizer: Callable[[str], List[Token]] = space_tokenizer,
-        max_tokens_per_doc: int = -1,
-        max_chars_per_doc: int = -1,
-        in_memory: bool = False,
+            self,
+            data_folder: Union[str, Path],
+            train_file=None,
+            test_file=None,
+            dev_file=None,
+            tokenizer: Callable[[str], List[Token]] = space_tokenizer,
+            max_tokens_per_doc: int = -1,
+            max_chars_per_doc: int = -1,
+            in_memory: bool = False,
     ):
         """
         Instantiates a Corpus from text classification-formatted task data
@@ -349,18 +348,18 @@ class FeideggerCorpus(Corpus):
 
 class CSVClassificationCorpus(Corpus):
     def __init__(
-        self,
-        data_folder: Union[str, Path],
-        column_name_map: Dict[int, str],
-        train_file=None,
-        test_file=None,
-        dev_file=None,
-        tokenizer: Callable[[str], List[Token]] = segtok_tokenizer,
-        max_tokens_per_doc=-1,
-        max_chars_per_doc=-1,
-        in_memory: bool = False,
-        skip_header: bool = False,
-        **fmtparams,
+            self,
+            data_folder: Union[str, Path],
+            column_name_map: Dict[int, str],
+            train_file=None,
+            test_file=None,
+            dev_file=None,
+            tokenizer: Callable[[str], List[Token]] = segtok_tokenizer,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            in_memory: bool = False,
+            skip_header: bool = False,
+            **fmtparams,
     ):
         """
         Instantiates a Corpus for text classification from CSV column formatted data
@@ -462,14 +461,14 @@ class CSVClassificationCorpus(Corpus):
 
 class ParallelTextCorpus(Corpus):
     def __init__(
-        self,
-        source_file: Union[str, Path],
-        target_file: Union[str, Path],
-        name: str = None,
-        use_tokenizer: bool = True,
-        max_tokens_per_doc=-1,
-        max_chars_per_doc=-1,
-        in_memory: bool = True,
+            self,
+            source_file: Union[str, Path],
+            target_file: Union[str, Path],
+            name: str = None,
+            use_tokenizer: bool = True,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            in_memory: bool = True,
     ):
         """
         Instantiates a Corpus for text classification from CSV column formatted data
@@ -509,14 +508,14 @@ class ParallelTextCorpus(Corpus):
 
 class OpusParallelCorpus(ParallelTextCorpus):
     def __init__(
-        self,
-        dataset: str,
-        l1: str,
-        l2: str,
-        use_tokenizer: bool = True,
-        max_tokens_per_doc=-1,
-        max_chars_per_doc=-1,
-        in_memory: bool = True,
+            self,
+            dataset: str,
+            l1: str,
+            l2: str,
+            use_tokenizer: bool = True,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            in_memory: bool = True,
     ):
         """
         Instantiates a Parallel Corpus from OPUS (http://opus.nlpl.eu/)
@@ -542,18 +541,18 @@ class OpusParallelCorpus(ParallelTextCorpus):
             link = f"https://object.pouta.csc.fi/OPUS-Tatoeba/v20190709/moses/{l1}-{l2}.txt.zip"
 
             l1_file = (
-                Path(flair.cache_root)
-                / "datasets"
-                / dataset
-                / f"{l1}-{l2}"
-                / f"Tatoeba.{l1}-{l2}.{l1}"
+                    Path(flair.cache_root)
+                    / "datasets"
+                    / dataset
+                    / f"{l1}-{l2}"
+                    / f"Tatoeba.{l1}-{l2}.{l1}"
             )
             l2_file = (
-                Path(flair.cache_root)
-                / "datasets"
-                / dataset
-                / f"{l1}-{l2}"
-                / f"Tatoeba.{l1}-{l2}.{l2}"
+                    Path(flair.cache_root)
+                    / "datasets"
+                    / dataset
+                    / f"{l1}-{l2}"
+                    / f"Tatoeba.{l1}-{l2}.{l2}"
             )
 
         # download and unzip in file structure if necessary
@@ -607,9 +606,9 @@ class StringDataset(FlairDataset):
     """
 
     def __init__(
-        self,
-        texts: Union[str, List[str]],
-        use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer,
+            self,
+            texts: Union[str, List[str]],
+            use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer,
     ):
         """
         Instantiate StringDataset
@@ -639,14 +638,14 @@ class StringDataset(FlairDataset):
 
 class ColumnDataset(FlairDataset):
     def __init__(
-        self,
-        path_to_column_file: Path,
-        column_name_map: Dict[int, str],
-        tag_to_bioes: str = None,
-        comment_symbol: str = None,
-        in_memory: bool = True,
-        document_separator_token: str = None,
-        encoding: str = "utf-8",
+            self,
+            path_to_column_file: Path,
+            column_name_map: Dict[int, str],
+            tag_to_bioes: str = None,
+            comment_symbol: str = None,
+            in_memory: bool = True,
+            document_separator_token: str = None,
+            encoding: str = "utf-8",
     ):
         """
         Instantiates a column dataset (typically used for sequence labeling or word-level prediction).
@@ -764,7 +763,7 @@ class ColumnDataset(FlairDataset):
                 sentence: Sentence = Sentence()
                 while line:
                     if self.comment_symbol is not None and line.startswith(
-                        self.comment_symbol
+                            self.comment_symbol
                     ):
                         line = file.readline()
                         continue
@@ -849,9 +848,9 @@ class UniversalDependenciesDataset(FlairDataset):
                     token.add_tag("pos", str(fields[4]))
                     token.add_tag("dependency", str(fields[7]))
 
-                    if 'SpaceAfter=No' in fields[9]:
-                        token.whitespace_after=False
-                    
+                    if len(fields) > 9 and 'SpaceAfter=No' in fields[9]:
+                        token.whitespace_after = False
+
                     for morph in str(fields[5]).split("|"):
                         if "=" not in morph:
                             continue
@@ -909,6 +908,9 @@ class UniversalDependenciesDataset(FlairDataset):
                         token.add_tag("pos", str(fields[4]))
                         token.add_tag("dependency", str(fields[7]))
 
+                        if len(fields) > 9 and 'SpaceAfter=No' in fields[9]:
+                            token.whitespace_after = False
+
                         for morph in str(fields[5]).split("|"):
                             if "=" not in morph:
                                 continue
@@ -927,15 +929,15 @@ class UniversalDependenciesDataset(FlairDataset):
 
 class CSVClassificationDataset(FlairDataset):
     def __init__(
-        self,
-        path_to_file: Union[str, Path],
-        column_name_map: Dict[int, str],
-        max_tokens_per_doc: int = -1,
-        max_chars_per_doc: int = -1,
-        tokenizer=segtok_tokenizer,
-        in_memory: bool = True,
-        skip_header: bool = False,
-        **fmtparams,
+            self,
+            path_to_file: Union[str, Path],
+            column_name_map: Dict[int, str],
+            max_tokens_per_doc: int = -1,
+            max_chars_per_doc: int = -1,
+            tokenizer=segtok_tokenizer,
+            in_memory: bool = True,
+            skip_header: bool = False,
+            **fmtparams,
     ):
         """
         Instantiates a Dataset for text classification from CSV column formatted data
@@ -1019,8 +1021,8 @@ class CSVClassificationDataset(FlairDataset):
 
                     for column in self.column_name_map:
                         if (
-                            self.column_name_map[column].startswith("label")
-                            and row[column]
+                                self.column_name_map[column].startswith("label")
+                                and row[column]
                         ):
                             sentence.add_label(row[column])
 
@@ -1063,12 +1065,12 @@ class CSVClassificationDataset(FlairDataset):
 
 class ClassificationDataset(FlairDataset):
     def __init__(
-        self,
-        path_to_file: Union[str, Path],
-        max_tokens_per_doc=-1,
-        max_chars_per_doc=-1,
-        tokenizer=segtok_tokenizer,
-        in_memory: bool = True,
+            self,
+            path_to_file: Union[str, Path],
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            tokenizer=segtok_tokenizer,
+            in_memory: bool = True,
     ):
         """
         Reads a data file for text classification. The file should contain one document/text per line.
@@ -1128,7 +1130,7 @@ class ClassificationDataset(FlairDataset):
                 line = f.readline()
 
     def _parse_line_to_sentence(
-        self, line: str, label_prefix: str, tokenizer: Callable[[str], List[Token]]
+            self, line: str, label_prefix: str, tokenizer: Callable[[str], List[Token]]
     ):
         words = line.split()
 
@@ -1152,8 +1154,8 @@ class ClassificationDataset(FlairDataset):
             sentence = Sentence(text, labels=labels, use_tokenizer=tokenizer)
 
             if (
-                sentence is not None
-                and 0 < self.max_tokens_per_doc < len(sentence)
+                    sentence is not None
+                    and 0 < self.max_tokens_per_doc < len(sentence)
             ):
                 sentence.tokens = sentence.tokens[: self.max_tokens_per_doc]
 
@@ -1182,18 +1184,18 @@ class ClassificationDataset(FlairDataset):
 
 class MongoDataset(FlairDataset):
     def __init__(
-        self,
-        query: str,
-        host: str,
-        port: int,
-        database: str,
-        collection: str,
-        text_field: str,
-        categories_field: List[str] = None,
-        max_tokens_per_doc: int = -1,
-        max_chars_per_doc: int = -1,
-        tokenizer=segtok_tokenizer,
-        in_memory: bool = True,
+            self,
+            query: str,
+            host: str,
+            port: int,
+            database: str,
+            collection: str,
+            text_field: str,
+            categories_field: List[str] = None,
+            max_tokens_per_doc: int = -1,
+            max_chars_per_doc: int = -1,
+            tokenizer=segtok_tokenizer,
+            in_memory: bool = True,
     ):
         """
         Reads Mongo collections. Each collection should contain one document/text per item.
@@ -1270,7 +1272,7 @@ class MongoDataset(FlairDataset):
             self.total_sentence_count = self.__cursor.count_documents()
 
     def _parse_document_to_sentence(
-        self, text: str, labels: List[str], tokenizer: Callable[[str], List[Token]]
+            self, text: str, labels: List[str], tokenizer: Callable[[str], List[Token]]
     ):
         if self.max_chars_per_doc > 0:
             text = text[: self.max_chars_per_doc]
@@ -1280,8 +1282,8 @@ class MongoDataset(FlairDataset):
 
             if self.max_tokens_per_doc > 0:
                 sentence.tokens = sentence.tokens[
-                    : min(len(sentence), self.max_tokens_per_doc)
-                ]
+                                  : min(len(sentence), self.max_tokens_per_doc)
+                                  ]
 
             return sentence
         return None
@@ -1307,13 +1309,13 @@ class MongoDataset(FlairDataset):
 
 class ParallelTextDataset(FlairDataset):
     def __init__(
-        self,
-        path_to_source: Union[str, Path],
-        path_to_target: Union[str, Path],
-        max_tokens_per_doc=-1,
-        max_chars_per_doc=-1,
-        use_tokenizer=True,
-        in_memory: bool = True,
+            self,
+            path_to_source: Union[str, Path],
+            path_to_target: Union[str, Path],
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            use_tokenizer=True,
+            in_memory: bool = True,
     ):
         if type(path_to_source) == str:
             path_to_source: Path = Path(path_to_source)
@@ -1337,7 +1339,7 @@ class ParallelTextDataset(FlairDataset):
             self.target_lines: List[str] = []
 
         with open(str(path_to_source), encoding="utf-8") as source_file, open(
-            str(path_to_target), encoding="utf-8"
+                str(path_to_target), encoding="utf-8"
         ) as target_file:
 
             source_line = source_file.readline()
@@ -1418,11 +1420,11 @@ class FeideggerDataset(FlairDataset):
 
 class CONLL_03(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = True,
-        document_as_sequence: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+            document_as_sequence: bool = False,
     ):
         """
         Initialize the CoNLL-03 corpus. This is only possible if you've manually downloaded it to your machine.
@@ -1468,11 +1470,11 @@ class CONLL_03(ColumnCorpus):
 
 class CONLL_03_GERMAN(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = True,
-        document_as_sequence: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+            document_as_sequence: bool = False,
     ):
         """
         Initialize the CoNLL-03 corpus for German. This is only possible if you've manually downloaded it to your machine.
@@ -1518,11 +1520,11 @@ class CONLL_03_GERMAN(ColumnCorpus):
 
 class CONLL_03_DUTCH(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = True,
-        document_as_sequence: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+            document_as_sequence: bool = False,
     ):
         """
         Initialize the CoNLL-03 corpus for Dutch. The first time you call this constructor it will automatically
@@ -1566,10 +1568,10 @@ class CONLL_03_DUTCH(ColumnCorpus):
 
 class CONLL_03_SPANISH(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = True,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
     ):
         """
         Initialize the CoNLL-03 corpus for Spanish. The first time you call this constructor it will automatically
@@ -1611,10 +1613,10 @@ class CONLL_03_SPANISH(ColumnCorpus):
 
 class CONLL_2000(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "np",
-        in_memory: bool = True,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "np",
+            in_memory: bool = True,
     ):
         """
         Initialize the CoNLL-2000 corpus for English chunking.
@@ -1651,20 +1653,20 @@ class CONLL_2000(ColumnCorpus):
             import gzip, shutil
 
             with gzip.open(
-                Path(flair.cache_root) / "datasets" / dataset_name / "train.txt.gz",
-                "rb",
+                    Path(flair.cache_root) / "datasets" / dataset_name / "train.txt.gz",
+                    "rb",
             ) as f_in:
                 with open(
-                    Path(flair.cache_root) / "datasets" / dataset_name / "train.txt",
-                    "wb",
+                        Path(flair.cache_root) / "datasets" / dataset_name / "train.txt",
+                        "wb",
                 ) as f_out:
                     shutil.copyfileobj(f_in, f_out)
             with gzip.open(
-                Path(flair.cache_root) / "datasets" / dataset_name / "test.txt.gz", "rb"
+                    Path(flair.cache_root) / "datasets" / dataset_name / "test.txt.gz", "rb"
             ) as f_in:
                 with open(
-                    Path(flair.cache_root) / "datasets" / dataset_name / "test.txt",
-                    "wb",
+                        Path(flair.cache_root) / "datasets" / dataset_name / "test.txt",
+                        "wb",
                 ) as f_out:
                     shutil.copyfileobj(f_in, f_out)
 
@@ -1675,10 +1677,10 @@ class CONLL_2000(ColumnCorpus):
 
 class GERMEVAL(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = True,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
     ):
         """
         Initialize the GermEval NER corpus for German. This is only possible if you've manually downloaded it to your
@@ -1741,11 +1743,11 @@ class IMDB(ClassificationCorpus):
             import tarfile
 
             with tarfile.open(
-                Path(flair.cache_root)
-                / "datasets"
-                / dataset_name
-                / "aclImdb_v1.tar.gz",
-                "r:gz",
+                    Path(flair.cache_root)
+                    / "datasets"
+                    / dataset_name
+                    / "aclImdb_v1.tar.gz",
+                    "r:gz",
             ) as f_in:
                 datasets = ["train", "test"]
                 labels = ["pos", "neg"]
@@ -1764,7 +1766,7 @@ class IMDB(ClassificationCorpus):
                             current_path = data_path / "aclImdb" / dataset / label
                             for file_name in current_path.iterdir():
                                 if file_name.is_file() and file_name.name.endswith(
-                                    ".txt"
+                                        ".txt"
                                 ):
                                     f_p.write(
                                         f"__label__{label} "
@@ -1805,12 +1807,12 @@ class NEWSGROUPS(ClassificationCorpus):
             import tarfile
 
             with tarfile.open(
-                Path(flair.cache_root)
-                / "datasets"
-                / dataset_name
-                / "original"
-                / "20news-bydate.tar.gz",
-                "r:gz",
+                    Path(flair.cache_root)
+                    / "datasets"
+                    / dataset_name
+                    / "original"
+                    / "20news-bydate.tar.gz",
+                    "r:gz",
             ) as f_in:
                 datasets = ["20news-bydate-test", "20news-bydate-train"]
                 labels = [
@@ -1847,7 +1849,7 @@ class NEWSGROUPS(ClassificationCorpus):
                             ],
                         )
                         with open(
-                            f"{data_path}/{dataset}.txt", "at", encoding="utf-8"
+                                f"{data_path}/{dataset}.txt", "at", encoding="utf-8"
                         ) as f_p:
                             current_path = data_path / "original" / dataset / label
                             for file_name in current_path.iterdir():
@@ -1867,10 +1869,10 @@ class NEWSGROUPS(ClassificationCorpus):
 
 class NER_BASQUE(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = True,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -1897,8 +1899,8 @@ class NER_BASQUE(ColumnCorpus):
             import tarfile, shutil
 
             with tarfile.open(
-                Path(flair.cache_root) / "datasets" / dataset_name / "eiec_v1.0.tgz",
-                "r:gz",
+                    Path(flair.cache_root) / "datasets" / dataset_name / "eiec_v1.0.tgz",
+                    "r:gz",
             ) as f_in:
                 corpus_files = (
                     "eiec_v1.0/named_ent_eu.train",
@@ -1942,15 +1944,15 @@ class TREC_50(ClassificationCorpus):
 
         if not data_file.is_file():
             for original_filename, new_filename in zip(
-                original_filenames, new_filenames
+                    original_filenames, new_filenames
             ):
                 with open(
-                    data_folder / "original" / original_filename,
-                    "rt",
-                    encoding="latin1",
+                        data_folder / "original" / original_filename,
+                        "rt",
+                        encoding="latin1",
                 ) as open_fp:
                     with open(
-                        data_folder / new_filename, "wt", encoding="utf-8"
+                            data_folder / new_filename, "wt", encoding="utf-8"
                     ) as write_fp:
                         for line in open_fp:
                             line = line.rstrip()
@@ -2000,15 +2002,15 @@ class TREC_6(ClassificationCorpus):
 
         if not data_file.is_file():
             for original_filename, new_filename in zip(
-                original_filenames, new_filenames
+                    original_filenames, new_filenames
             ):
                 with open(
-                    data_folder / "original" / original_filename,
-                    "rt",
-                    encoding="latin1",
+                        data_folder / "original" / original_filename,
+                        "rt",
+                        encoding="latin1",
                 ) as open_fp:
                     with open(
-                        data_folder / new_filename, "wt", encoding="utf-8"
+                            data_folder / new_filename, "wt", encoding="utf-8"
                     ) as write_fp:
                         for line in open_fp:
                             line = line.rstrip()
@@ -3034,10 +3036,10 @@ def _download_wikiner(language_code: str, dataset_name: str):
     lc = language_code
 
     data_file = (
-        Path(flair.cache_root)
-        / "datasets"
-        / dataset_name
-        / f"aij-wikiner-{lc}-wp3.train"
+            Path(flair.cache_root)
+            / "datasets"
+            / dataset_name
+            / f"aij-wikiner-{lc}-wp3.train"
     )
     if not data_file.is_file():
 
@@ -3055,11 +3057,11 @@ def _download_wikiner(language_code: str, dataset_name: str):
             "rb",
         )
         with bz_file as f, open(
-            Path(flair.cache_root)
-            / "datasets"
-            / dataset_name
-            / f"aij-wikiner-{lc}-wp3.train",
-            "w",
+                Path(flair.cache_root)
+                / "datasets"
+                / dataset_name
+                / f"aij-wikiner-{lc}-wp3.train",
+                "w",
         ) as out:
             for line in f:
                 line = line.decode("utf-8")
@@ -3070,10 +3072,10 @@ def _download_wikiner(language_code: str, dataset_name: str):
 
 class WIKINER_ENGLISH(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3099,10 +3101,10 @@ class WIKINER_ENGLISH(ColumnCorpus):
 
 class WIKINER_GERMAN(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3128,10 +3130,10 @@ class WIKINER_GERMAN(ColumnCorpus):
 
 class WIKINER_DUTCH(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3157,10 +3159,10 @@ class WIKINER_DUTCH(ColumnCorpus):
 
 class WIKINER_FRENCH(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3186,10 +3188,10 @@ class WIKINER_FRENCH(ColumnCorpus):
 
 class WIKINER_ITALIAN(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3215,10 +3217,10 @@ class WIKINER_ITALIAN(ColumnCorpus):
 
 class WIKINER_SPANISH(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3244,10 +3246,10 @@ class WIKINER_SPANISH(ColumnCorpus):
 
 class WIKINER_PORTUGUESE(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3273,10 +3275,10 @@ class WIKINER_PORTUGUESE(ColumnCorpus):
 
 class WIKINER_POLISH(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3302,10 +3304,10 @@ class WIKINER_POLISH(ColumnCorpus):
 
 class WIKINER_RUSSIAN(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = False,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = False,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3331,10 +3333,10 @@ class WIKINER_RUSSIAN(ColumnCorpus):
 
 class WNUT_17(ColumnCorpus):
     def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "ner",
-        in_memory: bool = True,
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -3365,16 +3367,16 @@ class WNUT_17(ColumnCorpus):
 
 class DataLoader(torch.utils.data.dataloader.DataLoader):
     def __init__(
-        self,
-        dataset,
-        batch_size=1,
-        shuffle=False,
-        sampler=None,
-        batch_sampler=None,
-        num_workers=8,
-        drop_last=False,
-        timeout=0,
-        worker_init_fn=None,
+            self,
+            dataset,
+            batch_size=1,
+            shuffle=False,
+            sampler=None,
+            batch_sampler=None,
+            num_workers=8,
+            drop_last=False,
+            timeout=0,
+            worker_init_fn=None,
     ):
 
         # in certain cases, multi-CPU data loading makes no sense and slows


### PR DESCRIPTION
Set `whitespace_after` in `UniversalDependenciesDataset`, so `to_plain_string` method is returning original sentence.