### PR TITLE
GH-1580: True whitespaces in ColumnCorpus

### DIFF
--- a/tests/resources/tasks/column_with_whitespaces/eng.testa
+++ b/tests/resources/tasks/column_with_whitespaces/eng.testa
@@ -1,0 +1,8 @@
+It O +
+is O +
+a O +
+French B-LOC -
+- O -
+speaking O +
+town O -
+. O +

--- a/tests/resources/tasks/column_with_whitespaces/eng.testb
+++ b/tests/resources/tasks/column_with_whitespaces/eng.testb
@@ -1,0 +1,8 @@
+It O +
+is O +
+a O +
+US B-LOC -
+- O -
+based O +
+company O -
+. O +

--- a/tests/resources/tasks/column_with_whitespaces/eng.train
+++ b/tests/resources/tasks/column_with_whitespaces/eng.train
@@ -1,0 +1,8 @@
+It O +
+is O +
+a O +
+German B-LOC -
+- O -
+owned O +
+firm O -
+. O +

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -104,6 +104,7 @@ def test_sentence_to_real_string(tasks_base_path):
     corpus = flair.datasets.GERMEVAL_14(base_path=tasks_base_path)
 
     sentence = corpus.train[0]
+    sentence.infer_space_after()
     assert (
         'Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in einer Weise aufgetreten , die alles andere als überzeugend war " .'
         == sentence.to_tokenized_string()
@@ -114,6 +115,7 @@ def test_sentence_to_real_string(tasks_base_path):
     )
 
     sentence = corpus.train[1]
+    sentence.infer_space_after()
     assert (
         "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf ."
         == sentence.to_tokenized_string()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -70,6 +70,20 @@ def test_load_sequence_labeling_data(tasks_base_path):
     assert len(corpus.test) == 1
 
 
+def test_load_sequence_labeling_whitespace_after(tasks_base_path):
+    # get training, test and dev data
+    corpus = flair.datasets.ColumnCorpus(
+        tasks_base_path / "column_with_whitespaces", column_format={0: 'text', 1: 'ner', 2: 'space-after'}
+    )
+
+    assert len(corpus.train) == 1
+    assert len(corpus.dev) == 1
+    assert len(corpus.test) == 1
+
+    assert corpus.train[0].to_tokenized_string() == "It is a German - owned firm ."
+    assert corpus.train[0].to_plain_string() == "It is a German-owned firm."
+
+
 def test_load_germeval_data(tasks_base_path):
     # get training, test and dev data
     corpus = flair.datasets.GERMEVAL_14(tasks_base_path)


### PR DESCRIPTION
Closes #1580 

The `ColumnCorpus` currently assumes that there is always a whitespace between two tokens. This PR adds the option of specifying a special "space-after" column. If that column has a "-" it means that no whitespace follows this token. 

For instance, the following sentence in column format: 

```console
It O +
is O +
a O +
French B-LOC -
- O -
speaking O +
town O -
. O +
```

First column is the token, second the NER tag and third the whitespace after information. After the PR, you can read the corpus like this: 

```python
# read the corpus and specify which column holds the "space after" information
corpus = ColumnCorpus('path/to/corpus', column_format={0: 'text', 1: 'ner', 2: 'space-after'})

# go through sentences 
for sentence in corpus.get_all_sentences():

    # print tokenized version
    print(sentence.to_tokenized_string())

    # print plain version (true whitespacing)
    print(sentence.to_plain_string())
```

If the corpus only consists of the one sentence formatted like above, it will print: 

```console
It is a French - speaking town .
It is a French-speaking town.
```

So the true whitespacing information is now preserved.