### PR TITLE
GH-1403: anneal against score and loss

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -20,6 +20,7 @@ from . import models
 from . import visual
 from . import trainers
 from . import nn
+from .training_utils import AnnealOnPlateau
 
 import logging.config
 

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -444,21 +444,6 @@ class AnnealOnPlateau(object):
     def in_cooldown(self):
         return self.cooldown_counter > 0
 
-    # def is_better(self, a, best):
-    #     if self.mode == 'min' and self.threshold_mode == 'rel':
-    #         rel_epsilon = 1. - self.threshold
-    #         return a < best * rel_epsilon
-    #
-    #     elif self.mode == 'min' and self.threshold_mode == 'abs':
-    #         return a < best - self.threshold
-    #
-    #     elif self.mode == 'max' and self.threshold_mode == 'rel':
-    #         rel_epsilon = self.threshold + 1.
-    #         return a > best * rel_epsilon
-    #
-    #     else:  # mode == 'max' and epsilon_mode == 'abs':
-    #         return a > best + self.threshold
-
     def _init_is_better(self, mode):
         if mode not in {'min', 'max'}:
             raise ValueError('mode ' + mode + ' is unknown!')


### PR DESCRIPTION
Add new scheduler that uses dev score as main metric to anneal against, but additionally uses dev loss in case two epochs have the same dev score.

Closes #1403 