### PR TITLE
Refactor datasets for code legibility

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1027,14 +1027,33 @@ class Corpus:
     def __init__(
         self,
         train: FlairDataset,
-        dev: FlairDataset,
-        test: FlairDataset,
+        dev: FlairDataset = None,
+        test: FlairDataset = None,
         name: str = "corpus",
     ):
-        self._train: FlairDataset = train
-        self._dev: FlairDataset = dev
-        self._test: FlairDataset = test
+        # set name
         self.name: str = name
+
+        # sample test data if none is provided
+        if test is None:
+            train_length = len(train)
+            test_size: int = round(train_length / 10)
+            splits = random_split(train, [train_length - test_size, test_size])
+            train = splits[0]
+            test = splits[1]
+
+        # sample dev data if none is provided
+        if dev is None:
+            train_length = len(train)
+            dev_size: int = round(train_length / 10)
+            splits = random_split(train, [train_length - dev_size, dev_size])
+            train = splits[0]
+            dev = splits[1]
+
+        # set train dev and test data
+        self._train: FlairDataset = train
+        self._test: FlairDataset = test
+        self._dev: FlairDataset = dev
 
     @property
     def train(self) -> FlairDataset:


### PR DESCRIPTION
This PR does some small refactorings on `flair.datasets` for easier code legibility and fewer redundancies. All in all, this PR removes about 100 lines of code.

- Moves the default sampling logic from all corpora classes to the parent `Corpus` class. You can now instantiate a `Corpus` only with a train file which will trigger the sampling. 

- Moves the default logic for identifying train, dev and test files into a dedicated method to avoid duplicates in code. 