### PR TITLE
GH-1538: option to specify document delimiter for language model training

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2046,7 +2046,7 @@ class FlairEmbeddings(TokenEmbeddings):
             # if this is not possible, use LM to generate embedding. First, get text sentences
             text_sentences = [sentence.to_tokenized_string() for sentence in sentences]
 
-            start_marker = "\n"
+            start_marker = self.lm.document_delimiter if "document_delimiter" in self.lm.__dict__ else '\n'
             end_marker = " "
 
             # get hidden states from language model

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -23,12 +23,14 @@ class LanguageModel(nn.Module):
         nlayers: int,
         embedding_size: int = 100,
         nout=None,
+        document_delimiter: str = '\n',
         dropout=0.1,
     ):
 
         super(LanguageModel, self).__init__()
 
         self.dictionary = dictionary
+        self.document_delimiter = document_delimiter
         self.is_forward_lm: bool = is_forward_lm
 
         self.dropout = dropout
@@ -187,14 +189,17 @@ class LanguageModel(nn.Module):
 
         state = torch.load(str(model_file), map_location=flair.device)
 
+        document_delimiter = state["document_delimiter"] if "document_delimiter" in state else '\n'
+
         model = LanguageModel(
-            state["dictionary"],
-            state["is_forward_lm"],
-            state["hidden_size"],
-            state["nlayers"],
-            state["embedding_size"],
-            state["nout"],
-            state["dropout"],
+            dictionary=state["dictionary"],
+            is_forward_lm=state["is_forward_lm"],
+            hidden_size=state["hidden_size"],
+            nlayers=state["nlayers"],
+            embedding_size=state["embedding_size"],
+            nout=state["nout"],
+            document_delimiter=document_delimiter,
+            dropout=state["dropout"],
         )
         model.load_state_dict(state["state_dict"])
         model.eval()
@@ -209,18 +214,21 @@ class LanguageModel(nn.Module):
         epoch = state["epoch"] if "epoch" in state else None
         split = state["split"] if "split" in state else None
         loss = state["loss"] if "loss" in state else None
+        document_delimiter = state["document_delimiter"] if "document_delimiter" in state else '\n'
+
         optimizer_state_dict = (
             state["optimizer_state_dict"] if "optimizer_state_dict" in state else None
         )
 
         model = LanguageModel(
-            state["dictionary"],
-            state["is_forward_lm"],
-            state["hidden_size"],
-            state["nlayers"],
-            state["embedding_size"],
-            state["nout"],
-            state["dropout"],
+            dictionary=state["dictionary"],
+            is_forward_lm=state["is_forward_lm"],
+            hidden_size=state["hidden_size"],
+            nlayers=state["nlayers"],
+            embedding_size=state["embedding_size"],
+            nout=state["nout"],
+            document_delimiter=document_delimiter,
+            dropout=state["dropout"],
         )
         model.load_state_dict(state["state_dict"])
         model.eval()
@@ -245,6 +253,7 @@ class LanguageModel(nn.Module):
             "nlayers": self.nlayers,
             "embedding_size": self.embedding_size,
             "nout": self.nout,
+            "document_delimiter": self.document_delimiter,
             "dropout": self.dropout,
             "optimizer_state_dict": optimizer.state_dict(),
             "epoch": epoch,
@@ -263,6 +272,7 @@ class LanguageModel(nn.Module):
             "nlayers": self.nlayers,
             "embedding_size": self.embedding_size,
             "nout": self.nout,
+            "document_delimiter": self.document_delimiter,
             "dropout": self.dropout,
         }
 


### PR DESCRIPTION
Previously, text files used to train a `LanguageModel` were split at newlines and shuffled at each epoch. This is problematic if text files contain documents that span several lines. Closes #1538 

With this PR, you now have the option of specifying a document_delimiter when training a LanguageModel. Say, you have a corpus of textual lists and use "[SEP]" to mark boundaries between two lists, like this: 

```
Colors:
- blue
- green
- red
[SEP]
Cities:
- Berlin
- Munich
[SEP]
...
```

Then you can now train a language model by setting the `document_delimiter` in the `TextCorpus` and `LanguageModel` objects. This will make sure only documents as a whole will get shuffled during training (i.e. the lists in the above example): 

```python
# your document delimiter
delimiter = '[SEP]'

# set it when you load the corpus
corpus = TextCorpus(
    "data/corpora/conala-corpus/",
    dictionary,
    is_forward_lm,
    character_level=True,
    document_delimiter=delimiter,
)

# set it when you init the language model
language_model = LanguageModel(
    dictionary,
    is_forward_lm=True,
    hidden_size=512,
    nlayers=1,
    document_delimiter=delimiter
)

# train your language model as always
trainer = LanguageModelTrainer(language_model, corpus)
```
