### PR TITLE
GH-1365: add two new dutch NER models

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1128,7 +1128,10 @@ class SequenceTagger(flair.nn.Model):
             [aws_resource_path_v04, "release-fr-ner-0", "fr-ner-wikiner-0.4.pt"]
         )
         model_map["nl-ner"] = "/".join(
-            [aws_resource_path_v04, "NER-conll2002-dutch", "nl-ner-conll02-v0.1.pt"]
+            [hu_path, "dutch-ner_0", "nl-ner-bert-conll02-v0.5.pt"]
+        )
+        model_map["nl-ner-rnn"] = "/".join(
+            [hu_path, "dutch-ner-flair-0", "nl-ner-conll02-v0.5.pt"]
         )
         model_map["ml-pos"] = "https://raw.githubusercontent.com/qburst/models-repository/master/FlairMalayalamModels/malayalam-xpos-model.pt"
         model_map["ml-upos"] = "https://raw.githubusercontent.com/qburst/models-repository/master/FlairMalayalamModels/malayalam-upos-model.pt"


### PR DESCRIPTION
This PR adds two new models for Dutch NER and so closes #1365 

The new default model is a BERT-based RNN model with the highest accuracy: 

```python
from flair.data import Sentence
from flair.models import SequenceTagger

# load the default BERT-based model
tagger = SequenceTagger.load('nl-ner')

# tag sentence
sentence = Sentence('Ik hou van Amsterdam')
tagger.predict(sentence)
```

You can also load a Flair-based RNN model (might be faster on some setups): 

```python
# load the default BERT-based model
tagger = SequenceTagger.load('nl-ner-rnn')
```