### PR TITLE
GH-1449: fix BIOES encoding error caused by refactoring

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -696,7 +696,7 @@ class Sentence(DataPoint):
             tags = iob_iobes(tags)
 
         for index, tag in enumerate(tags):
-            self.tokens[index].add_label(tag_type, tag)
+            self.tokens[index].set_label(tag_type, tag)
 
     def infer_space_after(self):
         """


### PR DESCRIPTION
The `DataPoint` refactoring caused the BIOES encoding to no longer work correctly in the `ColumnCorpus`. This PR fixed this again. 