### PR TITLE
GH-1503: Sentiment Datasets

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -934,11 +934,15 @@ class Corpus:
     def test(self) -> FlairDataset:
         return self._test
 
-    def downsample(self, percentage: float = 0.1, only_downsample_train=False):
+    def downsample(self, percentage: float = 0.1, downsample_train=True, downsample_dev=True, downsample_test=True):
 
-        self._train = self._downsample_to_proportion(self.train, percentage)
-        if not only_downsample_train:
+        if downsample_train:
+            self._train = self._downsample_to_proportion(self.train, percentage)
+
+        if downsample_dev:
             self._dev = self._downsample_to_proportion(self.dev, percentage)
+
+        if downsample_test:
             self._test = self._downsample_to_proportion(self.test, percentage)
 
         return self
@@ -1104,7 +1108,8 @@ class Corpus:
 
         from flair.datasets import DataLoader
 
-        loader = DataLoader(self.train, batch_size=1)
+        data = ConcatDataset([self.train, self.test])
+        loader = DataLoader(data, batch_size=1)
 
         log.info("Computing label dictionary. Progress:")
         for batch in Tqdm.tqdm(iter(loader)):

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -543,7 +543,8 @@ class ModelTrainer:
                     self.model.save(base_path / "best-model.pt")
                     current_state_dict = self.model.state_dict()
                     self.model.load_state_dict(last_epoch_model_state_dict)
-                    self.model.save(base_path / "pre-best-model.pt")
+                    if anneal_with_prestarts:
+                        self.model.save(base_path / "pre-best-model.pt")
                     self.model.load_state_dict(current_state_dict)
 
             # if we do not use dev data for model selection, save final model


### PR DESCRIPTION
This PR adds two new sentiment datasets to Flair, namely `AMAZON_REVIEWS`, a very large corpus of Amazon reviews with sentiment labels, and `SENTIMENT_140`, a corpus of tweets labeled with sentiment. See #1503 

There are also a number of improvements for the `ClassificationCorpus` and `ClassificationDataset` classes: 
- It is now possible to select from three memory modes ('full', 'partial' and 'disk'). Use full if the entire dataset and all objects fit into memory. Use 'partial' if it doesn't and use 'disk' if even 'partial' does not fit. 
- It is also now possible to provide "name maps" to rename labels in datasets. For instance, some sentiment analysis datasets use '0' and '1' as labels, while some others use 'POSITIVE' and 'NEGATIVE'. By providing name maps you can rename labels so they are consistent across datasets. 
- You can now choose which splits to downsample (for instance you might want to downsample 'train' and 'dev' but not 'test')
- You can now specify the option "filter_if_longer_than", to filter all sentences that have more than the number of provided whitespaces. This is useful to limit corpus size as some sentiment analysis datasets are gigantic. 

Putting it all together, you can now create a `MultiCorpus` of 5 sentiment analysis datasets and limit the max length of each data point to 50 tokens, like this: 

```python
corpus = MultiCorpus([
    IMDB(filter_if_longer_than=50),
    SENTEVAL_SST_BINARY(filter_if_longer_than=50),
    SENTEVAL_MR(filter_if_longer_than=50),
    SENTIMENT_140().downsample(0.1, downsample_test=False), # downsample train and dev, but not text
    AMAZON_REVIEWS(filter_if_longer_than=50, memory_mode='partial') # use partial memory mode since this dataset is huge
]
)
print(corpus)
```

In this example, we downsample Sentiment140 ('train' and 'dev' but not 'test') and keep the Amazon dataset in partial memory because it is too large.
 
