### PR TITLE
Add Portuguese Clinical POS model by @LucasFerroHAILab

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -97,6 +97,7 @@ class StackedEmbeddings(TokenEmbeddings):
             names.extend(embedding.get_names())
         return names
 
+
 class WordEmbeddings(TokenEmbeddings):
     """Standard static word embeddings, such as GloVe or FastText."""
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1136,6 +1136,10 @@ class SequenceTagger(flair.nn.Model):
         model_map["ml-pos"] = "https://raw.githubusercontent.com/qburst/models-repository/master/FlairMalayalamModels/malayalam-xpos-model.pt"
         model_map["ml-upos"] = "https://raw.githubusercontent.com/qburst/models-repository/master/FlairMalayalamModels/malayalam-upos-model.pt"
 
+        model_map["pt-pos-clinical"] = "/".join(
+            [hu_path, "clinical-pos-pt", "pucpr-flair-clinical-pos-tagging-best-model.pt"]
+        )
+
         model_map["keyphrase"] = "/".join(
             [hu_path, "keyphrase-semeval2017-scibert", "keyphrase-en-scibert.pt"]
         )

--- a/resources/docs/TUTORIAL_2_TAGGING.md
+++ b/resources/docs/TUTORIAL_2_TAGGING.md
@@ -151,6 +151,7 @@ Thanks to our contributors we are also able to distribute a couple of models for
 | 'da-pos' | Named Entity Recognition |  [Danish Dependency Treebank](https://github.com/UniversalDependencies/UD_Danish-DDT/blob/master/README.md)  |  | [AmaliePauli](https://github.com/AmaliePauli) |
 | 'ml-pos' | Part-of-Speech Tagging (fine-grained) |  30000 Malayalam sentences  | **83** | [sabiqueqb](https://github.com/sabiqueqb) |
 | 'ml-upos' | Part-of-Speech Tagging (universal)| 30000 Malayalam sentences | **87** | [sabiqueqb](https://github.com/sabiqueqb) |
+| 'pt-pos-clinical' | Part-of-Speech Tagging (fine-grained) for clinical texts | [PUCPR](https://github.com/HAILab-PUCPR/portuguese-clinical-pos-tagger) | **92.39** | [LucasFerroHAILab](https://github.com/LucasFerroHAILab) |
 
 
 ### Tagging a German sentence


### PR DESCRIPTION
@LucasFerroHAILab shared a model for POS tagging on Portuguese Clinical Texts with us. You can now load the model with: 

```python
# load your tagger
tagger = SequenceTagger.load('pt-pos-clinical')

# example sentence
sentence = Sentence('O vírus Covid causa fortes dores .')
tagger.predict(sentence)
print(sentence)
```

The model was trained on PUCPR, with an accuracy of 92.39. You can find all information in [their repo](https://github.com/HAILab-PUCPR/portuguese-clinical-pos-tagger) and their paper [Defining a state-of-the-art POS-tagging environment for Brazilian Portuguese clinical texts](https://link.springer.com/article/10.1007/s42600-020-00067-7). Please cite the paper when using the model. 

Thanks @LucasFerroHAILab for sharing the model!