### PR TITLE
GH-1494: transformer errors

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2283,11 +2283,11 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             tokenized_string = sentence.to_tokenized_string()
 
             # method 1: subtokenize sentence
-            subtokenized_sentence = self.tokenizer.encode(tokenized_string, add_special_tokens=True)
+            # subtokenized_sentence = self.tokenizer.encode(tokenized_string, add_special_tokens=True)
 
             # method 2:
-            # ids = self.tokenizer.encode(tokenized_string, add_special_tokens=False)
-            # subtokenized_sentence = self.tokenizer.build_inputs_with_special_tokens(ids)
+            ids = self.tokenizer.encode(tokenized_string, add_special_tokens=False)
+            subtokenized_sentence = self.tokenizer.build_inputs_with_special_tokens(ids)
 
             subtokenized_sentences.append(torch.tensor(subtokenized_sentence, dtype=torch.long))
             subtokens = self.tokenizer.convert_ids_to_tokens(subtokenized_sentence)

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2044,8 +2044,6 @@ class FlairEmbeddings(TokenEmbeddings):
         with gradient_context:
 
             # if this is not possible, use LM to generate embedding. First, get text sentences
-            # text_sentences = [f'{sentence.to_tokenized_string()} [REG] {sentence.to_tokenized_string()}' for sentence in sentences]
-            # print(text_sentences)
             text_sentences = [sentence.to_tokenized_string() for sentence in sentences]
 
             start_marker = "\n"
@@ -2064,7 +2062,6 @@ class FlairEmbeddings(TokenEmbeddings):
                 sentence_text = sentence.to_tokenized_string()
 
                 offset_forward: int = len(start_marker)
-                                     # + len(sentence_text) + 7
                 offset_backward: int = len(sentence_text) + len(start_marker)
 
                 for token in sentence.tokens:

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2297,7 +2297,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
             subtokenized_sentences.append(torch.tensor(subtokenized_sentence, dtype=torch.long))
             subtokens = self.tokenizer.convert_ids_to_tokens(subtokenized_sentence)
-            # print(subtokens)
 
             word_iterator = iter(sentence)
             token = next(word_iterator)


### PR DESCRIPTION
This PR addresses a number of issues found with TransformerWordEmbeddings in #1494 :

- Adds handling for unknown tokens
- Improve tokenizer type checks fo RoBERTa so that correct tokenizer is used
- Deactivates dropout if transformer used in a feature based approach
- Add "all" as shorthand option to use all layers in transformer
- Add option for trainable ScalarMix (this part still needs further work)