### PR TITLE
Add CLEF HIPE Flair Embeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1853,6 +1853,7 @@ class FlairEmbeddings(TokenEmbeddings):
 
         aws_path: str = "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources"
         hu_path: str = "https://flair.informatik.hu-berlin.de/resources"
+        clef_hipe_path: str = "https://files.ifi.uzh.ch/cl/siclemat/impresso/clef-hipe-2020/flair"
 
         self.PRETRAINED_MODEL_ARCHIVE_MAP = {
             # multilingual models
@@ -1972,6 +1973,13 @@ class FlairEmbeddings(TokenEmbeddings):
             # Tamil
             "ta-forward": f"{aws_path}/embeddings-stefan-it/lm-ta-opus-large-forward-v0.1.pt",
             "ta-backward": f"{aws_path}/embeddings-stefan-it/lm-ta-opus-large-backward-v0.1.pt",
+            # CLEF HIPE Shared task
+            "de-hipe-v1-forward": f"{clef_hipe_path}/de-hipe-flair-v1-forward/best-lm.pt",
+            "de-hipe-v1-backward": f"{clef_hipe_path}/de-hipe-flair-v1-backward/best-lm.pt",
+            "en-hipe-v1-forward": f"{clef_hipe_path}/en-flair-v1-forward/best-lm.pt",
+            "en-hipe-v1-backward": f"{clef_hipe_path}/en-flair-v1-backward/best-lm.pt",
+            "fr-hipe-v1-forward": f"{clef_hipe_path}/fr-hipe-flair-v1-forward/best-lm.pt",
+            "fr-hipe-v1-backward": f"{clef_hipe_path}/fr-hipe-flair-v1-backward/best-lm.pt",
         }
 
         if type(model) == str:
@@ -1979,6 +1987,10 @@ class FlairEmbeddings(TokenEmbeddings):
             # load model if in pretrained model map
             if model.lower() in self.PRETRAINED_MODEL_ARCHIVE_MAP:
                 base_path = self.PRETRAINED_MODEL_ARCHIVE_MAP[model.lower()]
+
+                # Fix for CLEF HIPE models (avoid overwriting best-lm.pt in cache_dir)
+                if "hipe" in model.lower():
+                    cache_dir = cache_dir / model.lower()
                 model = cached_path(base_path, cache_dir=cache_dir)
 
             elif replace_with_language_code(model) in self.PRETRAINED_MODEL_ARCHIVE_MAP:

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1974,12 +1974,12 @@ class FlairEmbeddings(TokenEmbeddings):
             "ta-forward": f"{aws_path}/embeddings-stefan-it/lm-ta-opus-large-forward-v0.1.pt",
             "ta-backward": f"{aws_path}/embeddings-stefan-it/lm-ta-opus-large-backward-v0.1.pt",
             # CLEF HIPE Shared task
-            "de-hipe-v1-forward": f"{clef_hipe_path}/de-hipe-flair-v1-forward/best-lm.pt",
-            "de-hipe-v1-backward": f"{clef_hipe_path}/de-hipe-flair-v1-backward/best-lm.pt",
-            "en-hipe-v1-forward": f"{clef_hipe_path}/en-flair-v1-forward/best-lm.pt",
-            "en-hipe-v1-backward": f"{clef_hipe_path}/en-flair-v1-backward/best-lm.pt",
-            "fr-hipe-v1-forward": f"{clef_hipe_path}/fr-hipe-flair-v1-forward/best-lm.pt",
-            "fr-hipe-v1-backward": f"{clef_hipe_path}/fr-hipe-flair-v1-backward/best-lm.pt",
+            "de-impresso-hipe-v1-forward": f"{clef_hipe_path}/de-hipe-flair-v1-forward/best-lm.pt",
+            "de-impresso-hipe-v1-backward": f"{clef_hipe_path}/de-hipe-flair-v1-backward/best-lm.pt",
+            "en-impresso-hipe-v1-forward": f"{clef_hipe_path}/en-flair-v1-forward/best-lm.pt",
+            "en-impresso-hipe-v1-backward": f"{clef_hipe_path}/en-flair-v1-backward/best-lm.pt",
+            "fr-impresso-hipe-v1-forward": f"{clef_hipe_path}/fr-hipe-flair-v1-forward/best-lm.pt",
+            "fr-impresso-hipe-v1-backward": f"{clef_hipe_path}/fr-hipe-flair-v1-backward/best-lm.pt",
         }
 
         if type(model) == str:
@@ -1989,7 +1989,7 @@ class FlairEmbeddings(TokenEmbeddings):
                 base_path = self.PRETRAINED_MODEL_ARCHIVE_MAP[model.lower()]
 
                 # Fix for CLEF HIPE models (avoid overwriting best-lm.pt in cache_dir)
-                if "hipe" in model.lower():
+                if "impresso-hipe" in model.lower():
                     cache_dir = cache_dir / model.lower()
                 model = cached_path(base_path, cache_dir=cache_dir)
 

--- a/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
+++ b/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
@@ -66,9 +66,9 @@ Currently, the following contextual string embeddings are provided (note: replac
 | 'sv-v0-X'    | Swedish | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Trained with various sources (Europarl, Wikipedia or OpenSubtitles2018) |
 | 'ta-X'    | Tamil | Added by [@stefan-it](https://github.com/stefan-it/plur) |
 | 'pubmed-X'    | English | Added by [@jessepeng](https://github.com/zalandoresearch/flair/pull/519): Trained with 5% of PubMed abstracts until 2015 (1150 hidden states, 3 layers)|
-| 'de-impresso-hipe-v1-X' | German (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
-| 'en-impresso-hipe-v1-X' | English (historical) | In-domain data (Chronicling America material) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
-| 'fr-impresso-hipe-v1-X' | French (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
+| 'de-impresso-hipe-v1-X' | German (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020). More information on the shared task can be found in [this paper](https://zenodo.org/record/3752679#.XqgzxXUzZzU) |
+| 'en-impresso-hipe-v1-X' | English (historical) | In-domain data (Chronicling America material) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020). More information on the shared task can be found in [this paper](https://zenodo.org/record/3752679#.XqgzxXUzZzU) |
+| 'fr-impresso-hipe-v1-X' | French (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020). More information on the shared task can be found in [this paper](https://zenodo.org/record/3752679#.XqgzxXUzZzU) |
 
 So, if you want to load embeddings from the German forward LM model, instantiate the method as follows:
 

--- a/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
+++ b/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
@@ -66,9 +66,9 @@ Currently, the following contextual string embeddings are provided (note: replac
 | 'sv-v0-X'    | Swedish | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Trained with various sources (Europarl, Wikipedia or OpenSubtitles2018) |
 | 'ta-X'    | Tamil | Added by [@stefan-it](https://github.com/stefan-it/plur) |
 | 'pubmed-X'    | English | Added by [@jessepeng](https://github.com/zalandoresearch/flair/pull/519): Trained with 5% of PubMed abstracts until 2015 (1150 hidden states, 3 layers)|
-| 'de-hipe-v1-X' | German (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
-| 'en-hipe-v1-X' | English (historical) | In-domain data (Chronicling America material) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
-| 'fr-hipe-v1-X' | French (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
+| 'de-impresso-hipe-v1-X' | German (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
+| 'en-impresso-hipe-v1-X' | English (historical) | In-domain data (Chronicling America material) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
+| 'fr-impresso-hipe-v1-X' | French (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
 
 So, if you want to load embeddings from the German forward LM model, instantiate the method as follows:
 

--- a/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
+++ b/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
@@ -66,7 +66,9 @@ Currently, the following contextual string embeddings are provided (note: replac
 | 'sv-v0-X'    | Swedish | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Trained with various sources (Europarl, Wikipedia or OpenSubtitles2018) |
 | 'ta-X'    | Tamil | Added by [@stefan-it](https://github.com/stefan-it/plur) |
 | 'pubmed-X'    | English | Added by [@jessepeng](https://github.com/zalandoresearch/flair/pull/519): Trained with 5% of PubMed abstracts until 2015 (1150 hidden states, 3 layers)|
-
+| 'de-hipe-v1-X' | German (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
+| 'en-hipe-v1-X' | English (historical) | In-domain data (Chronicling America material) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
+| 'fr-hipe-v1-X' | French (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020) |
 
 So, if you want to load embeddings from the German forward LM model, instantiate the method as follows:
 


### PR DESCRIPTION
Hi,

this PR adds the recently trained Flair embeddings on historic newspapers for German/English/French provided by the [CLEF HIPE shared task](https://impresso.github.io/CLEF-HIPE-2020/).

From the task organizers:

> The amount for our our indomain training differs largely between languages:

> - French taken from Swiss and Luxembourgish newspapers: 20G
> - English taken from Chronicling America material: 1.1G
> - German taken from Swiss and Luxembourgish newspapers: 8.5G

Technical details:

> Technical details: The embedding size for characters is 2048. We use flair 0.4.5 to compute the embeddings using a context of 250 characters, a batchsize of 400-600 (depending on the GPUs memory), 1 hidden layer, dropout of 0.1.

### Example usage

The new Flair embeddings can be used as shown in the following example:

```python
from flair.data import Sentence
from flair.embeddings import StackedEmbeddings, FlairEmbeddings

de_embeddings = StackedEmbeddings([FlairEmbeddings("de-impresso-hipe-v1-forward"), 
                                   FlairEmbeddings("de-impresso-hipe-v1-backward")])

en_embeddings = StackedEmbeddings([FlairEmbeddings("en-impresso-hipe-v1-forward"), 
                                   FlairEmbeddings("en-impresso-hipe-v1-backward")])

fr_embeddings = StackedEmbeddings([FlairEmbeddings("fr-impresso-hipe-v1-forward"), 
                                   FlairEmbeddings("fr-impresso-hipe-v1-backward")])
```

This will download all CLEF HIPE Flair embeddings. Now let's embed some sentences:

```python
de_sentence = Sentence("Der Prinz war in Verlegenheit .")
en_sentence = Sentence("Bold and artful achievement .")
fr_sentence = Sentence("La panique des éléphants au grand cortège dc Munich .")
```

Each forward and backward model has a dimension size of 2048, so using forward and backward Flair embeddings will yield 4096 as dimension for each token in a sentence:

```python
print(de_sentence[0].embedding.shape)
print(en_sentence[0].embedding.shape)
print(fr_sentence[0].embedding.shape)
# torch.Size([4096])
# torch.Size([4096])
# torch.Size([4096])
```

Let's calculate the perplexity for each sentence with the forward model:

```python
print(de_embeddings.embeddings[0].lm.calculate_perplexity(de_sentence.to_tagged_string()))
print(en_embeddings.embeddings[0].lm.calculate_perplexity(en_sentence.to_tagged_string()))
print(fr_embeddings.embeddings[0].lm.calculate_perplexity(fr_sentence.to_tagged_string()))
# 14.182144416945428
# 3.926759070460339
# 5.250280820082409
```

## Checksum comparison

In order to check, if the correct models were obtained from the CLEF HIPE server, here's a comparison of downloaded models and their chechsums:

```bash
$ sha256sum ~/.flair/embeddings/*hipe*/best-lm.pt
f51b3918554b394c265a6d621d4f396795619a124205636c2d52a9566033fe1e  /home/stefan/.flair/embeddings/de-hipe-v1-backward/best-lm.pt
ccc78794fa14dacee51e37bda6125f7d2c3f93f54826ec31614861df9f149ba1  /home/stefan/.flair/embeddings/de-hipe-v1-forward/best-lm.pt
0221191127e12dfc8c57ba8789722c5ee219b17f89a3e193ee3476248bb28042  /home/stefan/.flair/embeddings/en-hipe-v1-backward/best-lm.pt
bbfdde6831084381728db823644899171bb26456b8cb77f61a76711cbad076c9  /home/stefan/.flair/embeddings/en-hipe-v1-forward/best-lm.pt
a1fd8000162056fcfa4a845d714210c7b2f0317a55c6f6a99f6a98e418888140  /home/stefan/.flair/embeddings/fr-hipe-v1-backward/best-lm.pt
55a09b532645c9de3b0a903426e2d95d5d658268f4b6aa042f5eea1abe8f1bec  /home/stefan/.flair/embeddings/fr-hipe-v1-forward/best-lm.pt
```

I manually validated it with the original files, like:

```bash
$ curl -s https://files.ifi.uzh.ch/cl/siclemat/impresso/clef-hipe-2020/flair/de-hipe-flair-v1-backward/best-lm.pt | sha256sum
$ f51b3918554b394c265a6d621d4f396795619a124205636c2d52a9566033fe1e
```