### PR TITLE
resolve issues caused by embedding mode and lambda functions in ELMoEmbeddings in Release 0.5

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1616,9 +1616,9 @@ class ELMoEmbeddings(TokenEmbeddings):
                 options_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_options.json"
                 weight_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_weights_PubMed_only.hdf5"
         
-        # all ELMoEmbeddings before Release 0.5 used all layers
-        self.embedding_mode_fn = self.use_layers_all
-        if embedding_mode == "top":
+        if embedding_mode == "all":
+            self.embedding_mode_fn = self.use_layers_all
+        elif embedding_mode == "top":
             self.embedding_mode_fn = self.use_layers_top 
         elif embedding_mode == "average":
             self.embedding_mode_fn = self.use_layers_average   
@@ -1659,7 +1659,10 @@ class ELMoEmbeddings(TokenEmbeddings):
         return torch.mean(torch.stack(x), 0)
         
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
-
+        # ELMoEmbeddings before Release 0.5 did not set self.embedding_mode_fn
+        if not getattr(self, "embedding_mode_fn", None):
+            self.embedding_mode_fn = self.use_layers_all
+            
         sentence_words: List[List[str]] = []
         for sentence in sentences:
             sentence_words.append([token.text for token in sentence])

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1612,7 +1612,8 @@ class ELMoEmbeddings(TokenEmbeddings):
                     torch.FloatTensor(sentence_embeddings[1, token_idx, :]),
                     torch.FloatTensor(sentence_embeddings[2, token_idx, :])
                 ]
-                word_embedding = self.embedding_mode_fn(elmo_embedding_layers)
+                #word_embedding = self.embedding_mode_fn(elmo_embedding_layers)
+                word_embedding = torch.cat(elmo_embedding_layers, 0)
                 token.set_embedding(self.name, word_embedding)
 
         return sentences

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1560,14 +1560,14 @@ class ELMoEmbeddings(TokenEmbeddings):
             if model == "pubmed":
                 options_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_options.json"
                 weight_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_weights_PubMed_only.hdf5"
-
+        '''
         if embedding_mode == "all":
             self.embedding_mode_fn = lambda x: torch.cat(x, 0)
         elif embedding_mode == "top":
             self.embedding_mode_fn = lambda x: x[-1]
         elif embedding_mode == "average":
             self.embedding_mode_fn = lambda x: torch.mean(torch.stack(x), 0)
-
+        '''
         # put on Cuda if available
         from flair import device
 


### PR DESCRIPTION
Made this PR to address issues #1618 and #1634 . Replaced the lambda functions in ELMoEmbeddings class (in token.py) with three instance methods. Also added lines inside _add_embeddings_internal to check that if embedding_mode_fn exists, if not, assign it to be the embedding mode function for all layers to prevent "AttributeError: 'ELMoEmbeddings' object has no attribute 'embedding_mode_fn'".