### PR TITLE
Add supports for additional Japanese tokenizers.

### DIFF
--- a/flair/tokenization.py
+++ b/flair/tokenization.py
@@ -167,17 +167,21 @@ class SpaceTokenizer(Tokenizer):
 class JapaneseTokenizer(Tokenizer):
     """
         Tokenizer using konoha, a third party library which supports
-        multiple Japanese tokenizer such as MeCab, KyTea and SudachiPy.
+        multiple Japanese tokenizer such as MeCab, Janome and SudachiPy.
 
         For further details see:
             https://github.com/himkt/konoha
     """
 
-    def __init__(self, tokenizer: str):
+    def __init__(self, tokenizer: str, sudachi_mode: str="A"):
         super(JapaneseTokenizer, self).__init__()
 
-        if tokenizer.lower() != "mecab":
-            raise NotImplementedError("Currently, MeCab is only supported.")
+        available_tokenizers = ["mecab", "janome", "sudachi"]
+
+        if tokenizer.lower() not in available_tokenizers:
+            raise NotImplementedError(
+                f"Currently, {tokenizer} is only supported. Supported tokenizers: {available_tokenizers}."
+            )
 
         try:
             import konoha
@@ -185,18 +189,16 @@ class JapaneseTokenizer(Tokenizer):
             log.warning("-" * 100)
             log.warning('ATTENTION! The library "konoha" is not installed!')
             log.warning(
-                'To use Japanese tokenizer, please first install with the following steps:'
+                '- If you want to use MeCab, install mecab with "sudo apt install mecab libmecab-dev mecab-ipadic".'
             )
-            log.warning(
-                '- Install mecab with "sudo apt install mecab libmecab-dev mecab-ipadic"'
-            )
-            log.warning('- Install konoha with "pip install konoha[mecab]"')
+            log.warning('- Install konoha with "pip install konoha[{tokenizer_name}]"')
+            log.warning('  - You can choose tokenizer from ["mecab", "janome", "sudachi"].')
             log.warning("-" * 100)
-            pass
+            exit()
 
         self.tokenizer = tokenizer
         self.sentence_tokenizer = konoha.SentenceTokenizer()
-        self.word_tokenizer = konoha.WordTokenizer(tokenizer)
+        self.word_tokenizer = konoha.WordTokenizer(tokenizer, mode=sudachi_mode)
 
     def tokenize(self, text: str) -> List[Token]:
         tokens: List[Token] = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ regex
 tabulate
 langdetect
 sentencepiece!=0.1.92
+konoha[janome]<5.0.0,>=4.0.0

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -83,10 +83,8 @@ def test_create_sentence_with_spacy_tokenizer():
     assert "." == sentence.tokens[3].text
 
 
-# skip because it is optional https://github.com/flairNLP/flair/pull/1296
-@pytest.mark.skip(reason="JapaneseTokenizer need optional requirements, so we skip the test by default")
 def test_create_sentence_using_japanese_tokenizer():
-    sentence: Sentence = Sentence("私はベルリンが好き", use_tokenizer=JapaneseTokenizer("mecab"))
+    sentence: Sentence = Sentence("私はベルリンが好き", use_tokenizer=JapaneseTokenizer("janome"))
 
     assert 5 == len(sentence.tokens)
     assert "私" == sentence.tokens[0].text


### PR DESCRIPTION
Related: #1296

Hello all! I'm the author of #1267 
Recently, I updated konoha adding supports for new tokenizers.
In this PR, I add supports for two Japanese tokenizers to flair.tokenization.JapaneseTokenizer; [Janome](https://github.com/mocobeta/janome) and [SudachiPy](https://github.com/WorksApplications/SudachiPy).

These tokenizers work without building any external software outside `pip install`.
So I'm wondering if I can add support for built-in Japanese tokenization to flair.
(Of course, it's not a strong opinion. I'd like feedback from the flair team!)

I attach examples for using JapaneseTokenizer in some cases:

## Case1. New available tokenizers for Japanese!: Janome and SudachiPy

```
> python                                                                                                                                                                                                                                                                                                                                     (feat/support-japanese-tokenizers| ● 3)
Python 3.8.5 (default, Jul 24 2020, 16:45:21)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import flair
>>> print(flair.data.Sentence("私はベルリンが好き", use_tokenizer=flair.tokenization.JapaneseTokenizer("janome")))
Sentence: "私 は ベルリン が 好き"   [− Tokens: 5]
>>> print(flair.data.Sentence("高輪ゲートウェイ駅", use_tokenizer=flair.tokenization.JapaneseTokenizer("sudachi", sudachi_mode="A")))
Sentence: "高輪 ゲートウェイ 駅"   [− Tokens: 3]
>>> print(flair.data.Sentence("高輪ゲートウェイ駅", use_tokenizer=flair.tokenization.JapaneseTokenizer("sudachi", sudachi_mode="C")))
Sentence: "高輪ゲートウェイ駅"   [− Tokens: 1]
```

## Case2. If it doesn't install konoha, the library for Japanese tokenizer. (almost the same as current message)

```
> python                                                                                                                                                                                                                                                                                                                                     (feat/support-japanese-tokenizers| ● 3)
Python 3.8.5 (default, Jul 24 2020, 16:45:21)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import flair
>>> print(flair.data.Sentence("高輪ゲートウェイ駅", use_tokenizer=flair.tokenization.JapaneseTokenizer("janome")))
2020-07-31 01:15:32,426 ----------------------------------------------------------------------------------------------------
2020-07-31 01:15:32,426 ATTENTION! The library "konoha" is not installed!
2020-07-31 01:15:32,426 - If you want to use MeCab, install mecab with "sudo apt install mecab libmecab-dev mecab-ipadic".
2020-07-31 01:15:32,426 - Install konoha with "pip install konoha[{tokenizer_name}]"
2020-07-31 01:15:32,426   - You can choose tokenizer from ["mecab", "janome", "sudachi"].
2020-07-31 01:15:32,426 ----------------------------------------------------------------------------------------------------
```


## Case3. If users specify a tokenizer which is not supported.

```
> python                                                                                                                                                                                                                                                                                                                                     (feat/support-japanese-tokenizers| ● 3)
Python 3.8.5 (default, Jul 24 2020, 16:45:21)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import flair
>>> print(flair.data.Sentence("高輪ゲートウェイ駅", use_tokenizer=flair.tokenization.JapaneseTokenizer("unknown_tokenizer")))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/makoto-hiramatsu/work/github.com/himkt/flair/flair/tokenization.py", line 182, in __init__
    raise NotImplementedError(
NotImplementedError: Currently, unknown_tokenizer is only supported. Supported tokenizers: ['mecab', 'janome', 'sudachi'].
```

Thanks as always for maintaining flair,