### PR TITLE
Refactor evaluation

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -442,6 +442,15 @@ class Span(DataPoint):
             else '<span ({}): "{}">'.format(ids, self.text)
         )
 
+    def __getitem__(self, idx: int) -> Token:
+        return self.tokens[idx]
+
+    def __iter__(self):
+        return iter(self.tokens)
+
+    def __len__(self) -> int:
+        return len(self.tokens)
+
     @property
     def tag(self):
         return self.labels[0].value
@@ -771,6 +780,9 @@ class Sentence(DataPoint):
     def __iter__(self):
         return iter(self.tokens)
 
+    def __len__(self) -> int:
+        return len(self.tokens)
+
     def __repr__(self):
         tagged_string = self.to_tagged_string()
         tokenized_string = self.to_tokenized_string()
@@ -809,9 +821,6 @@ class Sentence(DataPoint):
         token_labels = f'  − Token-Labels: "{tagged_string}"' if tokenized_string != tagged_string else ""
 
         return f'Sentence: "{tokenized_string}"   [− Tokens: {len(self)}{token_labels}{sentence_labels}]'
-
-    def __len__(self) -> int:
-        return len(self.tokens)
 
     def get_language_code(self) -> str:
         if self.language_code is None:

--- a/flair/data.py
+++ b/flair/data.py
@@ -923,17 +923,17 @@ class Corpus:
         if test is None:
             train_length = len(train)
             test_size: int = round(train_length / 10)
-            splits = random_split(train, [train_length - test_size, test_size])
-            train = splits[0]
-            test = splits[1]
+            splits = randomly_split_into_two_datasets(train, test_size)
+            test = splits[0]
+            train = splits[1]
 
         # sample dev data if none is provided
         if dev is None:
             train_length = len(train)
             dev_size: int = round(train_length / 10)
-            splits = random_split(train, [train_length - dev_size, dev_size])
-            train = splits[0]
-            dev = splits[1]
+            splits = randomly_split_into_two_datasets(train, dev_size)
+            dev = splits[0]
+            train = splits[1]
 
         # set train dev and test data
         self._train: FlairDataset = train
@@ -1418,3 +1418,17 @@ def build_spacy_tokenizer(model) -> Callable[[str], List[Token]]:
         return tokens
 
     return tokenizer
+
+
+def randomly_split_into_two_datasets(dataset, length_of_first):
+
+    import random
+    indices = [i for i in range(len(dataset))]
+    random.shuffle(indices)
+
+    first_dataset = indices[:length_of_first]
+    second_dataset = indices[length_of_first:]
+    first_dataset.sort()
+    second_dataset.sort()
+
+    return [Subset(dataset, first_dataset), Subset(dataset, second_dataset)]

--- a/flair/data.py
+++ b/flair/data.py
@@ -1036,8 +1036,8 @@ class Corpus:
     def _downsample_to_proportion(dataset: Dataset, proportion: float):
 
         sampled_size: int = round(len(dataset) * proportion)
-        splits = random_split(dataset, [len(dataset) - sampled_size, sampled_size])
-        return splits[1]
+        splits = randomly_split_into_two_datasets(dataset, sampled_size)
+        return splits[0]
 
     def obtain_statistics(
             self, label_type: str = None, pretty_print: bool = True

--- a/flair/embeddings/base.py
+++ b/flair/embeddings/base.py
@@ -65,6 +65,12 @@ class Embeddings(torch.nn.Module):
         """Private method for adding embeddings to all words in a list of sentences."""
         pass
 
+    def get_names(self) -> List[str]:
+        """Returns a list of embedding names. In most cases, it is just a list with one item, namely the name of
+        this embedding. But in some cases, the embedding is made up by different embeddings (StackedEmbedding).
+        Then, the list contains the names of all embeddings in the stack."""
+        return [self.name]
+
 
 class ScalarMix(torch.nn.Module):
     """

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -205,15 +205,10 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
 
         self.to(flair.device)
 
-        self.pooling = pooling
-        if self.pooling == "mean":
-            self.pool_op = torch.mean
-        elif pooling == "max":
-            self.pool_op = torch.max
-        elif pooling == "min":
-            self.pool_op = torch.min
-        else:
+        if pooling not in ['min', 'max', 'mean']:
             raise ValueError(f"Pooling operation for {self.mode!r} is not defined")
+
+        self.pooling = pooling
         self.name: str = f"document_{self.pooling}"
 
     @property
@@ -245,9 +240,11 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
                 word_embeddings = self.embedding_flex_nonlinear_map(word_embeddings)
 
             if self.pooling == "mean":
-                pooled_embedding = self.pool_op(word_embeddings, 0)
-            else:
-                pooled_embedding, _ = self.pool_op(word_embeddings, 0)
+                pooled_embedding = torch.mean(word_embeddings, 0)
+            elif self.pooling == "max":
+                pooled_embedding, _ = torch.max(word_embeddings, 0)
+            elif self.pooling == "min":
+                pooled_embedding, _ = torch.min(word_embeddings, 0)
 
             sentence.set_embedding(self.name, pooled_embedding)
 

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -88,6 +88,14 @@ class StackedEmbeddings(TokenEmbeddings):
     def __str__(self):
         return f'StackedEmbeddings [{",".join([str(e) for e in self.embeddings])}]'
 
+    def get_names(self) -> List[str]:
+        """Returns a list of embedding names. In most cases, it is just a list with one item, namely the name of
+        this embedding. But in some cases, the embedding is made up by different embeddings (StackedEmbedding).
+        Then, the list contains the names of all embeddings in the stack."""
+        names = []
+        for embedding in self.embeddings:
+            names.extend(embedding.get_names())
+        return names
 
 class WordEmbeddings(TokenEmbeddings):
     """Standard static word embeddings, such as GloVe or FastText."""
@@ -784,6 +792,9 @@ class PooledFlairEmbeddings(TokenEmbeddings):
 
     def embedding_length(self) -> int:
         return self.embedding_length
+
+    def get_names(self) -> List[str]:
+        return [self.name, self.context_embeddings.name]
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -505,7 +505,7 @@ class SequenceTagger(flair.nn.Model):
 
     def evaluate(
         self,
-        sentences: Union[List[DataPoint], Dataset],
+        sentences: Union[List[Sentence], Dataset],
         out_path: Union[str, Path] = None,
         embedding_storage_mode: str = "none",
         mini_batch_size: int = 32,

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -600,12 +600,7 @@ class SequenceTagger(flair.nn.Model):
 
         self.embeddings.embed(sentences)
 
-        # if type(self.embeddings) == StackedEmbeddings:
-        #     names = [embedding.name for embedding in self.embeddings.embeddings]
         names = self.embeddings.get_names()
-        print(names)
-
-        print(self.embeddings)
 
         lengths: List[int] = [len(sentence.tokens) for sentence in sentences]
         longest_token_sequence_in_batch: int = max(lengths)

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -501,7 +501,7 @@ class SequenceTagger(flair.nn.Model):
         for class_name in metric.get_classes():
             detailed_result += (
                 f"\n{class_name:<10} tp: {metric.get_tp(class_name)} - fp: {metric.get_fp(class_name)} - "
-                f"tn: {metric.get_tn(class_name)} - precision: "
+                f"fn: {metric.get_fn(class_name)} - precision: "
                 f"{metric.precision(class_name):.4f} - recall: {metric.recall(class_name):.4f} - "
                 f"f1-score: "
                 f"{metric.f_score(class_name):.4f}"

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -479,9 +479,12 @@ class SequenceTagger(flair.nn.Model):
         eval_loss /= batch_no
 
         detailed_result = (
-            f"\nMICRO_AVG: f1-score {metric.micro_avg_f_score():.4f}"
-            f"\nMACRO_AVG: f1-score {metric.macro_avg_f_score():.4f}"
+            "\nResults:"
+            f"\n- F1-score (micro) {metric.micro_avg_f_score():.4f}"
+            f"\n- F1-score (macro) {metric.macro_avg_f_score():.4f}"
+            '\n\nBy class:'
         )
+
         for class_name in metric.get_classes():
             detailed_result += (
                 f"\n{class_name:<10} tp: {metric.get_tp(class_name)} - fp: {metric.get_fp(class_name)} - "
@@ -573,7 +576,7 @@ class SequenceTagger(flair.nn.Model):
 
         # use classification report in detailed results
         detailed_result = (
-            "Overall:"
+            "\nResults:"
             f"\n- F1-score (micro) {metrics.f1_score(y_true, y_pred, average='micro'):.4f}"
             f"\n- F1-score (macro) {metrics.f1_score(y_true, y_pred, average='macro'):.4f}"
             f"\n- Accuracy {metrics.accuracy_score(y_true, y_pred):.4f}"

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -527,7 +527,6 @@ class SequenceTagger(flair.nn.Model):
 
             # predict for batch
             loss = self.predict(batch,
-                                use_tokenizer=False,
                                 embedding_storage_mode=embedding_storage_mode,
                                 mini_batch_size=mini_batch_size,
                                 label_name='predicted',

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -410,7 +410,6 @@ class SequenceTagger(flair.nn.Model):
 
             # predict for batch
             loss = self.predict(batch,
-                                use_tokenizer=False,
                                 embedding_storage_mode=embedding_storage_mode,
                                 mini_batch_size=mini_batch_size,
                                 label_name='predicted',

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -268,7 +268,7 @@ class TextClassifier(flair.nn.Model):
             for batch in data_loader:
 
                 batch_count += 1
-                
+
                 # predict for batch
                 loss = self.predict(batch,
                                     embedding_storage_mode=embedding_storage_mode,

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -268,17 +268,20 @@ class TextClassifier(flair.nn.Model):
             for batch in data_loader:
 
                 batch_count += 1
-
-                scores = self.forward(batch)
-                predictions = self._obtain_labels(scores)
-                loss = self._calculate_loss(scores, batch)
+                
+                # predict for batch
+                loss = self.predict(batch,
+                                    embedding_storage_mode=embedding_storage_mode,
+                                    mini_batch_size=mini_batch_size,
+                                    label_name='predicted',
+                                    return_loss=True)
 
                 eval_loss += loss
 
                 sentences_for_batch = [sent.to_plain_string() for sent in batch]
 
                 true_values_for_batch = [sentence.get_labels(self.label_type) for sentence in batch]
-                available_labels = self.label_dictionary.get_items()
+                predictions = [sentence.get_labels('predicted') for sentence in batch]
 
                 for sentence, prediction, true_value in zip(
                     sentences_for_batch,

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -1,14 +1,16 @@
 from pathlib import Path
 
+from torch.utils.data.dataset import Dataset
+
 import flair
 import flair.embeddings
 import torch
 import torch.nn as nn
 from typing import List, Union
 
-from flair.datasets import DataLoader
+from flair.datasets import DataLoader, SentenceDataset
 from flair.training_utils import MetricRegression, Result, store_embeddings
-from flair.data import Sentence, Label
+from flair.data import Sentence, Label, DataPoint
 import logging
 
 log = logging.getLogger("flair")
@@ -92,10 +94,17 @@ class TextRegressor(flair.models.TextClassifier):
 
     def evaluate(
         self,
-        data_loader: DataLoader,
-        out_path: Path = None,
+        sentences: Union[List[DataPoint], Dataset],
+        out_path: Union[str, Path] = None,
         embedding_storage_mode: str = "none",
+        mini_batch_size: int = 32,
+        num_workers: int = 8,
     ) -> (Result, float):
+
+        # read Dataset into data loader (if list of sentences passed, make Dataset first)
+        if not isinstance(sentences, Dataset):
+            sentences = SentenceDataset(sentences)
+        data_loader = DataLoader(sentences, batch_size=mini_batch_size, num_workers=num_workers)
 
         with torch.no_grad():
             eval_loss = 0

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -7,9 +7,11 @@ from abc import abstractmethod
 
 from typing import Union, List
 
+from torch.utils.data.dataset import Dataset
+
 import flair
 from flair import file_utils
-from flair.data import DataPoint
+from flair.data import DataPoint, Sentence
 from flair.datasets import DataLoader
 from flair.training_utils import Result
 
@@ -28,7 +30,7 @@ class Model(torch.nn.Module):
     @abstractmethod
     def evaluate(
         self,
-        data_loader: DataLoader,
+        sentences: Union[List[DataPoint], Dataset],
         out_path: Path = None,
         embedding_storage_mode: str = "none",
     ) -> (Result, float):

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -398,11 +398,9 @@ class ModelTrainer:
 
                 if log_train:
                     train_eval_result, train_loss = self.model.evaluate(
-                        DataLoader(
-                            self.corpus.train,
-                            batch_size=mini_batch_chunk_size,
-                            num_workers=num_workers,
-                        ),
+                        self.corpus.train,
+                        mini_batch_size=mini_batch_chunk_size,
+                        num_workers=num_workers,
                         embedding_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{train_eval_result.log_line}"
@@ -412,11 +410,9 @@ class ModelTrainer:
 
                 if log_train_part:
                     train_part_eval_result, train_part_loss = self.model.evaluate(
-                        DataLoader(
-                            train_part,
-                            batch_size=mini_batch_chunk_size,
-                            num_workers=num_workers,
-                        ),
+                        train_part,
+                        mini_batch_size=mini_batch_chunk_size,
+                        num_workers=num_workers,
                         embedding_storage_mode=embeddings_storage_mode,
                     )
                     result_line += (
@@ -428,11 +424,9 @@ class ModelTrainer:
 
                 if log_dev:
                     dev_eval_result, dev_loss = self.model.evaluate(
-                        DataLoader(
-                            self.corpus.dev,
-                            batch_size=mini_batch_chunk_size,
-                            num_workers=num_workers,
-                        ),
+                        self.corpus.dev,
+                        mini_batch_size=mini_batch_chunk_size,
+                        num_workers=num_workers,
                         embedding_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{dev_loss}\t{dev_eval_result.log_line}"
@@ -457,12 +451,10 @@ class ModelTrainer:
 
                 if log_test:
                     test_eval_result, test_loss = self.model.evaluate(
-                        DataLoader(
-                            self.corpus.test,
-                            batch_size=mini_batch_chunk_size,
-                            num_workers=num_workers,
-                        ),
-                        base_path / "test.tsv",
+                        self.corpus.test,
+                        mini_batch_size=mini_batch_chunk_size,
+                        num_workers=num_workers,
+                        out_path=base_path / "test.tsv",
                         embedding_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{test_loss}\t{test_eval_result.log_line}"
@@ -624,11 +616,9 @@ class ModelTrainer:
             self.model = self.model.load(base_path / "best-model.pt")
 
         test_results, test_loss = self.model.evaluate(
-            DataLoader(
-                self.corpus.test,
-                batch_size=eval_mini_batch_size,
-                num_workers=num_workers,
-            ),
+            self.corpus.test,
+            mini_batch_size=eval_mini_batch_size,
+            num_workers=num_workers,
             out_path=base_path / "test.tsv",
             embedding_storage_mode="none",
         )
@@ -643,11 +633,9 @@ class ModelTrainer:
             for subcorpus in self.corpus.corpora:
                 log_line(log)
                 self.model.evaluate(
-                    DataLoader(
-                        subcorpus.test,
-                        batch_size=eval_mini_batch_size,
-                        num_workers=num_workers,
-                    ),
+                    subcorpus.test,
+                    mini_batch_size=eval_mini_batch_size,
+                    num_workers=num_workers,
                     out_path=base_path / f"{subcorpus.name}-test.tsv",
                     embedding_storage_mode="none",
                 )

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -16,7 +16,6 @@ import flair.datasets
 glove_embedding: WordEmbeddings = WordEmbeddings("glove")
 
 
-@pytest.mark.integration
 def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
     corpus = flair.datasets.ColumnCorpus(
         data_folder=tasks_base_path / "fashion", column_format={0: "text", 2: "ner"}

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -49,11 +49,12 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
 
     sentence = Sentence("Berlin is a really nice city.")
 
-    for s in model.predict(sentence):
-        for l in s.labels:
-            assert l.value is not None
-            assert 0.0 <= l.score <= 1.0
-            assert type(l.score) is float
+    model.predict(sentence)
+
+    for label in sentence.labels:
+        assert label.value is not None
+        assert 0.0 <= label.score <= 1.0
+        assert type(label.score) is float
 
     del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
@@ -86,12 +87,12 @@ def test_train_load_use_classifier_with_sampler(results_base_path, tasks_base_pa
     )
 
     sentence = Sentence("Berlin is a really nice city.")
+    model.predict(sentence)
 
-    for s in model.predict(sentence):
-        for l in s.labels:
-            assert l.value is not None
-            assert 0.0 <= l.score <= 1.0
-            assert type(l.score) is float
+    for label in sentence.labels:
+        assert label.value is not None
+        assert 0.0 <= label.score <= 1.0
+        assert type(label.score) is float
 
     del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
@@ -120,11 +121,12 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
 
     sentence = Sentence("Berlin is a really nice city.")
 
-    for s in model.predict(sentence, multi_class_prob=True):
-        for l in s.labels:
-            assert l.value is not None
-            assert 0.0 <= l.score <= 1.0
-            assert type(l.score) is float
+    model.predict(sentence, multi_class_prob=True)
+
+    for label in sentence.labels:
+        assert label.value is not None
+        assert 0.0 <= label.score <= 1.0
+        assert type(label.score) is float
 
     del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
@@ -161,25 +163,25 @@ def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_pat
 
     sentence = Sentence("apple tv")
 
-    for s in model.predict(sentence):
-        for l in s.labels:
-            print(l)
-            assert l.value is not None
-            assert 0.0 <= l.score <= 1.0
-            assert type(l.score) is float
+    model.predict(sentence)
+
+    for label in sentence.labels:
+        print(label)
+        assert label.value is not None
+        assert 0.0 <= label.score <= 1.0
+        assert type(label.score) is float
 
     sentence = Sentence("apple tv")
 
-    for s in model.predict(sentence):
+    model.predict(sentence)
 
-        assert "apple" in sentence.get_label_names()
-        assert "tv" in sentence.get_label_names()
+    assert "apple" in sentence.get_label_names()
+    assert "tv" in sentence.get_label_names()
 
-        for l in s.labels:
-            print(l)
-            assert l.value is not None
-            assert 0.0 <= l.score <= 1.0
-            assert type(l.score) is float
+    for label in sentence.labels:
+        assert label.value is not None
+        assert 0.0 <= label.score <= 1.0
+        assert type(label.score) is float
 
     del trainer, model, corpus
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
@@ -212,11 +214,12 @@ def test_train_load_use_classifier_flair(results_base_path, tasks_base_path):
 
     sentence = Sentence("Berlin is a really nice city.")
 
-    for s in model.predict(sentence):
-        for l in s.labels:
-            assert l.value is not None
-            assert 0.0 <= l.score <= 1.0
-            assert type(l.score) is float
+    model.predict(sentence)
+
+    for label in sentence.labels:
+        assert label.value is not None
+        assert 0.0 <= label.score <= 1.0
+        assert type(label.score) is float
 
     del trainer, model, corpus, flair_document_embeddings
     loaded_model = TextClassifier.load(results_base_path / "final-model.pt")


### PR DESCRIPTION
This PR makes a number of refactorings to the evaluation routines in Flair. In short: whenever possible, we now use the evaluation methods of sklearn (instead of our own implementations which kept getting issues). This applies to text classification and (most) sequence tagging. 

A notable exception is "span-F1" which is used to evaluate NER because there is no good way of counting true negatives. After this PR, our implementation should now exactly mirror the original `conlleval` script of the CoNLL-02 challenge. In addition to using our reimplementation, an output file is now automatically generated that can be directly used with the `conlleval` script. 

In more detail, this PR makes the following changes: 

- `Span` is now a list of `Token` and can now be iterated like a sentence
- `flair.DataLoader` is now used throughout 
- The `evaluate()` interface in the `Model` base class is changed so that it no longer requires a data loader, but ran run either over list of `Sentence` or a `Dataset`
- `SequenceTagger.evaluate()` now explicitly distinguishes between F1 and Span-F1. In the latter case, no TN are counted (closes #1663) and a non-sklearn implementation is used. 
- An unrelated serialization error is fixed in `DocumentPoolEmbeddings`

In the `evaluate()` method of the `SequenceTagger` and `TextClassifier`, we now explicitly call the `.predict() `method. To enable this, we made some changes to the `predict()` interface, namely you can now optionally specify the "label name" of the predicted label: 

```python
sentence = Sentence('I love Berlin')

tagger = SequenceTagger.load('ner')

# specify label name to be 'conll03_ner'
tagger.predict(sentence, label_name='conll03_ner')

print(sentence)
```

This may be useful if you have multiple ner taggers and wish to tag the same sentence with them. Then you can distinguish between the tags by the taggers. It is also now no longer possible to give the predict method a string - you now must pass a sentence. 

This PR also makes it possible to set seeds when loading and downsampling corpora, so that the sample is always the same: 

```python
# set a random seed 
import random
random.seed(4)

# load and downsample corpus
corpus = SENTEVAL_MR(filter_if_longer_than=50).downsample(0.1)

# print first sentence of dev and test 
print(corpus.dev[0])
print(corpus.test[0])
```

