### PR TITLE
GH-1531: add taggers for historical German speech and thought 

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -15,7 +15,7 @@ import flair.nn
 from flair.data import Dictionary, Sentence, Token, Label, space_tokenizer
 from flair.datasets import SentenceDataset, StringDataset
 from flair.embeddings import TokenEmbeddings
-from flair.file_utils import cached_path
+from flair.file_utils import cached_path, unzip_file
 from flair.training_utils import Metric, Result, store_embeddings
 
 log = logging.getLogger("flair")
@@ -1014,6 +1014,35 @@ class SequenceTagger(flair.nn.Model):
         cache_dir = Path("models")
         if model_name in model_map:
             model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
+
+        # the historical German taggers by the @redewiegergabe project
+        if model_name == "de-historic-indirect":
+            model_file = Path(flair.cache_root)  / cache_dir / 'indirect' / 'final-model.pt'
+            if not model_file.exists():
+                cached_path('http://www.redewiedergabe.de/models/indirect.zip', cache_dir=cache_dir)
+                unzip_file(Path(flair.cache_root)  / cache_dir / 'indirect.zip', Path(flair.cache_root)  / cache_dir)
+            model_name = str(Path(flair.cache_root)  / cache_dir / 'indirect' / 'final-model.pt')
+
+        if model_name == "de-historic-direct":
+            model_file = Path(flair.cache_root)  / cache_dir / 'direct' / 'final-model.pt'
+            if not model_file.exists():
+                cached_path('http://www.redewiedergabe.de/models/direct.zip', cache_dir=cache_dir)
+                unzip_file(Path(flair.cache_root)  / cache_dir / 'direct.zip', Path(flair.cache_root)  / cache_dir)
+            model_name = str(Path(flair.cache_root)  / cache_dir / 'direct' / 'final-model.pt')
+
+        if model_name == "de-historic-reported":
+            model_file = Path(flair.cache_root)  / cache_dir / 'reported' / 'final-model.pt'
+            if not model_file.exists():
+                cached_path('http://www.redewiedergabe.de/models/reported.zip', cache_dir=cache_dir)
+                unzip_file(Path(flair.cache_root)  / cache_dir / 'reported.zip', Path(flair.cache_root)  / cache_dir)
+            model_name = str(Path(flair.cache_root)  / cache_dir / 'reported' / 'final-model.pt')
+
+        if model_name == "de-historic-free-indirect":
+            model_file = Path(flair.cache_root)  / cache_dir / 'freeIndirect' / 'final-model.pt'
+            if not model_file.exists():
+                cached_path('http://www.redewiedergabe.de/models/freeIndirect.zip', cache_dir=cache_dir)
+                unzip_file(Path(flair.cache_root)  / cache_dir / 'freeIndirect.zip', Path(flair.cache_root)  / cache_dir)
+            model_name = str(Path(flair.cache_root)  / cache_dir / 'freeIndirect' / 'final-model.pt')
 
         return model_name
 


### PR DESCRIPTION
This PR adds the taggers for historical German speech and thought created by the @redewiedergabe project. 

closes #1531 