### PR TITLE
ELMoEmbeddings: pin 0.9.0 of allennlp

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1612,7 +1612,7 @@ class ELMoEmbeddings(TokenEmbeddings):
             log.warning("-" * 100)
             log.warning('ATTENTION! The library "allennlp" is not installed!')
             log.warning(
-                'To use ELMoEmbeddings, please first install with "pip install allennlp"'
+                'To use ELMoEmbeddings, please first install with "pip install allennlp==0.9.0"'
             )
             log.warning("-" * 100)
             pass


### PR DESCRIPTION
Hi,

this PR updates the installation instructions for `allennlp` library in `ELMoEmbeddings`.

Versions >= *0.9.2* no longer support `allennlp.commands.elmo`, so `ELMoEmbeddings` can't be used then.

Fixes #1729.