### PR TITLE
GH-647: add ELMo layer documentation

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -782,7 +782,8 @@ class BytePairEmbeddings(TokenEmbeddings):
 
 
 class ELMoEmbeddings(TokenEmbeddings):
-    """Contextual word embeddings using word-level LM, as proposed in Peters et al., 2018."""
+    """Contextual word embeddings using word-level LM, as proposed in Peters et al., 2018.
+    ELMo word vectors are constructed by concatenating the top 3 layers in the LM."""
 
     def __init__(
         self, model: str = "original", options_file: str = None, weight_file: str = None

--- a/resources/docs/embeddings/ELMO_EMBEDDINGS.md
+++ b/resources/docs/embeddings/ELMO_EMBEDDINGS.md
@@ -20,6 +20,8 @@ sentence = Sentence('The grass is green .')
 embedding.embed(sentence)
 ```
 
+By default, the top 3 layers in the language model are concatenated to form the word embedding.
+
 AllenNLP provides the following pre-trained models. To use any of the following models inside Flair
 simple specify the embedding id when initializing the `ELMoEmbeddings`.
 


### PR DESCRIPTION
Add explanation that ELMo concatenates top 3 layers to make word embedding (see #647) 