### PR TITLE
GH-1604: deserialize to CPU and move to GPU to avoid error #1604

### DIFF
--- a/flair/nn.py
+++ b/flair/nn.py
@@ -85,7 +85,7 @@ class Model(torch.nn.Module):
             # load_big_file is a workaround by https://github.com/highway11git to load models on some Mac/Windows setups
             # see https://github.com/zalandoresearch/flair/issues/351
             f = file_utils.load_big_file(str(model_file))
-            state = torch.load(f, map_location=flair.device)
+            state = torch.load(f, map_location='cpu')
 
         model = cls._init_model_with_state_dict(state)
 


### PR DESCRIPTION
Closes #1604 