### PR TITLE
GH-1664: add new datasets to __init__.py

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -7,14 +7,20 @@ from .base import MongoDataset
 # Expose all sequence labeling datasets
 from .sequence_labeling import ColumnCorpus
 from .sequence_labeling import ColumnDataset
+from .sequence_labeling import BIOFID
 from .sequence_labeling import CONLL_03
 from .sequence_labeling import CONLL_03_GERMAN
 from .sequence_labeling import CONLL_03_DUTCH
-from .sequence_labeling import NER_SWEDISH
 from .sequence_labeling import CONLL_03_SPANISH
 from .sequence_labeling import CONLL_2000
 from .sequence_labeling import DANE
 from .sequence_labeling import GERMEVAL_14
+from .sequence_labeling import INSPEC
+from .sequence_labeling import NER_BASQUE
+from .sequence_labeling import NER_FINNISH
+from .sequence_labeling import NER_SWEDISH
+from .sequence_labeling import SEMEVAL2010
+from .sequence_labeling import SEMEVAL2017
 from .sequence_labeling import WIKINER_ENGLISH
 from .sequence_labeling import WIKINER_GERMAN
 from .sequence_labeling import WIKINER_DUTCH
@@ -25,19 +31,16 @@ from .sequence_labeling import WIKINER_PORTUGUESE
 from .sequence_labeling import WIKINER_POLISH
 from .sequence_labeling import WIKINER_RUSSIAN
 from .sequence_labeling import WNUT_17
-from .sequence_labeling import BIOFID
-from .sequence_labeling import NER_FINNISH
-from .sequence_labeling import INSPEC
-from .sequence_labeling import SEMEVAL2010
-from .sequence_labeling import SEMEVAL2017
 
 # Expose all document classification datasets
 from .document_classification import ClassificationCorpus
 from .document_classification import ClassificationDataset
 from .document_classification import CSVClassificationCorpus
 from .document_classification import CSVClassificationDataset
+from .document_classification import AMAZON_REVIEWS
 from .document_classification import IMDB
 from .document_classification import NEWSGROUPS
+from .document_classification import SENTIMENT_140
 from .document_classification import SENTEVAL_CR
 from .document_classification import SENTEVAL_MR
 from .document_classification import SENTEVAL_MPQA

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -267,6 +267,38 @@ class ColumnDataset(FlairDataset):
         return sentence
 
 
+class BIOFID(ColumnCorpus):
+    def __init__(
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+    ):
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "lemma", 2: "pos", 3: "ner"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        biofid_path = "https://raw.githubusercontent.com/texttechnologylab/BIOfid/master/BIOfid-Dataset-NER/"
+        cached_path(f"{biofid_path}train.conll", Path("datasets") / dataset_name)
+        cached_path(f"{biofid_path}dev.conll", Path("datasets") / dataset_name)
+        cached_path(f"{biofid_path}test.conll", Path("datasets") / dataset_name)
+
+        super(BIOFID, self).__init__(
+            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
+        )
+
+
 class CONLL_03(ColumnCorpus):
     def __init__(
             self,
@@ -414,55 +446,6 @@ class CONLL_03_DUTCH(ColumnCorpus):
             encoding="latin-1",
             in_memory=in_memory,
             document_separator_token=None if not document_as_sequence else "-DOCSTART-",
-        )
-        
-        
-class NER_SWEDISH(ColumnCorpus):
-    def __init__(
-            self,
-            base_path: Union[str, Path] = None,
-            tag_to_bioes: str = "ner",
-            in_memory: bool = True,
-    ):
-        """
-        Initialize the NER_SWEDISH corpus for Swedish. The first time you call this constructor it will automatically
-        download the dataset.
-        :param base_path: Default is None, meaning that corpus gets auto-downloaded and loaded. You can override this
-        to point to a different folder but typically this should not be necessary.
-        :param in_memory: If True, keeps dataset in memory giving speedups in training.
-        :param document_as_sequence: If True, all sentences of a document are read into a single Sentence object
-        """
-
-        if type(base_path) == str:
-            base_path: Path = Path(base_path)
-
-        # column format
-        columns = {0: "text", 1: "ner"}
-
-        # this dataset name
-        dataset_name = self.__class__.__name__.lower()
-
-        # default dataset folder is the cache root
-        if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
-        data_folder = base_path / dataset_name
-
-        # download data if necessary
-        ner_spraakbanken_path = "https://raw.githubusercontent.com/klintan/swedish-ner-corpus/master/"
-        cached_path(f"{ner_spraakbanken_path}test_corpus.txt", Path("datasets") / dataset_name)
-        cached_path(f"{ner_spraakbanken_path}train_corpus.txt", Path("datasets") / dataset_name)
-        
-       
-        #data is not in IOB2 format. Thus we transform it to IOB2
-        add_IOB2_tags(data_file=Path(data_folder / "test_corpus.txt"))
-        add_IOB2_tags(data_file=Path(data_folder / "train_corpus.txt"))
-        
-
-        super(NER_SWEDISH, self).__init__(
-            data_folder,
-            columns,
-            tag_to_bioes=tag_to_bioes,
-            in_memory=in_memory,
         )
         
         
@@ -723,6 +706,41 @@ class GERMEVAL_14(ColumnCorpus):
         )
 
 
+class INSPEC(ColumnCorpus):
+    def __init__(
+        self,
+        base_path: Union[str, Path] = None,
+        tag_to_bioes: str = "keyword",
+        in_memory: bool = True,
+    ):
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "keyword"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        inspec_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/Inspec"
+        cached_path(f"{inspec_path}/train.txt", Path("datasets") / dataset_name)
+        cached_path(f"{inspec_path}/test.txt", Path("datasets") / dataset_name)
+        if not "dev.txt" in os.listdir(data_folder):
+            cached_path(f"{inspec_path}/valid.txt", Path("datasets") / dataset_name)
+            #rename according to train - test - dev - convention
+            os.rename(data_folder / "valid.txt", data_folder / "dev.txt")
+
+        super(INSPEC, self).__init__(
+            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
+        )
+
+
 class NER_BASQUE(ColumnCorpus):
     def __init__(
             self,
@@ -812,6 +830,115 @@ def _remove_lines_without_annotations(data_file: Union[str, Path] = None):
                 if len(line.split()) != 1:
                     f.write(line)
 
+
+class NER_SWEDISH(ColumnCorpus):
+    def __init__(
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+    ):
+        """
+        Initialize the NER_SWEDISH corpus for Swedish. The first time you call this constructor it will automatically
+        download the dataset.
+        :param base_path: Default is None, meaning that corpus gets auto-downloaded and loaded. You can override this
+        to point to a different folder but typically this should not be necessary.
+        :param in_memory: If True, keeps dataset in memory giving speedups in training.
+        :param document_as_sequence: If True, all sentences of a document are read into a single Sentence object
+        """
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "ner"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        ner_spraakbanken_path = "https://raw.githubusercontent.com/klintan/swedish-ner-corpus/master/"
+        cached_path(f"{ner_spraakbanken_path}test_corpus.txt", Path("datasets") / dataset_name)
+        cached_path(f"{ner_spraakbanken_path}train_corpus.txt", Path("datasets") / dataset_name)
+
+        # data is not in IOB2 format. Thus we transform it to IOB2
+        add_IOB2_tags(data_file=Path(data_folder / "test_corpus.txt"))
+        add_IOB2_tags(data_file=Path(data_folder / "train_corpus.txt"))
+
+        super(NER_SWEDISH, self).__init__(
+            data_folder,
+            columns,
+            tag_to_bioes=tag_to_bioes,
+            in_memory=in_memory,
+        )
+
+
+class SEMEVAL2017(ColumnCorpus):
+    def __init__(
+        self,
+        base_path: Union[str, Path] = None,
+        tag_to_bioes: str = "keyword",
+        in_memory: bool = True,
+    ):
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "keyword"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        semeval2017_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/SemEval-2017"
+        cached_path(f"{semeval2017_path}/train.txt", Path("datasets") / dataset_name)
+        cached_path(f"{semeval2017_path}/test.txt", Path("datasets") / dataset_name)
+        cached_path(f"{semeval2017_path}/dev.txt", Path("datasets") / dataset_name)
+
+        super(SEMEVAL2017, self).__init__(
+            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
+        )
+
+
+class SEMEVAL2010(ColumnCorpus):
+    def __init__(
+        self,
+        base_path: Union[str, Path] = None,
+        tag_to_bioes: str = "keyword",
+        in_memory: bool = True,
+    ):
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "keyword"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        semeval2010_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/processed_semeval-2010"
+        cached_path(f"{semeval2010_path}/train.txt", Path("datasets") / dataset_name)
+        cached_path(f"{semeval2010_path}/test.txt", Path("datasets") / dataset_name)
+
+        super(SEMEVAL2010, self).__init__(
+            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
+        )
 
 
 class WIKINER_ENGLISH(ColumnCorpus):
@@ -1108,133 +1235,6 @@ class WNUT_17(ColumnCorpus):
             data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
         )
 
-
-class BIOFID(ColumnCorpus):
-    def __init__(
-            self,
-            base_path: Union[str, Path] = None,
-            tag_to_bioes: str = "ner",
-            in_memory: bool = True,
-    ):
-        if type(base_path) == str:
-            base_path: Path = Path(base_path)
-
-        # column format
-        columns = {0: "text", 1: "lemma", 2: "pos", 3: "ner"}
-
-        # this dataset name
-        dataset_name = self.__class__.__name__.lower()
-
-        # default dataset folder is the cache root
-        if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
-        data_folder = base_path / dataset_name
-
-        # download data if necessary
-        biofid_path = "https://raw.githubusercontent.com/texttechnologylab/BIOfid/master/BIOfid-Dataset-NER/"
-        cached_path(f"{biofid_path}train.conll", Path("datasets") / dataset_name)
-        cached_path(f"{biofid_path}dev.conll", Path("datasets") / dataset_name)
-        cached_path(f"{biofid_path}test.conll", Path("datasets") / dataset_name)
-
-        super(BIOFID, self).__init__(
-            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
-        )
-
-class INSPEC(ColumnCorpus):
-    def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "keyword",
-        in_memory: bool = True,
-    ):
-
-        if type(base_path) == str:
-            base_path: Path = Path(base_path)
-
-        # column format
-        columns = {0: "text", 1: "keyword"}
-
-        # this dataset name
-        dataset_name = self.__class__.__name__.lower()
-
-        # default dataset folder is the cache root
-        if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
-        data_folder = base_path / dataset_name
-
-        inspec_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/Inspec"
-        cached_path(f"{inspec_path}/train.txt", Path("datasets") / dataset_name)
-        cached_path(f"{inspec_path}/test.txt", Path("datasets") / dataset_name)
-        if not "dev.txt" in os.listdir(data_folder):
-            cached_path(f"{inspec_path}/valid.txt", Path("datasets") / dataset_name)
-            #rename according to train - test - dev - convention
-            os.rename(data_folder / "valid.txt", data_folder / "dev.txt")
-
-        super(INSPEC, self).__init__(
-            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
-        )
-
-
-class SEMEVAL2017(ColumnCorpus):
-    def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "keyword",
-        in_memory: bool = True,
-    ):
-
-        if type(base_path) == str:
-            base_path: Path = Path(base_path)
-
-        # column format
-        columns = {0: "text", 1: "keyword"}
-
-        # this dataset name
-        dataset_name = self.__class__.__name__.lower()
-
-        # default dataset folder is the cache root
-        if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
-        data_folder = base_path / dataset_name
-
-        semeval2017_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/SemEval-2017"
-        cached_path(f"{semeval2017_path}/train.txt", Path("datasets") / dataset_name)
-        cached_path(f"{semeval2017_path}/test.txt", Path("datasets") / dataset_name)
-        cached_path(f"{semeval2017_path}/dev.txt", Path("datasets") / dataset_name)
-
-        super(SEMEVAL2017, self).__init__(
-            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
-        )
-
-class SEMEVAL2010(ColumnCorpus):
-    def __init__(
-        self,
-        base_path: Union[str, Path] = None,
-        tag_to_bioes: str = "keyword",
-        in_memory: bool = True,
-    ):
-
-        if type(base_path) == str:
-            base_path: Path = Path(base_path)
-
-        # column format
-        columns = {0: "text", 1: "keyword"}
-
-        # this dataset name
-        dataset_name = self.__class__.__name__.lower()
-
-        # default dataset folder is the cache root
-        if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
-        data_folder = base_path / dataset_name
-
-        semeval2010_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/processed_semeval-2010"
-        cached_path(f"{semeval2010_path}/train.txt", Path("datasets") / dataset_name)
-        cached_path(f"{semeval2010_path}/test.txt", Path("datasets") / dataset_name)
-
-        super(SEMEVAL2010, self).__init__(
-            data_folder, columns, tag_to_bioes=tag_to_bioes, in_memory=in_memory
-        )
 
 def _download_wikiner(language_code: str, dataset_name: str):
     # download data if necessary


### PR DESCRIPTION
This PR adds SENTIMENT_140 and AMAZON_REVIEWS to the datasets.__init__.py so that they can be loaded like this: 

```python
corpus = flair.datasets.SENTIMENT_140()
```

Also rearranges datasets in alphabetical order in the code.

Closes #1664 