### PR TITLE
fix encoding error for custom embeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -198,7 +198,7 @@ class StackedEmbeddings(TokenEmbeddings):
 class WordEmbeddings(TokenEmbeddings):
     """Standard static word embeddings, such as GloVe or FastText."""
 
-    def __init__(self, embeddings: str, field: str = None):
+    def __init__(self, embeddings: str, field: str = None,ignore: bool = False):
         """
         Initializes classic word embeddings. Constructor downloads required files if not there.
         :param embeddings: one of: 'glove', 'extvec', 'crawl' or two-letter language code or custom
@@ -317,9 +317,14 @@ class WordEmbeddings(TokenEmbeddings):
         self.static_embeddings = True
 
         if str(embeddings).endswith(".bin"):
-            self.precomputed_word_embeddings = gensim.models.KeyedVectors.load_word2vec_format(
-                str(embeddings), binary=True
-            )
+            if(ignore = True):
+                self.precomputed_word_embeddings = gensim.models.KeyedVectors.load_word2vec_format(
+                    str(embeddings), binary=True, unicode_error=True
+                )
+             else:
+                 self.precomputed_word_embeddings = gensim.models.KeyedVectors.load_word2vec_format(
+                    str(embeddings), binary=True, unicode_error=False
+                )
         else:
             self.precomputed_word_embeddings = gensim.models.KeyedVectors.load(
                 str(embeddings)


### PR DESCRIPTION
---> 51     WordEmbeddings(data_folder+'/model.bin',True),
3 frames
/usr/local/lib/python3.6/dist-packages/gensim/utils.py in any2unicode(text, encoding, errors)
    353     if isinstance(text, unicode):
    354         return text
--> 355     return unicode(text, encoding, errors=errors)
    356 
    357 

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0: invalid start byte