### PR TITLE
fix condition to assign whitespace_after attribute in the build_spacy_tokenizer wraper

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1411,8 +1411,7 @@ def build_spacy_tokenizer(model) -> Callable[[str], List[Token]]:
             tokens.append(token)
 
             if (previous_token is not None) and (
-                    token.start_pos - 1
-                    == previous_token.start_pos + len(previous_token.text)
+                token.start_pos == previous_token.start_pos + len(previous_token.text)
             ):
                 previous_token.whitespace_after = False
 


### PR DESCRIPTION
The old condition assigned False to whitespace_after when there is actually a whitespace after the token.

