### PR TITLE
GH-1388: fix issue where flair was crashing for cpu only version of pytorch

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2999,7 +2999,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
 
     def _apply(self, fn):
         major, minor, build, *_ = (int(info)
-                                for info in torch.__version__.split('.'))
+                                for info in torch.__version__.replace("+cpu","").split('.'))
 
         # fixed RNN change format for torch 1.4.0
         if major >= 1 and minor >= 4:

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -391,7 +391,7 @@ class LanguageModel(nn.Module):
 
     def _apply(self, fn):
         major, minor, build, *_ = (int(info)
-                                for info in torch.__version__.split('.'))
+                                for info in torch.__version__.replace("+cpu","").split('.'))
 
         # fixed RNN change format for torch 1.4.0
         if major >= 1 and minor >= 4:


### PR DESCRIPTION
- replace +cpu part of the version with empty string during access