### PR TITLE
GH-1021: Compute Flair embeddings over original string and without spaces after token

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2048,8 +2048,8 @@ class FlairEmbeddings(TokenEmbeddings):
             for i, sentence in enumerate(sentences):
                 sentence_text = sentence.to_plain_string()
 
-                offset_forward: int = len(start_marker)
-                offset_backward: int = len(sentence_text) + len(start_marker)
+                offset_forward: int = len(start_marker) - 1
+                offset_backward: int = len(sentence_text) + len(start_marker) - 1
 
                 for token in sentence.tokens:
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2031,7 +2031,7 @@ class FlairEmbeddings(TokenEmbeddings):
         with gradient_context:
 
             # if this is not possible, use LM to generate embedding. First, get text sentences
-            text_sentences = [sentence.to_tokenized_string() for sentence in sentences]
+            text_sentences = [sentence.to_plain_string() for sentence in sentences]
 
             start_marker = "\n"
             end_marker = " "
@@ -2046,7 +2046,7 @@ class FlairEmbeddings(TokenEmbeddings):
 
             # take first or last hidden states from language model as word representation
             for i, sentence in enumerate(sentences):
-                sentence_text = sentence.to_tokenized_string()
+                sentence_text = sentence.to_plain_string()
 
                 offset_forward: int = len(start_marker)
                 offset_backward: int = len(sentence_text) + len(start_marker)
@@ -2062,9 +2062,9 @@ class FlairEmbeddings(TokenEmbeddings):
 
                     embedding = all_hidden_states_in_lm[offset, i, :]
 
-                    # if self.tokenized_lm or token.whitespace_after:
-                    offset_forward += 1
-                    offset_backward -= 1
+                    if token.whitespace_after:
+                        offset_forward += 1
+                        offset_backward -= 1
 
                     offset_backward -= len(token.text)
 


### PR DESCRIPTION
Now, space is inserted after every token despite `whitespace_after` value. So sentences being embedded do not look the same as normal text on which Flair language models (embeddings) were trained.
Also, hidden state is taken as embedding after consuming a space.

This PR computes embeddings over text with original white spaces.
I am not sure if this approach is better in downstream tasks, but it is consistent with trained Flair language model.

Initial experiments shows that calculating token embedding without space gives better results. Using `whitespace_after` information is a little worse. First epoch of training with fixed seeds:
```
2020-01-18 21:54:41,014 epoch 1 - iter 43/431 - loss 12.58697907 - samples/sec: 104.66
2020-01-18 21:54:54,871 epoch 1 - iter 86/431 - loss 8.39764844 - samples/sec: 99.44
2020-01-18 21:55:08,917 epoch 1 - iter 129/431 - loss 6.48929740 - samples/sec: 98.12
2020-01-18 21:55:23,167 epoch 1 - iter 172/431 - loss 5.37756264 - samples/sec: 96.67
2020-01-18 21:55:36,985 epoch 1 - iter 215/431 - loss 4.63144744 - samples/sec: 99.72
2020-01-18 21:55:50,898 epoch 1 - iter 258/431 - loss 4.14733414 - samples/sec: 99.01
2020-01-18 21:56:04,915 epoch 1 - iter 301/431 - loss 3.76650934 - samples/sec: 98.27
2020-01-18 21:56:18,543 epoch 1 - iter 344/431 - loss 3.50686799 - samples/sec: 101.09
2020-01-18 21:56:32,710 epoch 1 - iter 387/431 - loss 3.27343043 - samples/sec: 97.24
2020-01-18 21:56:46,579 epoch 1 - iter 430/431 - loss 3.07420425 - samples/sec: 99.32
2020-01-18 21:56:46,824 ----------------------------------------------------------------------------------------------------
2020-01-18 21:56:46,824 EPOCH 1 done: loss 3.0724 - lr 0.1000
2020-01-18 21:57:00,554 DEV : loss 0.501313328742981 - score 0.9818
```
vs. with space after every token:
```
2020-01-18 21:50:48,533 epoch 1 - iter 43/431 - loss 12.42667790 - samples/sec: 103.46
2020-01-18 21:51:02,377 epoch 1 - iter 86/431 - loss 8.29389394 - samples/sec: 99.53
2020-01-18 21:51:16,640 epoch 1 - iter 129/431 - loss 6.39272680 - samples/sec: 96.59
2020-01-18 21:51:31,172 epoch 1 - iter 172/431 - loss 5.28999498 - samples/sec: 94.78
2020-01-18 21:51:45,272 epoch 1 - iter 215/431 - loss 4.54830917 - samples/sec: 97.70
2020-01-18 21:51:59,159 epoch 1 - iter 258/431 - loss 4.06829357 - samples/sec: 99.19
2020-01-18 21:52:13,226 epoch 1 - iter 301/431 - loss 3.69254654 - samples/sec: 97.92
2020-01-18 21:52:26,832 epoch 1 - iter 344/431 - loss 3.43669727 - samples/sec: 101.30
2020-01-18 21:52:41,262 epoch 1 - iter 387/431 - loss 3.21065094 - samples/sec: 95.45
2020-01-18 21:52:55,442 epoch 1 - iter 430/431 - loss 3.01424922 - samples/sec: 97.19
2020-01-18 21:52:55,693 ----------------------------------------------------------------------------------------------------
2020-01-18 21:52:55,693 EPOCH 1 done: loss 3.0125 - lr 0.1000
2020-01-18 21:53:09,711 DEV : loss 0.46862271428108215 - score 0.9831
```
vs. original code (embedding includes space after):
```
2020-01-18 19:11:18,763 epoch 1 - iter 43/431 - loss 13.77513606 - samples/sec: 100.09
2020-01-18 19:11:32,758 epoch 1 - iter 86/431 - loss 9.86612977 - samples/sec: 98.49
2020-01-18 19:11:46,444 epoch 1 - iter 129/431 - loss 7.84115263 - samples/sec: 100.66
2020-01-18 19:12:00,549 epoch 1 - iter 172/431 - loss 6.57365022 - samples/sec: 97.65
2020-01-18 19:12:14,326 epoch 1 - iter 215/431 - loss 5.71325676 - samples/sec: 99.98
2020-01-18 19:12:28,293 epoch 1 - iter 258/431 - loss 5.13455269 - samples/sec: 98.62
2020-01-18 19:12:42,390 epoch 1 - iter 301/431 - loss 4.66878698 - samples/sec: 97.71
2020-01-18 19:12:55,841 epoch 1 - iter 344/431 - loss 4.35207718 - samples/sec: 102.41
2020-01-18 19:13:09,813 epoch 1 - iter 387/431 - loss 4.08306071 - samples/sec: 98.59
2020-01-18 19:13:23,596 epoch 1 - iter 430/431 - loss 3.83598182 - samples/sec: 99.94
2020-01-18 19:13:23,847 ----------------------------------------------------------------------------------------------------
2020-01-18 19:13:23,847 EPOCH 1 done: loss 3.8318 - lr 0.1000
2020-01-18 19:13:37,732 DEV : loss 0.9926474690437317 - score 0.9577
```

You can test it on example `train.py` with POS tagging on UD after applying https://github.com/flairNLP/flair/pull/1361.