### PR TITLE
GH-1623: add fine-grained POS models

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -866,9 +866,8 @@ class SequenceTagger(flair.nn.Model):
 
         model_map = {}
 
-        aws_resource_path_v04 = (
-            "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/models-v0.4"
-        )
+        aws_resource_path_v04 = "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/models-v0.4"
+        hu_path: str = "https://nlp.informatik.hu-berlin.de/resources/models"
 
         model_map["ner"] = "/".join(
             [aws_resource_path_v04, "NER-conll03-english", "en-ner-conll03-v0.4.pt"]
@@ -921,7 +920,7 @@ class SequenceTagger(flair.nn.Model):
                 ]
             )
 
-        model_map["pos"] = "/".join(
+        model_map["upos"] = "/".join(
             [
                 aws_resource_path_v04,
                 "POS-ontonotes--h256-l1-b32-p3-0.5-%2Bglove%2Bnews-forward%2Bnews-backward-normal-locked0.5-word0.05--v0.4_0",
@@ -929,11 +928,27 @@ class SequenceTagger(flair.nn.Model):
             ]
         )
 
-        model_map["pos-fast"] = "/".join(
+        model_map["pos"] = "/".join(
+            [
+                hu_path,
+                "release-pos-0",
+                "en-pos-ontonotes-v0.5.pt",
+            ]
+        )
+
+        model_map["upos-fast"] = "/".join(
             [
                 aws_resource_path_v04,
                 "release-pos-fast-0",
                 "en-pos-ontonotes-fast-v0.4.pt",
+            ]
+        )
+
+        model_map["pos-fast"] = "/".join(
+            [
+                hu_path,
+                "release-pos-fast-0",
+                "en-pos-ontonotes-fast-v0.5.pt",
             ]
         )
 
@@ -988,7 +1003,7 @@ class SequenceTagger(flair.nn.Model):
         )
 
         model_map["de-pos"] = "/".join(
-            [aws_resource_path_v04, "release-de-pos-0", "de-pos-ud-hdt-v0.4.pt"]
+            [hu_path, "release-de-pos-0", "de-pos-ud-hdt-v0.5.pt"]
         )
 
         model_map["de-pos-fine-grained"] = "/".join(


### PR DESCRIPTION
This PR adds fine-grained POS models for English and updates the German one. 

For English you now have the option between 'pos' and 'upos' models for fine-grained and universal dependencies respectively. Load like this: 

```python
# Fine-grained POS model
tagger = SequenceTagger.load('pos')
sentence = Sentence("The grass is green")
tagger.predict(sentence)
print(sentence.to_tagged_string())

# Fine-grained POS model (fast variant)
tagger = SequenceTagger.load('pos-fast')
sentence = Sentence("The grass is green")
tagger.predict(sentence)
print(sentence.to_tagged_string())

# Universal POS model
tagger = SequenceTagger.load('upos')
sentence = Sentence("The grass is green")
tagger.predict(sentence)
print(sentence.to_tagged_string())

# Universal POS model (fast variant)
tagger = SequenceTagger.load('upos-fast')
sentence = Sentence("The grass is green")
tagger.predict(sentence)
print(sentence.to_tagged_string())

# German POS model
tagger = SequenceTagger.load('de-pos')
sentence = Sentence("Das Gras ist grün")
tagger.predict(sentence)
print(sentence.to_tagged_string())
```

Closes #1623 #1349 