### PR TITLE
GH-1362: Add option for hidden state position in FlairEmbeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1841,7 +1841,6 @@ class FlairEmbeddings(TokenEmbeddings):
                  fine_tune: bool = False,
                  chars_per_chunk: int = 512,
                  with_whitespace: bool = True,
-                 add_begin_state: bool = True,
                  tokenized_lm: bool = True,
                  ):
         """
@@ -2013,7 +2012,6 @@ class FlairEmbeddings(TokenEmbeddings):
 
         self.is_forward_lm: bool = self.lm.is_forward_lm
         self.with_whitespace: bool = with_whitespace
-        self.add_begin_state: bool = add_begin_state
         self.tokenized_lm: bool = tokenized_lm
         self.chars_per_chunk: int = chars_per_chunk
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2033,6 +2033,10 @@ class FlairEmbeddings(TokenEmbeddings):
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
 
+        # make compatible with serialized models (TODO: remove)
+        if "offset_mode" not in self.__dict__:
+            self.offset_mode = 'with_whitespace'
+
         # gradients are enable if fine-tuning is enabled
         gradient_context = torch.enable_grad() if self.fine_tune else torch.no_grad()
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1840,7 +1840,7 @@ class FlairEmbeddings(TokenEmbeddings):
                  model,
                  fine_tune: bool = False,
                  chars_per_chunk: int = 512,
-                 offset_mode: str = 'with_whitespace',
+                 with_whitespace: bool = True,
                  add_begin_state: bool = True,
                  tokenized_lm: bool = True,
                  ):
@@ -1854,8 +1854,8 @@ class FlairEmbeddings(TokenEmbeddings):
                 down training and often leads to overfitting, so use with caution.
         :param chars_per_chunk: max number of chars per rnn pass to control speed/memory tradeoff. Higher means faster
                 but requires more memory. Lower means slower but less memory.
-        :param offset_mode: One of 'with_whitespace', 'without_whitespace' or 'both'. 'with_whitespace' ist default
-                but for some tasks such as POS tagging 'without_whitespace' works better
+        :param with_whitespace: If True, use hidden state after whitespace after word. If False, use hidden
+                 state at last character of word.
         :param tokenized_lm: Whether this lm is tokenized. Default is True, but for LMs trained over unprocessed text
                 False might be better.
         """
@@ -2012,7 +2012,7 @@ class FlairEmbeddings(TokenEmbeddings):
         self.static_embeddings = not fine_tune
 
         self.is_forward_lm: bool = self.lm.is_forward_lm
-        self.offset_mode: str = offset_mode
+        self.with_whitespace: bool = with_whitespace
         self.add_begin_state: bool = add_begin_state
         self.tokenized_lm: bool = tokenized_lm
         self.chars_per_chunk: int = chars_per_chunk
@@ -2048,8 +2048,8 @@ class FlairEmbeddings(TokenEmbeddings):
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
 
         # make compatible with serialized models (TODO: remove)
-        if "offset_mode" not in self.__dict__:
-            self.offset_mode = 'with_whitespace'
+        if "with_whitespace" not in self.__dict__:
+            self.with_whitespace = True
         if "tokenized_lm" not in self.__dict__:
             self.tokenized_lm = True
 
@@ -2091,31 +2091,12 @@ class FlairEmbeddings(TokenEmbeddings):
                         offset_without_whitespace = offset_backward - 1
 
                     # offset mode that extracts at whitespace after last character
-                    if self.offset_mode == 'end_with_whitespace':
+                    if self.with_whitespace:
                         embedding = all_hidden_states_in_lm[offset_with_whitespace, i, :]
-
                     # offset mode that extracts at last character
-                    if self.offset_mode == 'end_without_whitespace':
+                    else:
                         embedding = all_hidden_states_in_lm[offset_without_whitespace, i, :]
 
-                    if self.offset_mode == 'end_both':
-                        embedding_with = all_hidden_states_in_lm[offset_with_whitespace, i, :]
-                        embedding_without = all_hidden_states_in_lm[offset_without_whitespace, i, :]
-                        embedding = torch.cat([embedding_with, embedding_without])
-
-                    if self.offset_mode == 'begin':
-                        begin_offset = offset_without_whitespace - len(token.text)
-                        embedding = all_hidden_states_in_lm[begin_offset, i, :]
-
-                    if self.offset_mode == 'begin_and_end_with_whitespace':
-                        begin_offset = offset_without_whitespace - len(token.text)
-                        begin_embedding = all_hidden_states_in_lm[begin_offset, i, :]
-                        embedding_with = all_hidden_states_in_lm[offset_with_whitespace, i, :]
-                        embedding = torch.cat([begin_embedding, embedding_with])
-
-                    # tokenized_lm=False,
-                    # offset_mode='with_whitespace'
-                    # and tokens with whitespace_after=False.
                     if self.tokenized_lm or token.whitespace_after:
                         offset_forward += 1
                         offset_backward -= 1


### PR DESCRIPTION
This PR adds the option to choose which hidden state to use in FlairEmbeddings: either the state at the end of each word, or the state at the whitespace after. Default is the state at the whitespace after. 

You can change the default like this:
```python
embeddings = FlairEmbeddings('news-forward', with_whitespace=False)
```

This configuration seems to be better for syntactic tasks. For POS tagging, it seems that you should set `with_whitespace=False`. For instance, on UD_ENGLISH POS-tagging, we get **96.56 +- 0.03** with whitespace and **96.72 +- 0.04** without, averaged over three runs. 

See the discussion in #1362 for more details. 