### PR TITLE
GH-1610: transformer tokenizer is re-loaded upon de-serialization

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -56,7 +56,7 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
         self.model = AutoModel.from_pretrained(model, config=config)
 
         # model name
-        self.name = str(model)
+        self.name = 'transformer-document-' + str(model)
 
         # when initializing, embeddings are in eval mode by default
         self.model.eval()
@@ -157,6 +157,12 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
             else self.model.config.hidden_size
         )
 
+    def __setstate__(self, d):
+        self.__dict__ = d
+
+        # reload tokenizer to get around serialization issues
+        model_name = self.name.split('transformer-document-')[-1]
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 class DocumentPoolEmbeddings(DocumentEmbeddings):
     def __init__(

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1056,6 +1056,13 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         return length
 
+    def __setstate__(self, d):
+        self.__dict__ = d
+
+        # reload tokenizer to get around serialization issues
+        model_name = self.name.split('transformer-word-')[-1]
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+
 
 class FastTextEmbeddings(TokenEmbeddings):
     """FastText Embeddings with oov functionality"""


### PR DESCRIPTION
There are some weird errors in transformer tokenizers when training/saving a model on one machine and using it on another. See #1610. This PR changes de-serialization so that tokenizer is always re-loaded when loading a model.