### PR TITLE
New sentiment models

### DIFF
--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -432,7 +432,7 @@ class TextClassifier(flair.nn.Model):
 
         model_map = {}
         aws_resource_path = "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/models-v0.4"
-        hu_path: str = "https://flair.informatik.hu-berlin.de/resources/models"
+        hu_path: str = "https://nlp.informatik.hu-berlin.de/resources/models"
 
         model_map["de-offensive-language"] = "/".join(
             [
@@ -444,13 +444,13 @@ class TextClassifier(flair.nn.Model):
 
         # English sentiment models
         model_map["sentiment"] = "/".join(
-            [hu_path, "sentiment-curated-distilbert-base-uncased", "sentiment-en-mix-distillbert.pt"]
+            [hu_path, "sentiment-curated-distilbert", "sentiment-en-mix-distillbert.pt"]
         )
         model_map["en-sentiment"] = "/".join(
-            [hu_path, "sentiment-curated-distilbert-base-uncased", "sentiment-en-mix-distillbert.pt"]
+            [hu_path, "sentiment-curated-distilbert", "sentiment-en-mix-distillbert.pt"]
         )
         model_map["sentiment-fast"] = "/".join(
-            [hu_path, "sentiment-curated-fasttext-rnn-sgd", "sentiment-en-mix-rnn.pt"]
+            [hu_path, "sentiment-curated-fasttext-rnn", "sentiment-en-mix-ft-rnn.pt"]
         )
 
         cache_dir = Path("models")

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -431,9 +431,8 @@ class TextClassifier(flair.nn.Model):
     def _fetch_model(model_name) -> str:
 
         model_map = {}
-        aws_resource_path = (
-            "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/models-v0.4"
-        )
+        aws_resource_path = "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/models-v0.4"
+        hu_path: str = "https://flair.informatik.hu-berlin.de/resources/models"
 
         model_map["de-offensive-language"] = "/".join(
             [
@@ -443,8 +442,15 @@ class TextClassifier(flair.nn.Model):
             ]
         )
 
+        # English sentiment models
+        model_map["sentiment"] = "/".join(
+            [hu_path, "sentiment-curated-distilbert-base-uncased", "sentiment-en-mix-distillbert.pt"]
+        )
         model_map["en-sentiment"] = "/".join(
-            [aws_resource_path, "classy-imdb-en-rnn-cuda%3A0", "imdb-v0.4.pt"]
+            [hu_path, "sentiment-curated-distilbert-base-uncased", "sentiment-en-mix-distillbert.pt"]
+        )
+        model_map["sentiment-fast"] = "/".join(
+            [hu_path, "sentiment-curated-fasttext-rnn-sgd", "sentiment-en-mix-rnn.pt"]
         )
 
         cache_dir = Path("models")


### PR DESCRIPTION
This PR adds new sentiment models for English to Flair and closes #1503 

The new models are trained over a combined corpus of sentiment dataset, including Amazon product reviews. So they should be applicable to more domains than the old sentiment models that were only trained with movie reviews. 

There are two new models, a transformer-based model you can load like this: 

```python
# load tagger
classifier = TextClassifier.load('sentiment')

# predict for example sentence
sentence = Sentence("enormously entertaining for moviegoers of any age .")
classifier.predict(sentence)

# check prediction
print(sentence)
```

And a faster, slightly less accurate model based on RNNs you can load like this:

```python
# load tagger
classifier = TextClassifier.load('sentiment-fast')

# predict for example sentence
sentence = Sentence("enormously entertaining for moviegoers of any age .")
classifier.predict(sentence)

# check prediction
print(sentence)
```