### PR TITLE
datasets: add support for BIOfid dataset

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -24,6 +24,7 @@ from .sequence_labeling import WIKINER_PORTUGUESE
 from .sequence_labeling import WIKINER_POLISH
 from .sequence_labeling import WIKINER_RUSSIAN
 from .sequence_labeling import WNUT_17
+from .sequence_labeling import BIOFID
 
 # Expose all document classification datasets
 from .document_classification import ClassificationCorpus

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -966,6 +966,38 @@ class WNUT_17(ColumnCorpus):
         )
 
 
+class BIOFID(ColumnCorpus):
+    def __init__(
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+    ):
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "lemma", 2: "pos", 3: "ner"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        biofid_path = "https://raw.githubusercontent.com/texttechnologylab/BIOfid/master/BIOfid-Dataset-NER/"
+        cached_path(f"{biofid_path}train.conll", Path("datasets") / dataset_name)
+        cached_path(f"{biofid_path}dev.conll", Path("datasets") / dataset_name)
+        cached_path(f"{biofid_path}test.conll", Path("datasets") / dataset_name)
+
+        super(BIOFID, self).__init__(
+            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
+        )
+
+
 def _download_wikiner(language_code: str, dataset_name: str):
     # download data if necessary
     wikiner_path = (


### PR DESCRIPTION
Hi,

this PR adds support for the BIOfid dataset:

> The Specialized Information Service Biodiversity Research (BIOfid) has been launched to mobilize valuable biological data from printed literature hidden in German libraries for over the past 250 years. In this project, we annotate German texts converted by OCR from historical scientific literature on the biodiversity of plants, birds, moths and butterflies. Our work enables the automatic extraction of biological information previously buried in the mass of papers and volumes. For this purpose, we generated training data for the tasks of Named Entity Recognition (NER) and Taxa Recognition (TR) in biological documents. We use this data to train a number of leading machine learning tools and create a gold standard for TR in biodiversity literature. More specifically, we perform a practical analysis of our newly generated BIOfid dataset through various downstream-task evaluations and establish a new state of the art for TR with 80.23% F-score. In this sense, our paper lays the foundations for future work in the field of information extraction in biology texts.

More information can be found in the paper ["BIOfid Dataset: Publishing a German Gold Standard for Named Entity Recognition in Historical Biodiversity Literature"](https://www.aclweb.org/anthology/K19-1081/) from Ahmed et al.

Data is taken from [their repository](https://github.com/texttechnologylab/BIOfid/tree/master/BIOfid-Dataset-NER).

## Usage

Here's an example of how to use the dataset in Flair:

```python
import flair.datasets

biofid = flair.datasets.BIOFID()

print(biofid)
```

Some sanity checks:

```python
tag_type = "ner"
tag_dictionary = biofid.make_tag_dictionary(tag_type=tag_type)

labels = set([item[2:] for item in tag_dictionary.get_items() if "-" in item])

assert len(labels) == 6 # As mentioned in the paper
```

However, the number of sentences differ a bit:

```python
len_train = len(biofid.train)
len_dev = len(biofid.dev)
len_test = len(biofid.test)

print(len_train + len_dev + len_test)
```

Outputs: 15,836, whereas the paper reports a number of 15,833.