### PR TITLE
GH-1644: added case where __label__<label> and <text> are seperated w…

### DIFF
--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -174,7 +174,7 @@ class ClassificationDataset(FlairDataset):
             line = f.readline()
             position = 0
             while line:
-                if "__label__" not in line or " " not in line:
+                if "__label__" not in line or (" " not in line and "\t" not in line):
                     position = f.tell()
                     line = f.readline()
                     continue


### PR DESCRIPTION
Closes #1644 
ClassificationDataset now also accepts line with "\t" seperator additionaly to blank spaces.