### PR TITLE
Padding entry conversion from CPU to flair_device to avoid CUDA embedding errors

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -3145,7 +3145,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
                 word_embeddings.append(
                     torch.zeros(
                         self.length_of_all_token_embeddings, dtype=torch.float
-                    ).unsqueeze(0)
+                    ).unsqueeze(0).to(flair.device)
                 )
 
             word_embeddings_tensor = torch.cat(word_embeddings, 0).to(flair.device)


### PR DESCRIPTION
Torch concatenate throws error if we try to concatenate "GPU" tensors with "CPU" tensors. This is happening in  Line 3151. `word_embeddings_tensor = torch.cat(word_embeddings, 0).to(flair.device)` 
throws ERROR, when some entries are in GPU (embeddings of elements) and some (Padding zeros) in CPU. Above change will bring all components in "word_embedings" list to common space (Flair Device).