### PR TITLE
Remove urllib3 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ transformers>=2.3.0
 bpemb>=0.2.9
 regex
 tabulate
-urllib3<1.25,>=1.20
 langdetect


### PR DESCRIPTION
Prevents urllib3 being downgraded in my environment (nothing in flair depends on urllib3)

At least I don't think it's needed... have I missed something? The line was added in https://github.com/flairNLP/flair/commit/3336f8f1fa93204a43fb513fc76c80b3a96ae6c5