### PR TITLE
GH-1645: change default fine-tuning in DocumentPoolEmbeddings to "none"

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -180,7 +180,7 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
     ):
         """The constructor takes a list of embeddings to be combined.
         :param embeddings: a list of token embeddings
-        :param fine_tune_mode: if set to "linear" a randomly initialized, trainable layer is added, if set to
+        :param fine_tune_mode: if set to "linear" a trainable layer is added, if set to
         "nonlinear", a nonlinearity is added as well. Set this to make the pooling trainable.
         :param pooling: a string which can any value from ['mean', 'max', 'min']
         """

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -175,11 +175,13 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
     def __init__(
         self,
         embeddings: List[TokenEmbeddings],
-        fine_tune_mode="linear",
+        fine_tune_mode: str = "none",
         pooling: str = "mean",
     ):
         """The constructor takes a list of embeddings to be combined.
         :param embeddings: a list of token embeddings
+        :param fine_tune_mode: if set to "linear" a randomly initialized, trainable layer is added, if set to
+        "nonlinear", a nonlinearity is added as well. Set this to make the pooling trainable.
         :param pooling: a string which can any value from ['mean', 'max', 'min']
         """
         super().__init__()


### PR DESCRIPTION
As discussed in #1645 there is some confusion regarding the fine-tuning layer that is initialized by default for the `DocumentPoolEmbeddings`. This PR turns this off by default (no fine-tuning) and adds some explanations to the method signature.