### PR TITLE
To avoid an infinite loop we check the value is greater, not only different

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -736,7 +736,7 @@ class Sentence(DataPoint):
         str = ""
         pos = 0
         for t in self.tokens:
-            while t.start_pos != pos:
+            while t.start_pos > pos:
                 str += " "
                 pos += 1
 


### PR DESCRIPTION
This PR fixes the issue #1529 . The problem is that we may get stuck in an infinite loop when the span `start_pos` indices of `Token` are incorrect, within the `to_original_text` method.

The solution is to simply stay in the `while` loop only if `start_pos` is **greater than** the `pos` counter. 