### PR TITLE
GH-1709: fix error in returning multiple classes

### DIFF
--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -231,7 +231,7 @@ class TextClassifier(flair.nn.Model):
 
                 for (sentence, labels) in zip(batch, predicted_labels):
                     for label in labels:
-                        if self.multi_label:
+                        if self.multi_label or multi_class_prob:
                             sentence.add_label(label_name, label.value, label.score)
                         else:
                             sentence.set_label(label_name, label.value, label.score)

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -123,6 +123,8 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
 
     model.predict(sentence, multi_class_prob=True)
 
+    assert len(sentence.labels) > 1
+
     for label in sentence.labels:
         assert label.value is not None
         assert 0.0 <= label.score <= 1.0


### PR DESCRIPTION
Fixes #1709 so that all label probabilities are output in TextClassifier.