### PR TITLE
GH-1453: SentEval classification datasets

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -220,7 +220,7 @@ class DataPoint:
         return self
 
     def get_labels(self, label_type: str = None):
-        if label_type == None:
+        if label_type is None:
             return self.labels
 
         return self.annotation_layers[label_type] if label_type in self.annotation_layers else []

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -1705,17 +1705,6 @@ class SENTEVAL_SST_BINARY(CSVClassificationCorpus):
             cached_path('https://raw.githubusercontent.com/PrincetonML/SIF/master/data/sentiment-test', Path("datasets") / dataset_name)
             cached_path('https://raw.githubusercontent.com/PrincetonML/SIF/master/data/sentiment-dev', Path("datasets") / dataset_name)
 
-            # create train.txt file by iterating over pos and neg file
-            # with open(data_folder / "train.txt", "a") as train_file:
-            #
-            #     with open(senteval_folder / "data" / "mpqa" / "mpqa.pos", encoding="latin1") as file:
-            #         for line in file:
-            #             train_file.write(f"__label__POSITIVE {line}")
-            #
-            #     with open(senteval_folder / "data" / "mpqa" / "mpqa.neg", encoding="latin1") as file:
-            #         for line in file:
-            #             train_file.write(f"__label__NEGATIVE {line}")
-
         super(SENTEVAL_SST_BINARY, self).__init__(
             data_folder,
             column_name_map={0: 'text', 1: 'label'},
@@ -1723,6 +1712,40 @@ class SENTEVAL_SST_BINARY(CSVClassificationCorpus):
             in_memory=in_memory,
             delimiter='\t',
             quotechar=None,
+        )
+
+
+class SENTEVAL_SST_GRANULAR(ClassificationCorpus):
+    def __init__(
+            self,
+            in_memory: bool = True,
+    ):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+
+        # download data if necessary
+        if not (data_folder / "train.txt").is_file():
+
+            # download senteval datasets if necessary und unzip
+            cached_path('https://raw.githubusercontent.com/AcademiaSinicaNLPLab/sentiment_dataset/master/data/stsa.fine.train', Path("datasets") / dataset_name / 'raw')
+            cached_path('https://raw.githubusercontent.com/AcademiaSinicaNLPLab/sentiment_dataset/master/data/stsa.fine.test', Path("datasets") / dataset_name / 'raw')
+            cached_path('https://raw.githubusercontent.com/AcademiaSinicaNLPLab/sentiment_dataset/master/data/stsa.fine.dev', Path("datasets") / dataset_name / 'raw')
+
+            # convert to FastText format
+            for split in ['train', 'dev', 'test']:
+                with open(data_folder / f"{split}.txt", "w") as train_file:
+
+                    with open(data_folder / 'raw' / f'stsa.fine.{split}', encoding="latin1") as file:
+                        for line in file:
+                            train_file.write(f"__label__{line[0]} {line[2:]}")
+
+        super(SENTEVAL_SST_GRANULAR, self).__init__(
+            data_folder,
+            tokenizer=segtok_tokenizer,
+            in_memory=in_memory,
         )
 
 

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -292,6 +292,7 @@ class CSVClassificationCorpus(Corpus):
         test: FlairDataset = CSVClassificationDataset(
             test_file,
             column_name_map,
+            label_type=label_type,
             tokenizer=tokenizer,
             max_tokens_per_doc=max_tokens_per_doc,
             max_chars_per_doc=max_chars_per_doc,
@@ -303,6 +304,7 @@ class CSVClassificationCorpus(Corpus):
         dev: FlairDataset = CSVClassificationDataset(
             dev_file,
             column_name_map,
+            label_type=label_type,
             tokenizer=tokenizer,
             max_tokens_per_doc=max_tokens_per_doc,
             max_chars_per_doc=max_chars_per_doc,

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -1526,6 +1526,166 @@ class CONLL_2000(ColumnCorpus):
         )
 
 
+class SENTEVAL_CR(ClassificationCorpus):
+    def __init__(
+            self,
+            in_memory: bool = True,
+    ):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+
+        # download data if necessary
+        if not (data_folder / "train.txt").is_file():
+
+            # download senteval datasets if necessary und unzip
+            senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
+            cached_path(senteval_path, Path("datasets") / "senteval")
+            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
+
+            # create dataset directory if necessary
+            if not os.path.exists(data_folder):
+                os.makedirs(data_folder)
+
+            # create train.txt file by iterating over pos and neg file
+            with open(data_folder / "train.txt", "a") as train_file:
+
+                with open(senteval_folder / "data" / "customerr" / "custrev.pos", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__POSITIVE {line}")
+
+                with open(senteval_folder / "data" / "customerr" / "custrev.neg", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__NEGATIVE {line}")
+
+        super(SENTEVAL_CR, self).__init__(
+            data_folder, label_type='sentiment', tokenizer=segtok_tokenizer, in_memory=in_memory
+        )
+
+
+class SENTEVAL_MR(ClassificationCorpus):
+    def __init__(
+            self,
+            in_memory: bool = True,
+    ):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+
+        # download data if necessary
+        if not (data_folder / "train.txt").is_file():
+
+            # download senteval datasets if necessary und unzip
+            senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
+            cached_path(senteval_path, Path("datasets") / "senteval")
+            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
+
+            # create dataset directory if necessary
+            if not os.path.exists(data_folder):
+                os.makedirs(data_folder)
+
+            # create train.txt file by iterating over pos and neg file
+            with open(data_folder / "train.txt", "a") as train_file:
+
+                with open(senteval_folder / "data" / "rt10662" / "rt-polarity.pos", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__POSITIVE {line}")
+
+                with open(senteval_folder / "data" / "rt10662" / "rt-polarity.neg", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__NEGATIVE {line}")
+
+        super(SENTEVAL_MR, self).__init__(
+            data_folder, label_type='sentiment', tokenizer=segtok_tokenizer, in_memory=in_memory
+        )
+
+
+class SENTEVAL_SUBJ(ClassificationCorpus):
+    def __init__(
+            self,
+            in_memory: bool = True,
+    ):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+
+        # download data if necessary
+        if not (data_folder / "train.txt").is_file():
+
+            # download senteval datasets if necessary und unzip
+            senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
+            cached_path(senteval_path, Path("datasets") / "senteval")
+            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
+
+            # create dataset directory if necessary
+            if not os.path.exists(data_folder):
+                os.makedirs(data_folder)
+
+            # create train.txt file by iterating over pos and neg file
+            with open(data_folder / "train.txt", "a") as train_file:
+
+                with open(senteval_folder / "data" / "subj" / "subj.subjective", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__SUBJECTIVE {line}")
+
+                with open(senteval_folder / "data" / "subj" / "subj.objective", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__OBJECTIVE {line}")
+
+        super(SENTEVAL_SUBJ, self).__init__(
+            data_folder, label_type='objectivity', tokenizer=segtok_tokenizer, in_memory=in_memory
+        )
+
+
+class SENTEVAL_MPQA(ClassificationCorpus):
+    def __init__(
+            self,
+            in_memory: bool = True,
+    ):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+
+        # download data if necessary
+        if not (data_folder / "train.txt").is_file():
+
+            # download senteval datasets if necessary und unzip
+            senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
+            cached_path(senteval_path, Path("datasets") / "senteval")
+            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
+
+            # create dataset directory if necessary
+            if not os.path.exists(data_folder):
+                os.makedirs(data_folder)
+
+            # create train.txt file by iterating over pos and neg file
+            with open(data_folder / "train.txt", "a") as train_file:
+
+                with open(senteval_folder / "data" / "mpqa" / "mpqa.pos", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__POSITIVE {line}")
+
+                with open(senteval_folder / "data" / "mpqa" / "mpqa.neg", encoding="latin1") as file:
+                    for line in file:
+                        train_file.write(f"__label__NEGATIVE {line}")
+
+        super(SENTEVAL_MPQA, self).__init__(
+            data_folder, label_type='sentiment', tokenizer=segtok_tokenizer, in_memory=in_memory
+        )
+
+
 class GERMEVAL(ColumnCorpus):
     def __init__(
             self,

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -246,6 +246,7 @@ class CSVClassificationCorpus(Corpus):
             self,
             data_folder: Union[str, Path],
             column_name_map: Dict[int, str],
+            label_type: str = 'class',
             train_file=None,
             test_file=None,
             dev_file=None,
@@ -279,6 +280,7 @@ class CSVClassificationCorpus(Corpus):
         train: FlairDataset = CSVClassificationDataset(
             train_file,
             column_name_map,
+            label_type=label_type,
             tokenizer=tokenizer,
             max_tokens_per_doc=max_tokens_per_doc,
             max_chars_per_doc=max_chars_per_doc,
@@ -778,6 +780,7 @@ class CSVClassificationDataset(FlairDataset):
             self,
             path_to_file: Union[str, Path],
             column_name_map: Dict[int, str],
+            label_type: str = "class",
             max_tokens_per_doc: int = -1,
             max_chars_per_doc: int = -1,
             tokenizer=segtok_tokenizer,
@@ -870,7 +873,7 @@ class CSVClassificationDataset(FlairDataset):
                                 self.column_name_map[column].startswith("label")
                                 and row[column]
                         ):
-                            sentence.add_label(self.column_name_map[column], row[column])
+                            sentence.add_label(label_type, row[column])
 
                     if 0 < self.max_tokens_per_doc < len(sentence):
                         sentence.tokens = sentence.tokens[: self.max_tokens_per_doc]

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -870,7 +870,7 @@ class CSVClassificationDataset(FlairDataset):
                                 self.column_name_map[column].startswith("label")
                                 and row[column]
                         ):
-                            sentence.add_label(row[column])
+                            sentence.add_label(self.column_name_map[column], row[column])
 
                     if 0 < self.max_tokens_per_doc < len(sentence):
                         sentence.tokens = sentence.tokens[: self.max_tokens_per_doc]
@@ -1683,6 +1683,46 @@ class SENTEVAL_MPQA(ClassificationCorpus):
 
         super(SENTEVAL_MPQA, self).__init__(
             data_folder, label_type='sentiment', tokenizer=segtok_tokenizer, in_memory=in_memory
+        )
+
+
+class SENTEVAL_SST_BINARY(CSVClassificationCorpus):
+    def __init__(
+            self,
+            in_memory: bool = True,
+    ):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+
+        # download data if necessary
+        if not (data_folder / "train.txt").is_file():
+
+            # download senteval datasets if necessary und unzip
+            cached_path('https://raw.githubusercontent.com/PrincetonML/SIF/master/data/sentiment-train', Path("datasets") / dataset_name)
+            cached_path('https://raw.githubusercontent.com/PrincetonML/SIF/master/data/sentiment-test', Path("datasets") / dataset_name)
+            cached_path('https://raw.githubusercontent.com/PrincetonML/SIF/master/data/sentiment-dev', Path("datasets") / dataset_name)
+
+            # create train.txt file by iterating over pos and neg file
+            # with open(data_folder / "train.txt", "a") as train_file:
+            #
+            #     with open(senteval_folder / "data" / "mpqa" / "mpqa.pos", encoding="latin1") as file:
+            #         for line in file:
+            #             train_file.write(f"__label__POSITIVE {line}")
+            #
+            #     with open(senteval_folder / "data" / "mpqa" / "mpqa.neg", encoding="latin1") as file:
+            #         for line in file:
+            #             train_file.write(f"__label__NEGATIVE {line}")
+
+        super(SENTEVAL_SST_BINARY, self).__init__(
+            data_folder,
+            column_name_map={0: 'text', 1: 'label'},
+            tokenizer=segtok_tokenizer,
+            in_memory=in_memory,
+            delimiter='\t',
+            quotechar=None,
         )
 
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -121,10 +121,12 @@ class TextClassifier(flair.nn.Model):
     def _init_model_with_state_dict(state):
         beta = 1.0 if "beta" not in state.keys() else state["beta"]
         weights = None if "weight_dict" not in state.keys() else state["weight_dict"]
+        label_type = None if "label_type" not in state.keys() else state["label_type"]
 
         model = TextClassifier(
             document_embeddings=state["document_embeddings"],
             label_dictionary=state["label_dictionary"],
+            label_type=label_type,
             multi_label=state["multi_label"],
             beta=beta,
             loss_weights=weights,

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -34,7 +34,7 @@ class TextClassifier(flair.nn.Model):
         self,
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
-        label_type: str = "class",
+        label_type: str = None,
         multi_label: bool = None,
         multi_label_threshold: float = 0.5,
         beta: float = 1.0,
@@ -170,6 +170,8 @@ class TextClassifier(flair.nn.Model):
         :param use_tokenizer: a custom tokenizer when string are provided (default is space based tokenizer).
         :return: the list of sentences containing the labels
         """
+        predicted_label_type = self.label_type if self.label_type is not None else 'class'
+
         with torch.no_grad():
             if not sentences:
                 return sentences
@@ -233,7 +235,7 @@ class TextClassifier(flair.nn.Model):
 
                 for (sentence, labels) in zip(batch, predicted_labels):
                     for label in labels:
-                        sentence.add_label(self.label_type, label.value, label.score)
+                        sentence.add_label(predicted_label_type, label.value, label.score)
 
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)


### PR DESCRIPTION
This PR adds 6 SentEval classification datasets to Flair. Closes #1453 

Load for instance like this: 

```python
from flair.datasets import SENTEVAL_SST_BINARY

corpus = SENTEVAL_SST_BINARY()
print(corpus)
```

Datasets are: 

- flair.datasets.SENTEVAL_CR
- flair.datasets.SENTEVAL_MR
- flair.datasets.SENTEVAL_SUBJ
- flair.datasets.SENTEVAL_MPQA
- flair.datasets.SENTEVAL_SST_BINARY
- flair.datasets.SENTEVAL_SST_GRANULAR