### PR TITLE
GH-647: add different ways to combine ELMo layers

### DIFF
--- a/resources/docs/embeddings/ELMO_EMBEDDINGS.md
+++ b/resources/docs/embeddings/ELMO_EMBEDDINGS.md
@@ -20,7 +20,12 @@ sentence = Sentence('The grass is green .')
 embedding.embed(sentence)
 ```
 
-By default, the top 3 layers in the language model are concatenated to form the word embedding.
+ELMo word embeddings can be constructed by combining ELMo layers in different ways. The available combination strategies are:
+- `"all"`: Use the concatenation of the three ELMo layers.
+- `"top"`: Use the top ELMo layer.
+- `"average"`: Use the average of the three ELMo layers.
+
+By default, the top 3 layers are concatenated to form the word embedding.
 
 AllenNLP provides the following pre-trained models. To use any of the following models inside Flair
 simple specify the embedding id when initializing the `ELMoEmbeddings`.


### PR DESCRIPTION
Addresses #647 by adding different ways to combine ELMo layers. Besides the default/current behavior of concatenating the 3 ELMo layers, the user can also get only the topmost layer, or an average of the 3 layers. These combining strategies are the same provided by [AllenNLP's ELMo CLI](https://github.com/allenai/allennlp/blob/d709e59ff3f54e137ea473d411056f68c197c266/allennlp/commands/elmo.py#L31).