### PR TITLE
GH-1449: labeling logic is part of DataPoint

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -219,7 +219,10 @@ class DataPoint:
 
         return self
 
-    def get_labels(self, label_type: str):
+    def get_labels(self, label_type: str = None):
+        if label_type == None:
+            return self.labels
+
         return self.annotation_layers[label_type] if label_type in self.annotation_layers else []
 
     @property
@@ -1083,7 +1086,7 @@ class Corpus:
             len(self.test),
         )
 
-    def make_label_dictionary(self, label_type: str = "class") -> Dictionary:
+    def make_label_dictionary(self, label_type: str = None) -> Dictionary:
         """
         Creates a dictionary of all labels assigned to the sentences in the corpus.
         :return: dictionary of labels
@@ -1101,7 +1104,9 @@ class Corpus:
             for sentence in batch:
 
                 # check if sentence itself has labels
-                for label in sentence.get_labels(label_type):
+                labels = sentence.get_labels(label_type) if label_type is not None else sentence.labels
+
+                for label in labels:
                     label_dictionary.add_item(label.value)
 
                 # check for labels of words
@@ -1111,7 +1116,7 @@ class Corpus:
                             label_dictionary.add_item(label.value)
 
                 if not label_dictionary.multi_label:
-                    if len(sentence.get_labels(label_type)) > 1:
+                    if len(labels) > 1:
                         label_dictionary.multi_label = True
 
         log.info(label_dictionary.idx2item)

--- a/flair/data.py
+++ b/flair/data.py
@@ -138,7 +138,7 @@ class Dictionary:
 
 class Label:
     """
-    This class represents a label of a sentence. Each label has a value and optionally a confidence score. The
+    This class represents a label. Each label has a value and optionally a confidence score. The
     score needs to be between 0.0 and 1.0. Default value for the score is 1.0.
     """
 
@@ -175,13 +175,23 @@ class Label:
         return {"value": self.value, "confidence": self.score}
 
     def __str__(self):
-        return "{} ({})".format(self._value, self._score)
+        return f"{self._value} ({self._score:.4f})"
 
     def __repr__(self):
-        return "{} ({})".format(self._value, self._score)
+        return f"{self._value} ({self._score:.4f})"
 
 
 class DataPoint:
+    """
+    This is the parent class of all data points in Flair (including Token, Sentence, Image, etc.). Each DataPoint
+    must be embeddable (hence the abstract property embedding() and methods to() and clear_embeddings()). Also,
+    each DataPoint may have Labels in several layers of annotation (hence the functions add_label(), get_labels()
+    and the property 'label')
+    """
+
+    def __init__(self):
+        self.annotation_layers = {}
+
     @property
     @abstractmethod
     def embedding(self):
@@ -195,9 +205,34 @@ class DataPoint:
     def clear_embeddings(self, embedding_names: List[str] = None):
         pass
 
+    def add_label(self, label_type: str, value: str, score: float = 1.):
+
+        if label_type not in self.annotation_layers:
+            self.annotation_layers[label_type] = [Label(value, score)]
+        else:
+            self.annotation_layers[label_type].append(Label(value, score))
+
+        return self
+
+    def set_label(self, label_type: str, value: str, score: float = 1.):
+        self.annotation_layers[label_type] = [Label(value, score)]
+
+        return self
+
+    def get_labels(self, label_type: str):
+        return self.annotation_layers[label_type] if label_type in self.annotation_layers else []
+
+    @property
+    def labels(self) -> List[Label]:
+        all_labels = []
+        for key in self.annotation_layers.keys():
+            all_labels.extend(self.annotation_layers[key])
+        return all_labels
+
 
 class DataPair(DataPoint):
     def __init__(self, first: DataPoint, second: DataPoint):
+        super().__init__()
         self.first = first
         self.second = second
 
@@ -209,11 +244,18 @@ class DataPair(DataPoint):
         self.first.clear_embeddings(embedding_names)
         self.second.clear_embeddings(embedding_names)
 
+    @property
     def embedding(self):
         return torch.cat([self.first.embedding, self.second.embedding])
 
     def __str__(self):
-        return f"DataPoint:\n first: {self.first}\n second: {self.second}"
+        return f"DataPair:\n − First {self.first}\n − Second {self.second}\n − Labels: {self.labels}"
+
+    def to_plain_string(self):
+        return f"DataPair: First {self.first}  ||  Second {self.second}"
+
+    def __len__(self):
+        return len(self.first) + len(self.second)
 
 
 class Token(DataPoint):
@@ -223,13 +265,15 @@ class Token(DataPoint):
     """
 
     def __init__(
-        self,
-        text: str,
-        idx: int = None,
-        head_id: int = None,
-        whitespace_after: bool = True,
-        start_position: int = None,
+            self,
+            text: str,
+            idx: int = None,
+            head_id: int = None,
+            whitespace_after: bool = True,
+            start_position: int = None,
     ):
+        super().__init__()
+
         self.text: str = text
         self.idx: int = idx
         self.head_id: int = head_id
@@ -242,23 +286,20 @@ class Token(DataPoint):
 
         self.sentence: Sentence = None
         self._embeddings: Dict = {}
-        self.tags: Dict[str, Label] = {}
         self.tags_proba_dist: Dict[str, List[Label]] = {}
 
     def add_tag_label(self, tag_type: str, tag: Label):
-        self.tags[tag_type] = tag
+        self.set_label(tag_type, tag.value, tag.score)
 
     def add_tags_proba_dist(self, tag_type: str, tags: List[Label]):
         self.tags_proba_dist[tag_type] = tags
 
     def add_tag(self, tag_type: str, tag_value: str, confidence=1.0):
-        tag = Label(tag_value, confidence)
-        self.tags[tag_type] = tag
+        self.set_label(tag_type, tag_value, confidence)
 
-    def get_tag(self, tag_type: str) -> Label:
-        if tag_type in self.tags:
-            return self.tags[tag_type]
-        return Label("")
+    def get_tag(self, label_type):
+        if len(self.get_labels(label_type)) == 0: return Label('')
+        return self.get_labels(label_type)[0]
 
     def get_tags_proba_dist(self, tag_type: str) -> List[Label]:
         if tag_type in self.tags_proba_dist:
@@ -338,15 +379,16 @@ class Token(DataPoint):
         )
 
 
-class Span:
+class Span(DataPoint):
     """
-    This class represents one textual span consisting of Tokens. A span may have a tag.
+    This class represents one textual span consisting of Tokens.
     """
 
-    def __init__(self, tokens: List[Token], tag: str = None, score=1.0):
+    def __init__(self, tokens: List[Token]):
+
+        super().__init__()
+
         self.tokens = tokens
-        self.tag = tag
-        self.score = score
         self.start_pos = None
         self.end_pos = None
 
@@ -378,16 +420,15 @@ class Span:
             "text": self.to_original_text(),
             "start_pos": self.start_pos,
             "end_pos": self.end_pos,
-            "type": self.tag,
-            "confidence": self.score,
+            "labels": self.labels,
         }
 
     def __str__(self) -> str:
         ids = ",".join([str(t.idx) for t in self.tokens])
+        label_string = " ".join([str(label) for label in self.labels])
+        labels = f'   [− Labels: {label_string}]' if self.labels is not None else ""
         return (
-            '{}-span [{}]: "{}"'.format(self.tag, ids, self.text)
-            if self.tag is not None
-            else 'span [{}]: "{}"'.format(ids, self.text)
+            'Span [{}]: "{}"{}'.format(ids, self.text, labels)
         )
 
     def __repr__(self) -> str:
@@ -397,6 +438,767 @@ class Span:
             if self.tag is not None
             else '<span ({}): "{}">'.format(ids, self.text)
         )
+
+    @property
+    def tag(self):
+        return self.labels[0].value
+
+    @property
+    def score(self):
+        return self.labels[0].score
+
+
+class Sentence(DataPoint):
+    """
+       A Sentence is a list of Tokens and is used to represent a sentence or text fragment.
+    """
+
+    def __init__(
+        self,
+        text: str = None,
+        use_tokenizer: Union[bool, Callable[[str], List[Token]]] = False,
+        language_code: str = None,
+    ):
+        """
+        Class to hold all meta related to a text (tokens, predictions, language code, ...)
+        :param text: original string
+        :param use_tokenizer: a custom tokenizer (default is space based tokenizer,
+        more advanced options are segtok_tokenizer to use segtok or build_spacy_tokenizer to use Spacy library
+        if available). Check the code of space_tokenizer to implement your own (if you need it).
+        If instead of providing a function, this parameter is just set to True, segtok will be used.
+        :param labels:
+        :param language_code:
+        """
+        super().__init__()
+
+        self.tokens: List[Token] = []
+
+        self._embeddings: Dict = {}
+
+        self.language_code: str = language_code
+
+        tokenizer = use_tokenizer
+        if type(use_tokenizer) == bool:
+            tokenizer = segtok_tokenizer if use_tokenizer else space_tokenizer
+
+        # if text is passed, instantiate sentence with tokens (words)
+        if text is not None:
+            text = self._restore_windows_1252_characters(text)
+            [self.add_token(token) for token in tokenizer(text)]
+
+        # log a warning if the dataset is empty
+        if text == "":
+            log.warning(
+                "ACHTUNG: An empty Sentence was created! Are there empty strings in your dataset?"
+            )
+
+        self.tokenized = None
+
+    def get_token(self, token_id: int) -> Token:
+        for token in self.tokens:
+            if token.idx == token_id:
+                return token
+
+    def add_token(self, token: Union[Token, str]):
+
+        if type(token) is str:
+            token = Token(token)
+
+        self.tokens.append(token)
+
+        # set token idx if not set
+        token.sentence = self
+        if token.idx is None:
+            token.idx = len(self.tokens)
+
+    def get_label_names(self):
+        label_names = []
+        for label in self.labels:
+            label_names.append(label.value)
+
+    def get_spans(self, label_type: str, min_score=-1) -> List[Span]:
+
+        spans: List[Span] = []
+
+        current_span = []
+
+        tags = defaultdict(lambda: 0.0)
+
+        previous_tag_value: str = "O"
+        for token in self:
+
+            tag: Label = token.get_tag(label_type)
+            tag_value = tag.value
+
+            # non-set tags are OUT tags
+            if tag_value == "" or tag_value == "O":
+                tag_value = "O-"
+
+            # anything that is not a BIOES tag is a SINGLE tag
+            if tag_value[0:2] not in ["B-", "I-", "O-", "E-", "S-"]:
+                tag_value = "S-" + tag_value
+
+            # anything that is not OUT is IN
+            in_span = False
+            if tag_value[0:2] not in ["O-"]:
+                in_span = True
+
+            # single and begin tags start a new span
+            starts_new_span = False
+            if tag_value[0:2] in ["B-", "S-"]:
+                starts_new_span = True
+
+            if (
+                    previous_tag_value[0:2] in ["S-"]
+                    and previous_tag_value[2:] != tag_value[2:]
+                    and in_span
+            ):
+                starts_new_span = True
+
+            if (starts_new_span or not in_span) and len(current_span) > 0:
+                scores = [t.get_labels(label_type)[0].score for t in current_span]
+                span_score = sum(scores) / len(scores)
+                if span_score > min_score:
+                    span = Span(current_span)
+                    span.add_label(
+                        label_type=label_type,
+                        value=sorted(tags.items(), key=lambda k_v: k_v[1], reverse=True)[0][0],
+                        score=span_score)
+                    spans.append(span)
+
+                current_span = []
+                tags = defaultdict(lambda: 0.0)
+
+            if in_span:
+                current_span.append(token)
+                weight = 1.1 if starts_new_span else 1.0
+                tags[tag_value[2:]] += weight
+
+            # remember previous tag
+            previous_tag_value = tag_value
+
+        if len(current_span) > 0:
+            scores = [t.get_labels(label_type)[0].score for t in current_span]
+            span_score = sum(scores) / len(scores)
+            if span_score > min_score:
+                span = Span(current_span)
+                span.add_label(
+                    label_type=label_type,
+                    value=sorted(tags.items(), key=lambda k_v: k_v[1], reverse=True)[0][0],
+                    score=span_score)
+                spans.append(span)
+
+        return spans
+
+    @property
+    def embedding(self):
+        return self.get_embedding()
+
+    def set_embedding(self, name: str, vector: torch.tensor):
+        device = flair.device
+        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
+            device = next(iter(self._embeddings.values())).device
+        if device != vector.device:
+            vector = vector.to(device)
+        self._embeddings[name] = vector
+
+    def get_embedding(self) -> torch.tensor:
+        embeddings = []
+        for embed in sorted(self._embeddings.keys()):
+            embedding = self._embeddings[embed]
+            embeddings.append(embedding)
+
+        if embeddings:
+            return torch.cat(embeddings, dim=0)
+
+        return torch.Tensor()
+
+    def to(self, device: str, pin_memory: bool = False):
+
+        # move sentence embeddings to device
+        for name, vector in self._embeddings.items():
+            if str(vector.device) != str(device):
+                if pin_memory:
+                    self._embeddings[name] = vector.to(
+                        device, non_blocking=True
+                    ).pin_memory()
+                else:
+                    self._embeddings[name] = vector.to(device, non_blocking=True)
+
+        # move token embeddings to device
+        for token in self:
+            token.to(device, pin_memory)
+
+    def clear_embeddings(self, embedding_names: List[str] = None):
+
+        # clear sentence embeddings
+        if embedding_names is None:
+            self._embeddings: Dict = {}
+        else:
+            for name in embedding_names:
+                if name in self._embeddings.keys():
+                    del self._embeddings[name]
+
+        # clear token embeddings
+        for token in self:
+            token.clear_embeddings(embedding_names)
+
+    def to_tagged_string(self, main_tag=None) -> str:
+        list = []
+        for token in self.tokens:
+            list.append(token.text)
+
+            tags: List[str] = []
+            for label_type in token.annotation_layers.keys():
+
+                if main_tag is not None and main_tag != label_type:
+                    continue
+
+                if token.get_labels(label_type)[0].value == "O":
+                    continue
+
+                tags.append(token.get_labels(label_type)[0].value)
+            all_tags = "<" + "/".join(tags) + ">"
+            if all_tags != "<>":
+                list.append(all_tags)
+        return " ".join(list)
+
+    def to_tokenized_string(self) -> str:
+
+        if self.tokenized is None:
+            self.tokenized = " ".join([t.text for t in self.tokens])
+
+        return self.tokenized
+
+    def to_plain_string(self):
+        plain = ""
+        for token in self.tokens:
+            plain += token.text
+            if token.whitespace_after:
+                plain += " "
+        return plain.rstrip()
+
+    def convert_tag_scheme(self, tag_type: str = "ner", target_scheme: str = "iob"):
+
+        tags: List[Label] = []
+        for token in self.tokens:
+            tags.append(token.get_tag(tag_type))
+
+        if target_scheme == "iob":
+            iob2(tags)
+
+        if target_scheme == "iobes":
+            iob2(tags)
+            tags = iob_iobes(tags)
+
+        for index, tag in enumerate(tags):
+            self.tokens[index].add_label(tag_type, tag)
+
+    def infer_space_after(self):
+        """
+        Heuristics in case you wish to infer whitespace_after values for tokenized text. This is useful for some old NLP
+        tasks (such as CoNLL-03 and CoNLL-2000) that provide only tokenized data with no info of original whitespacing.
+        :return:
+        """
+        last_token = None
+        quote_count: int = 0
+        # infer whitespace after field
+
+        for token in self.tokens:
+            if token.text == '"':
+                quote_count += 1
+                if quote_count % 2 != 0:
+                    token.whitespace_after = False
+                elif last_token is not None:
+                    last_token.whitespace_after = False
+
+            if last_token is not None:
+
+                if token.text in [".", ":", ",", ";", ")", "n't", "!", "?"]:
+                    last_token.whitespace_after = False
+
+                if token.text.startswith("'"):
+                    last_token.whitespace_after = False
+
+            if token.text in ["("]:
+                token.whitespace_after = False
+
+            last_token = token
+        return self
+
+    def to_original_text(self) -> str:
+        if len(self.tokens) > 0 and (self.tokens[0].start_pos is None):
+            return " ".join([t.text for t in self.tokens])
+        str = ""
+        pos = 0
+        for t in self.tokens:
+            while t.start_pos != pos:
+                str += " "
+                pos += 1
+
+            str += t.text
+            pos += len(t.text)
+
+        return str
+
+    def to_dict(self, tag_type: str = None):
+        labels = []
+        entities = []
+
+        if tag_type:
+            entities = [span.to_dict() for span in self.get_spans(tag_type)]
+        if self.labels:
+            labels = [l.to_dict() for l in self.labels]
+
+        return {"text": self.to_original_text(), "labels": labels, "entities": entities}
+
+    def __getitem__(self, idx: int) -> Token:
+        return self.tokens[idx]
+
+    def __iter__(self):
+        return iter(self.tokens)
+
+    def __repr__(self):
+        return 'Sentence: "{}" - {} Tokens'.format(
+            " ".join([t.text for t in self.tokens]), len(self)
+        )
+
+    def __copy__(self):
+        s = Sentence()
+        for token in self.tokens:
+            nt = Token(token.text)
+            for tag_type in token.tags:
+                nt.add_label(
+                    tag_type,
+                    token.get_tag(tag_type).value,
+                    token.get_tag(tag_type).score,
+                )
+
+            s.add_token(nt)
+        return s
+
+    def __str__(self) -> str:
+
+        tagged_string = self.to_tagged_string()
+        tokenized_string = self.to_tokenized_string()
+
+        # add Sentence labels to output if they exist
+        sentence_labels = f"  − Sentence-Labels: {self.annotation_layers}" if self.annotation_layers != {} else ""
+
+        # add Token labels to output if they exist
+        token_labels = f'  − Token-Labels: "{tagged_string}"' if tokenized_string != tagged_string else ""
+
+        return f'Sentence: "{tokenized_string}"   [− Tokens: {len(self)}{token_labels}{sentence_labels}]'
+
+    def __len__(self) -> int:
+        return len(self.tokens)
+
+    def get_language_code(self) -> str:
+        if self.language_code is None:
+            import langdetect
+
+            try:
+                self.language_code = langdetect.detect(self.to_plain_string())
+            except:
+                self.language_code = "en"
+
+        return self.language_code
+
+    @staticmethod
+    def _restore_windows_1252_characters(text: str) -> str:
+        def to_windows_1252(match):
+            try:
+                return bytes([ord(match.group(0))]).decode("windows-1252")
+            except UnicodeDecodeError:
+                # No character at the corresponding code point: remove it
+                return ""
+
+        return re.sub(r"[\u0080-\u0099]", to_windows_1252, text)
+
+
+class Image(DataPoint):
+
+    def __init__(self, data=None, imageURL=None):
+        super().__init__()
+
+        self.data = data
+        self._embeddings: Dict = {}
+        self.imageURL = imageURL
+
+    @property
+    def embedding(self):
+        return self.get_embedding()
+
+    def __str__(self):
+
+        image_repr = self.data.size() if self.data else ""
+        image_url = self.imageURL if self.imageURL else ""
+
+        return f"Image: {image_repr} {image_url}"
+
+    def get_embedding(self) -> torch.tensor:
+        embeddings = [
+            self._embeddings[embed] for embed in sorted(self._embeddings.keys())
+        ]
+
+        if embeddings:
+            return torch.cat(embeddings, dim=0)
+
+        return torch.tensor([], device=flair.device)
+
+    def set_embedding(self, name: str, vector: torch.tensor):
+        device = flair.device
+        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
+            device = next(iter(self._embeddings.values())).device
+        if device != vector.device:
+            vector = vector.to(device)
+        self._embeddings[name] = vector
+
+    def to(self, device: str, pin_memory: bool = False):
+        for name, vector in self._embeddings.items():
+            if str(vector.device) != str(device):
+                if pin_memory:
+                    self._embeddings[name] = vector.to(
+                        device, non_blocking=True
+                    ).pin_memory()
+                else:
+                    self._embeddings[name] = vector.to(device, non_blocking=True)
+
+    def clear_embeddings(self, embedding_names: List[str] = None):
+        if embedding_names is None:
+            self._embeddings: Dict = {}
+        else:
+            for name in embedding_names:
+                if name in self._embeddings.keys():
+                    del self._embeddings[name]
+
+
+class FlairDataset(Dataset):
+    @abstractmethod
+    def is_in_memory(self) -> bool:
+        pass
+
+
+class Corpus:
+    def __init__(
+            self,
+            train: FlairDataset,
+            dev: FlairDataset = None,
+            test: FlairDataset = None,
+            name: str = "corpus",
+    ):
+        # set name
+        self.name: str = name
+
+        # sample test data if none is provided
+        if test is None:
+            train_length = len(train)
+            test_size: int = round(train_length / 10)
+            splits = random_split(train, [train_length - test_size, test_size])
+            train = splits[0]
+            test = splits[1]
+
+        # sample dev data if none is provided
+        if dev is None:
+            train_length = len(train)
+            dev_size: int = round(train_length / 10)
+            splits = random_split(train, [train_length - dev_size, dev_size])
+            train = splits[0]
+            dev = splits[1]
+
+        # set train dev and test data
+        self._train: FlairDataset = train
+        self._test: FlairDataset = test
+        self._dev: FlairDataset = dev
+
+    @property
+    def train(self) -> FlairDataset:
+        return self._train
+
+    @property
+    def dev(self) -> FlairDataset:
+        return self._dev
+
+    @property
+    def test(self) -> FlairDataset:
+        return self._test
+
+    def downsample(self, percentage: float = 0.1, only_downsample_train=False):
+
+        self._train = self._downsample_to_proportion(self.train, percentage)
+        if not only_downsample_train:
+            self._dev = self._downsample_to_proportion(self.dev, percentage)
+            self._test = self._downsample_to_proportion(self.test, percentage)
+
+        return self
+
+    def filter_empty_sentences(self):
+        log.info("Filtering empty sentences")
+        self._train = Corpus._filter_empty_sentences(self._train)
+        self._test = Corpus._filter_empty_sentences(self._test)
+        self._dev = Corpus._filter_empty_sentences(self._dev)
+        log.info(self)
+
+    @staticmethod
+    def _filter_empty_sentences(dataset) -> Dataset:
+
+        # find out empty sentence indices
+        empty_sentence_indices = []
+        non_empty_sentence_indices = []
+        index = 0
+
+        from flair.datasets import DataLoader
+
+        for batch in DataLoader(dataset):
+            for sentence in batch:
+                if len(sentence) == 0:
+                    empty_sentence_indices.append(index)
+                else:
+                    non_empty_sentence_indices.append(index)
+                index += 1
+
+        # create subset of non-empty sentence indices
+        subset = Subset(dataset, non_empty_sentence_indices)
+
+        return subset
+
+    def make_vocab_dictionary(self, max_tokens=-1, min_freq=1) -> Dictionary:
+        """
+        Creates a dictionary of all tokens contained in the corpus.
+        By defining `max_tokens` you can set the maximum number of tokens that should be contained in the dictionary.
+        If there are more than `max_tokens` tokens in the corpus, the most frequent tokens are added first.
+        If `min_freq` is set the a value greater than 1 only tokens occurring more than `min_freq` times are considered
+        to be added to the dictionary.
+        :param max_tokens: the maximum number of tokens that should be added to the dictionary (-1 = take all tokens)
+        :param min_freq: a token needs to occur at least `min_freq` times to be added to the dictionary (-1 = there is no limitation)
+        :return: dictionary of tokens
+        """
+        tokens = self._get_most_common_tokens(max_tokens, min_freq)
+
+        vocab_dictionary: Dictionary = Dictionary()
+        for token in tokens:
+            vocab_dictionary.add_item(token)
+
+        return vocab_dictionary
+
+    def _get_most_common_tokens(self, max_tokens, min_freq) -> List[str]:
+        tokens_and_frequencies = Counter(self._get_all_tokens())
+        tokens_and_frequencies = tokens_and_frequencies.most_common()
+
+        tokens = []
+        for token, freq in tokens_and_frequencies:
+            if (min_freq != -1 and freq < min_freq) or (
+                    max_tokens != -1 and len(tokens) == max_tokens
+            ):
+                break
+            tokens.append(token)
+        return tokens
+
+    def _get_all_tokens(self) -> List[str]:
+        tokens = list(map((lambda s: s.tokens), self.train))
+        tokens = [token for sublist in tokens for token in sublist]
+        return list(map((lambda t: t.text), tokens))
+
+    @staticmethod
+    def _downsample_to_proportion(dataset: Dataset, proportion: float):
+
+        sampled_size: int = round(len(dataset) * proportion)
+        splits = random_split(dataset, [len(dataset) - sampled_size, sampled_size])
+        return splits[1]
+
+    def obtain_statistics(
+            self, label_type: str = None, pretty_print: bool = True
+    ) -> dict:
+        """
+        Print statistics about the class distribution (only labels of sentences are taken into account) and sentence
+        sizes.
+        """
+        json_string = {
+            "TRAIN": self._obtain_statistics_for(self.train, "TRAIN", label_type),
+            "TEST": self._obtain_statistics_for(self.test, "TEST", label_type),
+            "DEV": self._obtain_statistics_for(self.dev, "DEV", label_type),
+        }
+        if pretty_print:
+            import json
+
+            json_string = json.dumps(json_string, indent=4)
+        return json_string
+
+    @staticmethod
+    def _obtain_statistics_for(sentences, name, tag_type) -> dict:
+        if len(sentences) == 0:
+            return {}
+
+        classes_to_count = Corpus._count_sentence_labels(sentences)
+        tags_to_count = Corpus._count_token_labels(sentences, tag_type)
+        tokens_per_sentence = Corpus._get_tokens_per_sentence(sentences)
+
+        label_size_dict = {}
+        for l, c in classes_to_count.items():
+            label_size_dict[l] = c
+
+        tag_size_dict = {}
+        for l, c in tags_to_count.items():
+            tag_size_dict[l] = c
+
+        return {
+            "dataset": name,
+            "total_number_of_documents": len(sentences),
+            "number_of_documents_per_class": label_size_dict,
+            "number_of_tokens_per_tag": tag_size_dict,
+            "number_of_tokens": {
+                "total": sum(tokens_per_sentence),
+                "min": min(tokens_per_sentence),
+                "max": max(tokens_per_sentence),
+                "avg": sum(tokens_per_sentence) / len(sentences),
+            },
+        }
+
+    @staticmethod
+    def _get_tokens_per_sentence(sentences):
+        return list(map(lambda x: len(x.tokens), sentences))
+
+    @staticmethod
+    def _count_sentence_labels(sentences):
+        label_count = defaultdict(lambda: 0)
+        for sent in sentences:
+            for label in sent.labels:
+                label_count[label.value] += 1
+        return label_count
+
+    @staticmethod
+    def _count_token_labels(sentences, label_type):
+        label_count = defaultdict(lambda: 0)
+        for sent in sentences:
+            for token in sent.tokens:
+                if label_type in token.annotation_layers.keys():
+                    label = token.get_tag(label_type)
+                    label_count[label.value] += 1
+        return label_count
+
+    def __str__(self) -> str:
+        return "Corpus: %d train + %d dev + %d test sentences" % (
+            len(self.train),
+            len(self.dev),
+            len(self.test),
+        )
+
+    def make_label_dictionary(self, label_type: str = "class") -> Dictionary:
+        """
+        Creates a dictionary of all labels assigned to the sentences in the corpus.
+        :return: dictionary of labels
+        """
+        label_dictionary: Dictionary = Dictionary(add_unk=False)
+        label_dictionary.multi_label = False
+
+        from flair.datasets import DataLoader
+
+        loader = DataLoader(self.train, batch_size=1)
+
+        log.info("Computing label dictionary. Progress:")
+        for batch in Tqdm.tqdm(iter(loader)):
+
+            for sentence in batch:
+
+                # check if sentence itself has labels
+                for label in sentence.get_labels(label_type):
+                    label_dictionary.add_item(label.value)
+
+                # check for labels of words
+                if isinstance(sentence, Sentence):
+                    for token in sentence.tokens:
+                        for label in token.get_labels(label_type):
+                            label_dictionary.add_item(label.value)
+
+                if not label_dictionary.multi_label:
+                    if len(sentence.get_labels(label_type)) > 1:
+                        label_dictionary.multi_label = True
+
+        log.info(label_dictionary.idx2item)
+
+        return label_dictionary
+
+    def get_label_distribution(self):
+        class_to_count = defaultdict(lambda: 0)
+        for sent in self.train:
+            for label in sent.labels:
+                class_to_count[label.value] += 1
+        return class_to_count
+
+    def get_all_sentences(self) -> Dataset:
+        return ConcatDataset([self.train, self.dev, self.test])
+
+    def make_tag_dictionary(self, tag_type: str) -> Dictionary:
+
+        # Make the tag dictionary
+        tag_dictionary: Dictionary = Dictionary()
+        tag_dictionary.add_item("O")
+        for sentence in self.get_all_sentences():
+            for token in sentence.tokens:
+                tag_dictionary.add_item(token.get_tag(tag_type).value)
+        tag_dictionary.add_item("<START>")
+        tag_dictionary.add_item("<STOP>")
+        return tag_dictionary
+
+
+class MultiCorpus(Corpus):
+    def __init__(self, corpora: List[Corpus], name: str = "multicorpus"):
+        self.corpora: List[Corpus] = corpora
+
+        super(MultiCorpus, self).__init__(
+            ConcatDataset([corpus.train for corpus in self.corpora]),
+            ConcatDataset([corpus.dev for corpus in self.corpora]),
+            ConcatDataset([corpus.test for corpus in self.corpora]),
+            name=name,
+        )
+
+    def __str__(self):
+        return "\n".join([str(corpus) for corpus in self.corpora])
+
+
+def iob2(tags):
+    """
+    Check that tags have a valid IOB format.
+    Tags in IOB1 format are converted to IOB2.
+    """
+    for i, tag in enumerate(tags):
+        if tag.value == "O":
+            continue
+        split = tag.value.split("-")
+        if len(split) != 2 or split[0] not in ["I", "B"]:
+            return False
+        if split[0] == "B":
+            continue
+        elif i == 0 or tags[i - 1].value == "O":  # conversion IOB1 to IOB2
+            tags[i].value = "B" + tag.value[1:]
+        elif tags[i - 1].value[1:] == tag.value[1:]:
+            continue
+        else:  # conversion IOB1 to IOB2
+            tags[i].value = "B" + tag.value[1:]
+    return True
+
+
+def iob_iobes(tags):
+    """
+    IOB -> IOBES
+    """
+    new_tags = []
+    for i, tag in enumerate(tags):
+        if tag.value == "O":
+            new_tags.append(tag.value)
+        elif tag.value.split("-")[0] == "B":
+            if i + 1 != len(tags) and tags[i + 1].value.split("-")[0] == "I":
+                new_tags.append(tag.value)
+            else:
+                new_tags.append(tag.value.replace("B-", "S-"))
+        elif tag.value.split("-")[0] == "I":
+            if i + 1 < len(tags) and tags[i + 1].value.split("-")[0] == "I":
+                new_tags.append(tag.value)
+            else:
+                new_tags.append(tag.value.replace("I-", "E-"))
+        else:
+            raise Exception("Invalid IOB format!")
+    return new_tags
 
 
 def space_tokenizer(text: str) -> List[Token]:
@@ -569,8 +1371,8 @@ def build_spacy_tokenizer(model) -> Callable[[str], List[Token]]:
             tokens.append(token)
 
             if (previous_token is not None) and (
-                token.start_pos - 1
-                == previous_token.start_pos + len(previous_token.text)
+                    token.start_pos - 1
+                    == previous_token.start_pos + len(previous_token.text)
             ):
                 previous_token.whitespace_after = False
 
@@ -578,761 +1380,3 @@ def build_spacy_tokenizer(model) -> Callable[[str], List[Token]]:
         return tokens
 
     return tokenizer
-
-
-class Sentence(DataPoint):
-    """
-       A Sentence is a list of Tokens and is used to represent a sentence or text fragment.
-    """
-
-    def __init__(
-        self,
-        text: str = None,
-        use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer,
-        labels: Union[List[Label], List[str]] = None,
-        language_code: str = None,
-    ):
-        """
-        Class to hold all meta related to a text (tokens, predictions, language code, ...)
-        :param text: original string
-        :param use_tokenizer: a custom tokenizer (default is space based tokenizer,
-        more advanced options are segtok_tokenizer to use segtok or build_spacy_tokenizer to use Spacy library
-        if available). Check the code of space_tokenizer to implement your own (if you need it).
-        If instead of providing a function, this parameter is just set to True, segtok will be used.
-        :param labels:
-        :param language_code:
-        """
-        super(Sentence, self).__init__()
-
-        self.tokens: List[Token] = []
-
-        self.labels: List[Label] = []
-        if labels is not None:
-            self.add_labels(labels)
-
-        self._embeddings: Dict = {}
-
-        self.language_code: str = language_code
-
-        tokenizer = use_tokenizer
-        if type(use_tokenizer) == bool:
-            tokenizer = segtok_tokenizer if use_tokenizer else space_tokenizer
-
-        # if text is passed, instantiate sentence with tokens (words)
-        if text is not None:
-            text = self._restore_windows_1252_characters(text)
-            [self.add_token(token) for token in tokenizer(text)]
-
-        # log a warning if the dataset is empty
-        if text == "":
-            log.warning(
-                "ACHTUNG: An empty Sentence was created! Are there empty strings in your dataset?"
-            )
-
-        self.tokenized = None
-
-    def get_token(self, token_id: int) -> Token:
-        for token in self.tokens:
-            if token.idx == token_id:
-                return token
-
-    def add_token(self, token: Union[Token, str]):
-
-        if type(token) is str:
-            token = Token(token)
-
-        self.tokens.append(token)
-
-        # set token idx if not set
-        token.sentence = self
-        if token.idx is None:
-            token.idx = len(self.tokens)
-
-    def get_spans(self, tag_type: str, min_score=-1) -> List[Span]:
-
-        spans: List[Span] = []
-
-        current_span = []
-
-        tags = defaultdict(lambda: 0.0)
-
-        previous_tag_value: str = "O"
-        for token in self:
-
-            tag: Label = token.get_tag(tag_type)
-            tag_value = tag.value
-
-            # non-set tags are OUT tags
-            if tag_value == "" or tag_value == "O":
-                tag_value = "O-"
-
-            # anything that is not a BIOES tag is a SINGLE tag
-            if tag_value[0:2] not in ["B-", "I-", "O-", "E-", "S-"]:
-                tag_value = "S-" + tag_value
-
-            # anything that is not OUT is IN
-            in_span = False
-            if tag_value[0:2] not in ["O-"]:
-                in_span = True
-
-            # single and begin tags start a new span
-            starts_new_span = False
-            if tag_value[0:2] in ["B-", "S-"]:
-                starts_new_span = True
-
-            if (
-                previous_tag_value[0:2] in ["S-"]
-                and previous_tag_value[2:] != tag_value[2:]
-                and in_span
-            ):
-                starts_new_span = True
-
-            if (starts_new_span or not in_span) and len(current_span) > 0:
-                scores = [t.get_tag(tag_type).score for t in current_span]
-                span_score = sum(scores) / len(scores)
-                if span_score > min_score:
-                    spans.append(
-                        Span(
-                            current_span,
-                            tag=sorted(
-                                tags.items(), key=lambda k_v: k_v[1], reverse=True
-                            )[0][0],
-                            score=span_score,
-                        )
-                    )
-                current_span = []
-                tags = defaultdict(lambda: 0.0)
-
-            if in_span:
-                current_span.append(token)
-                weight = 1.1 if starts_new_span else 1.0
-                tags[tag_value[2:]] += weight
-
-            # remember previous tag
-            previous_tag_value = tag_value
-
-        if len(current_span) > 0:
-            scores = [t.get_tag(tag_type).score for t in current_span]
-            span_score = sum(scores) / len(scores)
-            if span_score > min_score:
-                spans.append(
-                    Span(
-                        current_span,
-                        tag=sorted(tags.items(), key=lambda k_v: k_v[1], reverse=True)[
-                            0
-                        ][0],
-                        score=span_score,
-                    )
-                )
-
-        return spans
-
-    def add_label(self, label: Union[Label, str]):
-        if type(label) is Label:
-            self.labels.append(label)
-
-        elif type(label) is str:
-            self.labels.append(Label(label))
-
-    def add_labels(self, labels: Union[List[Label], List[str]]):
-        for label in labels:
-            self.add_label(label)
-
-    def get_label_names(self) -> List[str]:
-        return [label.value for label in self.labels]
-
-    @property
-    def embedding(self):
-        return self.get_embedding()
-
-    def set_embedding(self, name: str, vector: torch.tensor):
-        device = flair.device
-        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
-            device = next(iter(self._embeddings.values())).device
-        if device != vector.device:
-            vector = vector.to(device)
-        self._embeddings[name] = vector
-
-    def get_embedding(self) -> torch.tensor:
-        embeddings = []
-        for embed in sorted(self._embeddings.keys()):
-            embedding = self._embeddings[embed]
-            embeddings.append(embedding)
-
-        if embeddings:
-            return torch.cat(embeddings, dim=0)
-
-        return torch.Tensor()
-
-    def to(self, device: str, pin_memory: bool = False):
-
-        # move sentence embeddings to device
-        for name, vector in self._embeddings.items():
-            if str(vector.device) != str(device):
-                if pin_memory:
-                    self._embeddings[name] = vector.to(
-                        device, non_blocking=True
-                    ).pin_memory()
-                else:
-                    self._embeddings[name] = vector.to(device, non_blocking=True)
-
-        # move token embeddings to device
-        for token in self:
-            token.to(device, pin_memory)
-
-    def clear_embeddings(self, embedding_names: List[str] = None):
-
-        # clear sentence embeddings
-        if embedding_names is None:
-            self._embeddings: Dict = {}
-        else:
-            for name in embedding_names:
-                if name in self._embeddings.keys():
-                    del self._embeddings[name]
-
-        # clear token embeddings
-        for token in self:
-            token.clear_embeddings(embedding_names)
-
-    def to_tagged_string(self, main_tag=None) -> str:
-        list = []
-        for token in self.tokens:
-            list.append(token.text)
-
-            tags: List[str] = []
-            for tag_type in token.tags.keys():
-
-                if main_tag is not None and main_tag != tag_type:
-                    continue
-
-                if (
-                    token.get_tag(tag_type).value == ""
-                    or token.get_tag(tag_type).value == "O"
-                ):
-                    continue
-                tags.append(token.get_tag(tag_type).value)
-            all_tags = "<" + "/".join(tags) + ">"
-            if all_tags != "<>":
-                list.append(all_tags)
-        return " ".join(list)
-
-    def to_tokenized_string(self) -> str:
-
-        if self.tokenized is None:
-            self.tokenized = " ".join([t.text for t in self.tokens])
-
-        return self.tokenized
-
-    def to_plain_string(self):
-        plain = ""
-        for token in self.tokens:
-            plain += token.text
-            if token.whitespace_after:
-                plain += " "
-        return plain.rstrip()
-
-    def convert_tag_scheme(self, tag_type: str = "ner", target_scheme: str = "iob"):
-
-        tags: List[Label] = []
-        for token in self.tokens:
-            tags.append(token.get_tag(tag_type))
-
-        if target_scheme == "iob":
-            iob2(tags)
-
-        if target_scheme == "iobes":
-            iob2(tags)
-            tags = iob_iobes(tags)
-
-        for index, tag in enumerate(tags):
-            self.tokens[index].add_tag(tag_type, tag)
-
-    def infer_space_after(self):
-        """
-        Heuristics in case you wish to infer whitespace_after values for tokenized text. This is useful for some old NLP
-        tasks (such as CoNLL-03 and CoNLL-2000) that provide only tokenized data with no info of original whitespacing.
-        :return:
-        """
-        last_token = None
-        quote_count: int = 0
-        # infer whitespace after field
-
-        for token in self.tokens:
-            if token.text == '"':
-                quote_count += 1
-                if quote_count % 2 != 0:
-                    token.whitespace_after = False
-                elif last_token is not None:
-                    last_token.whitespace_after = False
-
-            if last_token is not None:
-
-                if token.text in [".", ":", ",", ";", ")", "n't", "!", "?"]:
-                    last_token.whitespace_after = False
-
-                if token.text.startswith("'"):
-                    last_token.whitespace_after = False
-
-            if token.text in ["("]:
-                token.whitespace_after = False
-
-            last_token = token
-        return self
-
-    def to_original_text(self) -> str:
-        if len(self.tokens) > 0 and (self.tokens[0].start_pos is None):
-            return " ".join([t.text for t in self.tokens])
-        str = ""
-        pos = 0
-        for t in self.tokens:
-            while t.start_pos != pos:
-                str += " "
-                pos += 1
-
-            str += t.text
-            pos += len(t.text)
-
-        return str
-
-    def to_dict(self, tag_type: str = None):
-        labels = []
-        entities = []
-
-        if tag_type:
-            entities = [span.to_dict() for span in self.get_spans(tag_type)]
-        if self.labels:
-            labels = [l.to_dict() for l in self.labels]
-
-        return {"text": self.to_original_text(), "labels": labels, "entities": entities}
-
-    def __getitem__(self, idx: int) -> Token:
-        return self.tokens[idx]
-
-    def __iter__(self):
-        return iter(self.tokens)
-
-    def __repr__(self):
-        return 'Sentence: "{}" - {} Tokens'.format(
-            " ".join([t.text for t in self.tokens]), len(self)
-        )
-
-    def __copy__(self):
-        s = Sentence()
-        for token in self.tokens:
-            nt = Token(token.text)
-            for tag_type in token.tags:
-                nt.add_tag(
-                    tag_type,
-                    token.get_tag(tag_type).value,
-                    token.get_tag(tag_type).score,
-                )
-
-            s.add_token(nt)
-        return s
-
-    def __str__(self) -> str:
-
-        if self.labels:
-            return f'Sentence: "{self.to_tokenized_string()}" - {len(self)} Tokens - Labels: {self.labels} '
-        else:
-            return f'Sentence: "{self.to_tokenized_string()}" - {len(self)} Tokens'
-
-    def __len__(self) -> int:
-        return len(self.tokens)
-
-    def get_language_code(self) -> str:
-        if self.language_code is None:
-            import langdetect
-
-            try:
-                self.language_code = langdetect.detect(self.to_plain_string())
-            except:
-                self.language_code = "en"
-
-        return self.language_code
-
-    @staticmethod
-    def _restore_windows_1252_characters(text: str) -> str:
-        def to_windows_1252(match):
-            try:
-                return bytes([ord(match.group(0))]).decode("windows-1252")
-            except UnicodeDecodeError:
-                # No character at the corresponding code point: remove it
-                return ""
-
-        return re.sub(r"[\u0080-\u0099]", to_windows_1252, text)
-
-
-class Image(DataPoint):
-    def __init__(self, data=None, imageURL=None):
-        self.data = data
-        self._embeddings: Dict = {}
-        self.imageURL = imageURL
-
-    @property
-    def embedding(self):
-        return self.get_embedding()
-
-    def __str__(self):
-
-        image_repr = self.data.size() if self.data else ""
-        image_url = self.imageURL if self.imageURL else ""
-
-        return f"Image: {image_repr} {image_url}"
-
-    def get_embedding(self) -> torch.tensor:
-        embeddings = [
-            self._embeddings[embed] for embed in sorted(self._embeddings.keys())
-        ]
-
-        if embeddings:
-            return torch.cat(embeddings, dim=0)
-
-        return torch.tensor([], device=flair.device)
-
-    def set_embedding(self, name: str, vector: torch.tensor):
-        device = flair.device
-        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
-            device = next(iter(self._embeddings.values())).device
-        if device != vector.device:
-            vector = vector.to(device)
-        self._embeddings[name] = vector
-
-    def to(self, device: str, pin_memory: bool = False):
-        for name, vector in self._embeddings.items():
-            if str(vector.device) != str(device):
-                if pin_memory:
-                    self._embeddings[name] = vector.to(
-                        device, non_blocking=True
-                    ).pin_memory()
-                else:
-                    self._embeddings[name] = vector.to(device, non_blocking=True)
-
-    def clear_embeddings(self, embedding_names: List[str] = None):
-        if embedding_names is None:
-            self._embeddings: Dict = {}
-        else:
-            for name in embedding_names:
-                if name in self._embeddings.keys():
-                    del self._embeddings[name]
-
-
-class FlairDataset(Dataset):
-    @abstractmethod
-    def is_in_memory(self) -> bool:
-        pass
-
-
-class Corpus:
-    def __init__(
-        self,
-        train: FlairDataset,
-        dev: FlairDataset = None,
-        test: FlairDataset = None,
-        name: str = "corpus",
-    ):
-        # set name
-        self.name: str = name
-
-        # sample test data if none is provided
-        if test is None:
-            train_length = len(train)
-            test_size: int = round(train_length / 10)
-            splits = random_split(train, [train_length - test_size, test_size])
-            train = splits[0]
-            test = splits[1]
-
-        # sample dev data if none is provided
-        if dev is None:
-            train_length = len(train)
-            dev_size: int = round(train_length / 10)
-            splits = random_split(train, [train_length - dev_size, dev_size])
-            train = splits[0]
-            dev = splits[1]
-
-        # set train dev and test data
-        self._train: FlairDataset = train
-        self._test: FlairDataset = test
-        self._dev: FlairDataset = dev
-
-    @property
-    def train(self) -> FlairDataset:
-        return self._train
-
-    @property
-    def dev(self) -> FlairDataset:
-        return self._dev
-
-    @property
-    def test(self) -> FlairDataset:
-        return self._test
-
-    def downsample(self, percentage: float = 0.1, only_downsample_train=False):
-
-        self._train = self._downsample_to_proportion(self.train, percentage)
-        if not only_downsample_train:
-            self._dev = self._downsample_to_proportion(self.dev, percentage)
-            self._test = self._downsample_to_proportion(self.test, percentage)
-
-        return self
-
-    def filter_empty_sentences(self):
-        log.info("Filtering empty sentences")
-        self._train = Corpus._filter_empty_sentences(self._train)
-        self._test = Corpus._filter_empty_sentences(self._test)
-        self._dev = Corpus._filter_empty_sentences(self._dev)
-        log.info(self)
-
-    @staticmethod
-    def _filter_empty_sentences(dataset) -> Dataset:
-
-        # find out empty sentence indices
-        empty_sentence_indices = []
-        non_empty_sentence_indices = []
-        index = 0
-
-        from flair.datasets import DataLoader
-
-        for batch in DataLoader(dataset):
-            for sentence in batch:
-                if len(sentence) == 0:
-                    empty_sentence_indices.append(index)
-                else:
-                    non_empty_sentence_indices.append(index)
-                index += 1
-
-        # create subset of non-empty sentence indices
-        subset = Subset(dataset, non_empty_sentence_indices)
-
-        return subset
-
-    def make_vocab_dictionary(self, max_tokens=-1, min_freq=1) -> Dictionary:
-        """
-        Creates a dictionary of all tokens contained in the corpus.
-        By defining `max_tokens` you can set the maximum number of tokens that should be contained in the dictionary.
-        If there are more than `max_tokens` tokens in the corpus, the most frequent tokens are added first.
-        If `min_freq` is set the a value greater than 1 only tokens occurring more than `min_freq` times are considered
-        to be added to the dictionary.
-        :param max_tokens: the maximum number of tokens that should be added to the dictionary (-1 = take all tokens)
-        :param min_freq: a token needs to occur at least `min_freq` times to be added to the dictionary (-1 = there is no limitation)
-        :return: dictionary of tokens
-        """
-        tokens = self._get_most_common_tokens(max_tokens, min_freq)
-
-        vocab_dictionary: Dictionary = Dictionary()
-        for token in tokens:
-            vocab_dictionary.add_item(token)
-
-        return vocab_dictionary
-
-    def _get_most_common_tokens(self, max_tokens, min_freq) -> List[str]:
-        tokens_and_frequencies = Counter(self._get_all_tokens())
-        tokens_and_frequencies = tokens_and_frequencies.most_common()
-
-        tokens = []
-        for token, freq in tokens_and_frequencies:
-            if (min_freq != -1 and freq < min_freq) or (
-                max_tokens != -1 and len(tokens) == max_tokens
-            ):
-                break
-            tokens.append(token)
-        return tokens
-
-    def _get_all_tokens(self) -> List[str]:
-        tokens = list(map((lambda s: s.tokens), self.train))
-        tokens = [token for sublist in tokens for token in sublist]
-        return list(map((lambda t: t.text), tokens))
-
-    @staticmethod
-    def _downsample_to_proportion(dataset: Dataset, proportion: float):
-
-        sampled_size: int = round(len(dataset) * proportion)
-        splits = random_split(dataset, [len(dataset) - sampled_size, sampled_size])
-        return splits[1]
-
-    def obtain_statistics(
-        self, tag_type: str = None, pretty_print: bool = True
-    ) -> dict:
-        """
-        Print statistics about the class distribution (only labels of sentences are taken into account) and sentence
-        sizes.
-        """
-        json_string = {
-            "TRAIN": self._obtain_statistics_for(self.train, "TRAIN", tag_type),
-            "TEST": self._obtain_statistics_for(self.test, "TEST", tag_type),
-            "DEV": self._obtain_statistics_for(self.dev, "DEV", tag_type),
-        }
-        if pretty_print:
-            import json
-
-            json_string = json.dumps(json_string, indent=4)
-        return json_string
-
-    @staticmethod
-    def _obtain_statistics_for(sentences, name, tag_type) -> dict:
-        if len(sentences) == 0:
-            return {}
-
-        classes_to_count = Corpus._get_class_to_count(sentences)
-        tags_to_count = Corpus._get_tag_to_count(sentences, tag_type)
-        tokens_per_sentence = Corpus._get_tokens_per_sentence(sentences)
-
-        label_size_dict = {}
-        for l, c in classes_to_count.items():
-            label_size_dict[l] = c
-
-        tag_size_dict = {}
-        for l, c in tags_to_count.items():
-            tag_size_dict[l] = c
-
-        return {
-            "dataset": name,
-            "total_number_of_documents": len(sentences),
-            "number_of_documents_per_class": label_size_dict,
-            "number_of_tokens_per_tag": tag_size_dict,
-            "number_of_tokens": {
-                "total": sum(tokens_per_sentence),
-                "min": min(tokens_per_sentence),
-                "max": max(tokens_per_sentence),
-                "avg": sum(tokens_per_sentence) / len(sentences),
-            },
-        }
-
-    @staticmethod
-    def _get_tokens_per_sentence(sentences):
-        return list(map(lambda x: len(x.tokens), sentences))
-
-    @staticmethod
-    def _get_class_to_count(sentences):
-        class_to_count = defaultdict(lambda: 0)
-        for sent in sentences:
-            for label in sent.labels:
-                class_to_count[label.value] += 1
-        return class_to_count
-
-    @staticmethod
-    def _get_tag_to_count(sentences, tag_type):
-        tag_to_count = defaultdict(lambda: 0)
-        for sent in sentences:
-            for word in sent.tokens:
-                if tag_type in word.tags:
-                    label = word.tags[tag_type]
-                    tag_to_count[label.value] += 1
-        return tag_to_count
-
-    def __str__(self) -> str:
-        return "Corpus: %d train + %d dev + %d test sentences" % (
-            len(self.train),
-            len(self.dev),
-            len(self.test),
-        )
-
-    def make_label_dictionary(self) -> Dictionary:
-        """
-        Creates a dictionary of all labels assigned to the sentences in the corpus.
-        :return: dictionary of labels
-        """
-        label_dictionary: Dictionary = Dictionary(add_unk=False)
-        label_dictionary.multi_label = False
-
-        from flair.datasets import DataLoader
-
-        loader = DataLoader(self.train, batch_size=1)
-
-        log.info("Computing label dictionary. Progress:")
-        for batch in Tqdm.tqdm(iter(loader)):
-
-            for sentence in batch:
-
-                for label in sentence.labels:
-                    label_dictionary.add_item(label.value)
-
-                if not label_dictionary.multi_label:
-                    if len(sentence.labels) > 1:
-                        label_dictionary.multi_label = True
-
-        log.info(label_dictionary.idx2item)
-
-        return label_dictionary
-
-    def get_label_distribution(self):
-        class_to_count = defaultdict(lambda: 0)
-        for sent in self.train:
-            for label in sent.labels:
-                class_to_count[label.value] += 1
-        return class_to_count
-
-    def get_all_sentences(self) -> Dataset:
-        return ConcatDataset([self.train, self.dev, self.test])
-
-    def make_tag_dictionary(self, tag_type: str) -> Dictionary:
-
-        # Make the tag dictionary
-        tag_dictionary: Dictionary = Dictionary()
-        tag_dictionary.add_item("O")
-        for sentence in self.get_all_sentences():
-            for token in sentence.tokens:
-                tag_dictionary.add_item(token.get_tag(tag_type).value)
-        tag_dictionary.add_item("<START>")
-        tag_dictionary.add_item("<STOP>")
-        return tag_dictionary
-
-
-class MultiCorpus(Corpus):
-    def __init__(self, corpora: List[Corpus], name: str = "multicorpus"):
-        self.corpora: List[Corpus] = corpora
-
-        super(MultiCorpus, self).__init__(
-            ConcatDataset([corpus.train for corpus in self.corpora]),
-            ConcatDataset([corpus.dev for corpus in self.corpora]),
-            ConcatDataset([corpus.test for corpus in self.corpora]),
-            name=name,
-        )
-
-    def __str__(self):
-        return "\n".join([str(corpus) for corpus in self.corpora])
-
-
-def iob2(tags):
-    """
-    Check that tags have a valid IOB format.
-    Tags in IOB1 format are converted to IOB2.
-    """
-    for i, tag in enumerate(tags):
-        if tag.value == "O":
-            continue
-        split = tag.value.split("-")
-        if len(split) != 2 or split[0] not in ["I", "B"]:
-            return False
-        if split[0] == "B":
-            continue
-        elif i == 0 or tags[i - 1].value == "O":  # conversion IOB1 to IOB2
-            tags[i].value = "B" + tag.value[1:]
-        elif tags[i - 1].value[1:] == tag.value[1:]:
-            continue
-        else:  # conversion IOB1 to IOB2
-            tags[i].value = "B" + tag.value[1:]
-    return True
-
-
-def iob_iobes(tags):
-    """
-    IOB -> IOBES
-    """
-    new_tags = []
-    for i, tag in enumerate(tags):
-        if tag.value == "O":
-            new_tags.append(tag.value)
-        elif tag.value.split("-")[0] == "B":
-            if i + 1 != len(tags) and tags[i + 1].value.split("-")[0] == "I":
-                new_tags.append(tag.value)
-            else:
-                new_tags.append(tag.value.replace("B-", "S-"))
-        elif tag.value.split("-")[0] == "I":
-            if i + 1 < len(tags) and tags[i + 1].value.split("-")[0] == "I":
-                new_tags.append(tag.value)
-            else:
-                new_tags.append(tag.value.replace("I-", "E-"))
-        else:
-            raise Exception("Invalid IOB format!")
-    return new_tags

--- a/flair/data.py
+++ b/flair/data.py
@@ -518,6 +518,7 @@ class Sentence(DataPoint):
         label_names = []
         for label in self.labels:
             label_names.append(label.value)
+        return label_names
 
     def get_spans(self, label_type: str, min_score=-1) -> List[Span]:
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -423,7 +423,7 @@ class SequenceTagger(flair.nn.Model):
                 for (sentence, sent_tags) in zip(batch, tags):
                     for (token, tag) in zip(sentence.tokens, sent_tags):
                         token: Token = token
-                        token.add_tag_label("predicted", tag)
+                        token.add_tag("predicted", tag.value, tag.score)
 
                         # append both to file for evaluation
                         eval_line = "{} {} {} {}\n".format(

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -182,6 +182,11 @@ class TextClassifier(flair.nn.Model):
                     "is a better choice."
                 )
 
+            # filter empty sentences
+            if isinstance(sentences[0], Sentence):
+                sentences = [sentence for sentence in sentences if len(sentence) > 0]
+            if len(sentences) == 0: return sentences
+
             # reverse sort all sequences by their length
             rev_order_len_index = sorted(
                 range(len(sentences)), key=lambda k: len(sentences[k]), reverse=True
@@ -190,7 +195,7 @@ class TextClassifier(flair.nn.Model):
                 range(len(rev_order_len_index)), key=lambda k: rev_order_len_index[k]
             )
 
-            reordered_sentences: List[Union[Sentence, str]] = [
+            reordered_sentences: List[Union[DataPoint, str]] = [
                 sentences[index] for index in rev_order_len_index
             ]
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -34,7 +34,7 @@ class TextClassifier(flair.nn.Model):
         self,
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
-        label_type: str = None,
+        label_type: str = "class",
         multi_label: bool = None,
         multi_label_threshold: float = 0.5,
         beta: float = 1.0,

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 import flair.nn
 import flair.embeddings
-from flair.data import Dictionary, Sentence, Label, Token, space_tokenizer
+from flair.data import Dictionary, Sentence, Label, Token, space_tokenizer, DataPoint
 from flair.datasets import SentenceDataset, StringDataset
 from flair.file_utils import cached_path
 from flair.training_utils import (
@@ -34,6 +34,7 @@ class TextClassifier(flair.nn.Model):
         self,
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
+        label_type: str = 'class',
         multi_label: bool = None,
         multi_label_threshold: float = 0.5,
         beta: float = 1.0,
@@ -55,6 +56,7 @@ class TextClassifier(flair.nn.Model):
 
         self.document_embeddings: flair.embeddings.DocumentRNNEmbeddings = document_embeddings
         self.label_dictionary: Dictionary = label_dictionary
+        self.label_type = label_type
 
         if multi_label is not None:
             self.multi_label = multi_label
@@ -81,7 +83,7 @@ class TextClassifier(flair.nn.Model):
             self.document_embeddings.embedding_length, len(self.label_dictionary)
         )
 
-        self._init_weights()
+        nn.init.xavier_uniform_(self.decoder.weight)
 
         if self.multi_label:
             self.loss_function = nn.BCEWithLogitsLoss(weight=self.loss_weights)
@@ -91,15 +93,12 @@ class TextClassifier(flair.nn.Model):
         # auto-spawn on GPU if available
         self.to(flair.device)
 
-    def _init_weights(self):
-        nn.init.xavier_uniform_(self.decoder.weight)
-
-    def forward(self, sentences) -> List[List[float]]:
+    def forward(self, sentences):
 
         self.document_embeddings.embed(sentences)
 
         text_embedding_list = [
-            sentence.get_embedding().unsqueeze(0) for sentence in sentences
+            sentence.embedding.unsqueeze(0) for sentence in sentences
         ]
         text_embedding_tensor = torch.cat(text_embedding_list, 0).to(flair.device)
 
@@ -139,15 +138,15 @@ class TextClassifier(flair.nn.Model):
     ) -> torch.tensor:
 
         scores = self.forward(data_points)
+
         return self._calculate_loss(scores, data_points)
 
-    def forward_labels_and_loss(
-        self, sentences: Union[Sentence, List[Sentence]]
-    ) -> (List[List[Label]], torch.tensor):
-        scores = self.forward(sentences)
-        labels = self._obtain_labels(scores)
-        loss = self._calculate_loss(scores, sentences)
-        return labels, loss
+    def _calculate_loss(self, scores, data_points):
+
+        labels = self._labels_to_one_hot(data_points) if self.multi_label \
+            else self._labels_to_indices(data_points)
+
+        return self.loss_function(scores, labels)
 
     def predict(
         self,
@@ -173,7 +172,7 @@ class TextClassifier(flair.nn.Model):
             if not sentences:
                 return sentences
 
-            if isinstance(sentences, Sentence) or isinstance(sentences, str):
+            if isinstance(sentences, DataPoint) or isinstance(sentences, str):
                 sentences = [sentences]
 
             if (flair.device.type == "cuda") and embedding_storage_mode == "cpu":
@@ -195,7 +194,7 @@ class TextClassifier(flair.nn.Model):
                 sentences[index] for index in rev_order_len_index
             ]
 
-            if isinstance(sentences[0], Sentence):
+            if isinstance(sentences[0], DataPoint):
                 # remove previous embeddings
                 store_embeddings(reordered_sentences, "none")
                 dataset = SentenceDataset(reordered_sentences)
@@ -216,7 +215,6 @@ class TextClassifier(flair.nn.Model):
                 if verbose:
                     dataloader.set_description(f"Inferencing on batch {i}")
                 results += batch
-                batch = self._filter_empty_sentences(batch)
                 # stop if all sentences are empty
                 if not batch:
                     continue
@@ -227,7 +225,8 @@ class TextClassifier(flair.nn.Model):
                 )
 
                 for (sentence, labels) in zip(batch, predicted_labels):
-                    sentence.labels = labels
+                    for label in labels:
+                        sentence.add_label(self.label_type, label.value, label.score)
 
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
@@ -256,36 +255,33 @@ class TextClassifier(flair.nn.Model):
 
                 batch_count += 1
 
-                labels, loss = self.forward_labels_and_loss(batch)
+                scores = self.forward(batch)
+                predictions = self._obtain_labels(scores)
+                loss = self._calculate_loss(scores, batch)
 
                 eval_loss += loss
 
                 sentences_for_batch = [sent.to_plain_string() for sent in batch]
-                confidences_for_batch = [
-                    [label.score for label in sent_labels] for sent_labels in labels
-                ]
-                predictions_for_batch = [
-                    [label.value for label in sent_labels] for sent_labels in labels
-                ]
-                true_values_for_batch = [
-                    sentence.get_label_names() for sentence in batch
-                ]
+
+                true_values_for_batch = [sentence.get_labels(self.label_type) for sentence in batch]
                 available_labels = self.label_dictionary.get_items()
 
-                for sentence, confidence, prediction, true_value in zip(
+                for sentence, prediction, true_value in zip(
                     sentences_for_batch,
-                    confidences_for_batch,
-                    predictions_for_batch,
+                    predictions,
                     true_values_for_batch,
                 ):
-                    eval_line = "{}\t{}\t{}\t{}\n".format(
-                        sentence, true_value, prediction, confidence
+                    eval_line = "{}\t{}\t{}\n".format(
+                        sentence, true_value, prediction
                     )
                     lines.append(eval_line)
 
                 for predictions_for_sentence, true_values_for_sentence in zip(
-                    predictions_for_batch, true_values_for_batch
+                    predictions, true_values_for_batch
                 ):
+
+                    true_values_for_sentence = [label.value for label in true_values_for_sentence]
+                    predictions_for_sentence = [label.value for label in predictions_for_sentence]
 
                     for label in available_labels:
                         if (
@@ -327,7 +323,7 @@ class TextClassifier(flair.nn.Model):
                 )
 
             result = Result(
-                main_score=metric.micro_avg_f_score(),
+                main_score=metric.micro_avg_accuracy(),
                 log_line=f"{metric.precision()}\t{metric.recall()}\t{metric.micro_avg_f_score()}",
                 log_header="PRECISION\tRECALL\tF1",
                 detailed_results=detailed_result,
@@ -349,20 +345,6 @@ class TextClassifier(flair.nn.Model):
                 )
             )
         return filtered_sentences
-
-    def _calculate_loss(
-        self, scores: torch.tensor, sentences: List[Sentence]
-    ) -> torch.tensor:
-        """
-        Calculates the loss.
-        :param scores: the prediction scores from the model
-        :param sentences: list of sentences
-        :return: loss value
-        """
-        if self.multi_label:
-            return self._calculate_multi_label_loss(scores, sentences)
-
-        return self._calculate_single_label_loss(scores, sentences)
 
     def _obtain_labels(
         self, scores: List[List[float]], predict_prob: bool = False
@@ -409,18 +391,12 @@ class TextClassifier(flair.nn.Model):
             label_probs.append(Label(label, conf.item()))
         return label_probs
 
-    def _calculate_multi_label_loss(
-        self, label_scores, sentences: List[Sentence]
-    ) -> float:
-        return self.loss_function(label_scores, self._labels_to_one_hot(sentences))
-
-    def _calculate_single_label_loss(
-        self, label_scores, sentences: List[Sentence]
-    ) -> float:
-        return self.loss_function(label_scores, self._labels_to_indices(sentences))
-
     def _labels_to_one_hot(self, sentences: List[Sentence]):
-        label_list = [sentence.get_label_names() for sentence in sentences]
+
+        label_list = []
+        for sentence in sentences:
+            label_list.append([label.value for label in sentence.get_labels(self.label_type)])
+
         one_hot = convert_labels_to_one_hot(label_list, self.label_dictionary)
         one_hot = [torch.FloatTensor(l).unsqueeze(0) for l in one_hot]
         one_hot = torch.cat(one_hot, 0).to(flair.device)
@@ -431,7 +407,7 @@ class TextClassifier(flair.nn.Model):
             torch.LongTensor(
                 [
                     self.label_dictionary.get_idx_for_item(label.value)
-                    for label in sentence.labels
+                    for label in sentence.get_labels(self.label_type)
                 ]
             )
             for sentence in sentences

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -34,7 +34,7 @@ class TextClassifier(flair.nn.Model):
         self,
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
-        label_type: str = 'class',
+        label_type: str = None,
         multi_label: bool = None,
         multi_label_threshold: float = 0.5,
         beta: float = 1.0,
@@ -403,6 +403,7 @@ class TextClassifier(flair.nn.Model):
         return one_hot
 
     def _labels_to_indices(self, sentences: List[Sentence]):
+
         indices = [
             torch.LongTensor(
                 [

--- a/flair/samplers.py
+++ b/flair/samplers.py
@@ -40,13 +40,13 @@ class ImbalancedClassificationDatasetSampler(FlairSampler):
         # first determine the distribution of classes in the dataset
         label_count = defaultdict(int)
         for sentence in data_source:
-            for label in sentence.get_label_names():
-                label_count[label] += 1
+            for label in sentence.labels:
+                label_count[label.value] += 1
 
         # weight for each sample
         offset = 0
         weights = [
-            1.0 / (offset + label_count[data_source[idx].get_label_names()[0]])
+            1.0 / (offset + label_count[data_source[idx].labels[0].value])
             for idx in self.indices
         ]
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -322,28 +322,15 @@ def test_label_set_confidence():
 
 
 def test_tagged_corpus_make_label_dictionary():
-    sentence_1 = Sentence("sentence 1", labels=[Label("class_1")])
-    sentence_2 = Sentence("sentence 2", labels=[Label("class_2")])
-    sentence_3 = Sentence("sentence 3", labels=[Label("class_1")])
+    sentence_1 = Sentence("sentence 1").add_label('label', 'class_1')
+
+    sentence_2 = Sentence("sentence 2").add_label('label', 'class_2')
+
+    sentence_3 = Sentence("sentence 3").add_label('label', 'class_1')
 
     corpus: Corpus = Corpus([sentence_1, sentence_2, sentence_3], [], [])
 
-    label_dict = corpus.make_label_dictionary()
-
-    assert 2 == len(label_dict)
-    assert "<unk>" not in label_dict.get_items()
-    assert "class_1" in label_dict.get_items()
-    assert "class_2" in label_dict.get_items()
-
-
-def test_tagged_corpus_make_label_dictionary_string():
-    sentence_1 = Sentence("sentence 1", labels=["class_1"])
-    sentence_2 = Sentence("sentence 2", labels=["class_2"])
-    sentence_3 = Sentence("sentence 3", labels=["class_1"])
-
-    corpus: Corpus = Corpus([sentence_1, sentence_2, sentence_3], [], [])
-
-    label_dict = corpus.make_label_dictionary()
+    label_dict = corpus.make_label_dictionary('label')
 
     assert 2 == len(label_dict)
     assert "<unk>" not in label_dict.get_items()
@@ -352,47 +339,14 @@ def test_tagged_corpus_make_label_dictionary_string():
 
 
 def test_tagged_corpus_statistics():
-    train_sentence = Sentence(
-        "I love Berlin.", labels=[Label("class_1")], use_tokenizer=segtok_tokenizer
-    )
-    dev_sentence = Sentence(
-        "The sun is shining.", labels=[Label("class_2")], use_tokenizer=segtok_tokenizer
-    )
-    test_sentence = Sentence(
-        "Berlin is sunny.", labels=[Label("class_1")], use_tokenizer=segtok_tokenizer
-    )
 
-    class_to_count_dict = Corpus._get_class_to_count(
-        [train_sentence, dev_sentence, test_sentence]
-    )
+    train_sentence = Sentence("I love Berlin.", use_tokenizer=True).add_label('label', 'class_1')
 
-    assert "class_1" in class_to_count_dict
-    assert "class_2" in class_to_count_dict
-    assert 2 == class_to_count_dict["class_1"]
-    assert 1 == class_to_count_dict["class_2"]
+    dev_sentence = Sentence("The sun is shining.", use_tokenizer=True).add_label('label', 'class_2')
 
-    tokens_in_sentences = Corpus._get_tokens_per_sentence(
-        [train_sentence, dev_sentence, test_sentence]
-    )
+    test_sentence = Sentence("Berlin is sunny.", use_tokenizer=True).add_label('label', 'class_1')
 
-    assert 3 == len(tokens_in_sentences)
-    assert 4 == tokens_in_sentences[0]
-    assert 5 == tokens_in_sentences[1]
-    assert 4 == tokens_in_sentences[2]
-
-
-def test_tagged_corpus_statistics_string_label():
-    train_sentence = Sentence(
-        "I love Berlin.", labels=["class_1"], use_tokenizer=segtok_tokenizer
-    )
-    dev_sentence = Sentence(
-        "The sun is shining.", labels=["class_2"], use_tokenizer=segtok_tokenizer
-    )
-    test_sentence = Sentence(
-        "Berlin is sunny.", labels=["class_1"], use_tokenizer=segtok_tokenizer
-    )
-
-    class_to_count_dict = Corpus._get_class_to_count(
+    class_to_count_dict = Corpus._count_sentence_labels(
         [train_sentence, dev_sentence, test_sentence]
     )
 
@@ -412,19 +366,16 @@ def test_tagged_corpus_statistics_string_label():
 
 
 def test_tagged_corpus_statistics_multi_label():
-    train_sentence = Sentence(
-        "I love Berlin.", labels=["class_1"], use_tokenizer=segtok_tokenizer
-    )
-    dev_sentence = Sentence(
-        "The sun is shining.", labels=["class_2"], use_tokenizer=segtok_tokenizer
-    )
-    test_sentence = Sentence(
-        "Berlin is sunny.",
-        labels=["class_1", "class_2"],
-        use_tokenizer=segtok_tokenizer,
-    )
 
-    class_to_count_dict = Corpus._get_class_to_count(
+    train_sentence = Sentence("I love Berlin.", use_tokenizer=True).add_label('label', 'class_1')
+
+    dev_sentence = Sentence("The sun is shining.", use_tokenizer=True).add_label('label', 'class_2')
+
+    test_sentence = Sentence("Berlin is sunny.", use_tokenizer=True)
+    test_sentence.add_label('label', 'class_1')
+    test_sentence.add_label('label', 'class_2')
+
+    class_to_count_dict = Corpus._count_sentence_labels(
         [train_sentence, dev_sentence, test_sentence]
     )
 
@@ -460,7 +411,7 @@ def test_tagged_corpus_get_tag_statistic():
 
     test_sentence = Sentence("Nothing to do with companies.")
 
-    tag_to_count_dict = Corpus._get_tag_to_count(
+    tag_to_count_dict = Corpus._count_token_labels(
         [train_sentence, dev_sentence, test_sentence], "ner"
     )
 
@@ -472,9 +423,8 @@ def test_tagged_corpus_get_tag_statistic():
 
 
 def test_tagged_corpus_downsample():
-    sentence = Sentence(
-        "I love Berlin.", labels=[Label("class_1")], use_tokenizer=segtok_tokenizer
-    )
+
+    sentence = Sentence("I love Berlin.", use_tokenizer=True).add_label('label', 'class_1')
 
     corpus: Corpus = Corpus(
         [
@@ -631,9 +581,8 @@ def test_token_position_in_sentence():
 def test_sentence_to_dict():
     sentence = Sentence(
         "Zalando Research is   located in Berlin, the capital of Germany.",
-        labels=["business"],
-        use_tokenizer=segtok_tokenizer,
-    )
+        use_tokenizer=True,
+    ).add_label('class', 'business')
 
     # bioes tags
     sentence[0].add_tag("ner", "B-ORG")
@@ -654,7 +603,7 @@ def test_sentence_to_dict():
 
     sentence = Sentence(
         "Facebook, Inc. is a company, and Google is one as well.",
-        use_tokenizer=segtok_tokenizer,
+        use_tokenizer=True,
     )
 
     # bioes tags

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -572,7 +572,7 @@ def test_train_resume_text_classification_training(results_base_path, tasks_base
     #    [flair_embeddings], 128, 1, False
     #)
 
-    model = TextClassifier(document_embeddings, label_dict, False)
+    model = TextClassifier(document_embeddings, label_dict, multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -291,7 +291,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
 
-    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(document_embeddings, label_dict, multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -324,7 +324,7 @@ def test_train_classifier_with_sampler(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
 
-    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(document_embeddings, label_dict, multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(
@@ -355,7 +355,7 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
 
-    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(document_embeddings, label_dict, multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -447,7 +447,7 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
        [flair_embeddings], 128, 1, False, 64, False, False
     )
 
-    model: TextClassifier = TextClassifier(flair_document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(flair_document_embeddings, label_dict, multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -17,7 +17,7 @@ def init(tasks_base_path) -> Tuple[Corpus, Dictionary, TextClassifier]:
         [glove_embedding], 128, 1, False, 64, False, False
     )
 
-    model = TextClassifier(document_embeddings, label_dict, False)
+    model = TextClassifier(document_embeddings, label_dict, multi_label=False)
 
     return corpus, label_dict, model
 

--- a/tests/test_text_regressor.py
+++ b/tests/test_text_regressor.py
@@ -1,8 +1,7 @@
 import pytest
 from typing import Tuple
-
+import flair.datasets
 from flair.data import Dictionary, Corpus
-from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
 from flair.embeddings import WordEmbeddings, DocumentRNNEmbeddings
 from flair.models.text_regression_model import TextRegressor
 
@@ -11,7 +10,7 @@ from flair.trainers import ModelTrainer
 
 
 def init(tasks_base_path) -> Tuple[Corpus, TextRegressor, ModelTrainer]:
-    corpus = NLPTaskDataFetcher.load_corpus(NLPTask.REGRESSION, tasks_base_path)
+    corpus = flair.datasets.ClassificationCorpus(tasks_base_path / 'regression')
 
     glove_embedding: WordEmbeddings = WordEmbeddings("glove")
     document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -37,8 +37,7 @@ def test_plotting_training_curves_and_weights(resources_path):
 
 
 def mock_ner_span(text, tag, start, end):
-    span = Span([])
-    span.tag = tag
+    span = Span([]).set_label('class', tag)
     span.start_pos = start
     span.end_pos = end
     span.tokens = [Token(text[start:end])]


### PR DESCRIPTION
This PR refactors the `DataPoint` class and classes that inherit from it (`Token`, `Sentence`, `Image`, `Span`, etc.) so that all have the same methods for adding and accessing labels. 

- `DataPoint` base class now defined labeling methods (closes #1449) 
- Labels can no longer be passed to `Sentence` constructor, so instead of:
```python
sentence_1 = Sentence("this is great", labels=[Label("POSITIVE")])
```
you should now do: 
```python
sentence_1 = Sentence("this is great")
sentence_1.add_label('sentiment', 'POSITIVE')
```
or: 
```python
sentence_1 = Sentence("this is great").add_label('sentiment', 'POSITIVE')
```

Note that Sentence labels now have a `label_type` (in the example that's 'sentiment').

- The `Corpus` method `_get_class_to_count` is renamed to `_count_sentence_labels`
- The `Corpus` method `_get_tag_to_count` is renamed to `_count_token_labels`
- `Span` is now a `DataPoint` (so it has an `embedding` and `labels`)


