### PR TITLE
GH-1502: add language models by @redewiedergabe

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1852,6 +1852,7 @@ class FlairEmbeddings(TokenEmbeddings):
         cache_dir = Path("embeddings")
 
         aws_path: str = "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources"
+        hu_path: str = "https://flair.informatik.hu-berlin.de/resources"
 
         self.PRETRAINED_MODEL_ARCHIVE_MAP = {
             # multilingual models
@@ -1895,6 +1896,8 @@ class FlairEmbeddings(TokenEmbeddings):
             "de-historic-ha-backward": f"{aws_path}/embeddings-stefan-it/lm-historic-hamburger-anzeiger-backward-v0.1.pt",
             "de-historic-wz-forward": f"{aws_path}/embeddings-stefan-it/lm-historic-wiener-zeitung-forward-v0.1.pt",
             "de-historic-wz-backward": f"{aws_path}/embeddings-stefan-it/lm-historic-wiener-zeitung-backward-v0.1.pt",
+            "de-historic-rw-forward": f"{hu_path}/embeddings/redewiedergabe_lm_forward.pt",
+            "de-historic-rw-backward": f"{hu_path}/embeddings/redewiedergabe_lm_backward.pt",
             # Spanish
             "es-forward": f"{aws_path}/embeddings-v0.4/language_model_es_forward_long/lm-es-forward.pt",
             "es-backward": f"{aws_path}/embeddings-v0.4/language_model_es_backward_long/lm-es-backward.pt",

--- a/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
+++ b/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
@@ -40,6 +40,7 @@ Currently, the following contextual string embeddings are provided (note: replac
 | 'de-X'  | German  | Trained with mixed corpus (Web, Wikipedia, Subtitles) |
 | 'de-historic-ha-X'  | German (historical) | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Historical German trained over *Hamburger Anzeiger* |
 | 'de-historic-wz-X'  | German (historical) | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Historical German trained over *Wiener Zeitung* |
+| 'de-historic-rw-X'  | German (historical) | Added by [@redewiedergabe](https://github.com/redewiedergabe): Historical German trained over 100 million tokens |
 | 'es-X'    | Spanish | Added by [@iamyihwa](https://github.com/zalandoresearch/flair/issues/80): Trained with Wikipedia |
 | 'es-X-fast'    | Spanish | Added by [@iamyihwa](https://github.com/zalandoresearch/flair/issues/80): Trained with Wikipediam CPU-friendly |
 | 'eu-X'    | Basque | Added by [@stefan-it](https://github.com/zalandoresearch/flair/issues/614): Trained with Wikipedia/OPUS |


### PR DESCRIPTION
Adds the historical German language models trained by @redewiedergabe over 100 million tokens. Closes #1502 

Load the language models with:

```python
# load languagage models
embeddings_forward = FlairEmbeddings('de-historic-rw-forward')
embeddings_backward = FlairEmbeddings('de-historic-rw-backward')

# have some fun (generate "historical" German text)
print(embeddings_forward.lm.generate_text())
```