### PR TITLE
🤗 Transformers: Update to latest 3.0.0 version

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -6,8 +6,6 @@ import torch
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 from transformers import BertTokenizer, AlbertTokenizer, AutoTokenizer, AutoConfig, AutoModel
 
-from sentence_transformers import SentenceTransformer
-
 import flair
 from flair.data import Sentence
 from flair.embeddings.base import Embeddings, ScalarMix
@@ -532,6 +530,18 @@ class SentenceTransformerDocumentEmbeddings(DocumentEmbeddings):
         :param convert_to_numpy: bool whether the encode() returns a numpy array or PyTorch tensor
         """
         super().__init__()
+
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ModuleNotFoundError:
+            log.warning("-" * 100)
+            log.warning('ATTENTION! The library "sentence-transformers" is not installed!')
+            log.warning(
+                'To use Sentence Transformers, please first install with "pip install sentence-transformers"'
+            )
+            log.warning("-" * 100)
+            pass
+
         self.model = SentenceTransformer(model)
         self.name = 'sentence-transformers-' + str(model)
         self.batch_size = batch_size

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -954,10 +954,10 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
             while subtoken_ids_sentence:
                 nr_sentence_parts += 1
-                encoded_inputs = self.tokenizer.prepare_for_model(subtoken_ids_sentence,
-                                                                  max_length=self.max_subtokens_sequence_length,
-                                                                  stride=self.stride,
-                                                                  return_overflowing_tokens=self.allow_long_sentences)
+                encoded_inputs = self.tokenizer.encode_plus(subtoken_ids_sentence,
+                                                            max_length=self.max_subtokens_sequence_length,
+                                                            stride=self.stride,
+                                                            return_overflowing_tokens=self.allow_long_sentences)
 
                 subtoken_ids_split_sentence = encoded_inputs['input_ids']
                 subtokenized_sentences.append(torch.tensor(subtoken_ids_split_sentence, dtype=torch.long))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.1.1
 transformers>=3.0.0
-sentence-transformers>=0.2.6.1
 bpemb>=0.2.9
 regex
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ scikit-learn>=0.21.3
 sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.1.1
-transformers>=2.10.0
+transformers>=3.0.0
 sentence-transformers>=0.2.6.1
 bpemb>=0.2.9
 regex


### PR DESCRIPTION
Hi,

this PR updates the awesome 🤗 Transformers to latest 3.0.0 version, see release noted [here](https://github.com/huggingface/transformers/releases/tag/v3.0.0).

In version >= 3.0.0 the `prepare_for_model` method was removed, `encode_plus` should be used instead, see #1726 .

This PR fixes it :) I couldn't see any performance degradation when training one epoch for CoNLL-2003 in comparison to the `prepare_for_model` method.