### PR TITLE
BytePairEmbedding serialization

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1553,6 +1553,37 @@ class BPEmbSerializable(BPEmb):
         state["spm"] = sentencepiece_load(self.model_file)
 
 
+class _BPEmbSerializable(BPEmb):
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # save the sentence piece model as binary file (not as path which may change)
+        state["spm_model_binary"] = open(self.model_file, mode="rb").read()
+        state["spm"] = None
+        return state
+
+    def __setstate__(self, state):
+        from bpemb.util import sentencepiece_load
+
+        model_file = self.model_tpl.format(lang=state["lang"], vs=state["vs"])
+        self.__dict__ = state
+
+        # write out the binary sentence piece model into the expected directory
+        self.cache_dir: Path = Path(flair.cache_root) / "embeddings"
+        if "spm_model_binary" in self.__dict__:
+            # if the model was saved as binary and it is not found on disk, write to appropriate path
+            if not os.path.exists(self.cache_dir / state["lang"]):
+                os.makedirs(self.cache_dir / state["lang"])
+            self.model_file = self.cache_dir / model_file
+            with open(self.model_file, "wb") as out:
+                out.write(self.__dict__["spm_model_binary"])
+        else:
+            # otherwise, use normal process and potentially trigger another download
+            self.model_file = self._load_file(model_file)
+
+        # once the modes if there, load it with sentence piece
+        state["spm"] = sentencepiece_load(self.model_file)
+
+
 class BytePairEmbeddings(TokenEmbeddings):
     def __init__(
         self,
@@ -1575,7 +1606,7 @@ class BytePairEmbeddings(TokenEmbeddings):
             ), "Need to specify model_file_path and embedding_file_path if no language is given in BytePairEmbeddings(...)"
             dim=None
 
-        self.embedder = BPEmb(
+        self.embedder = _BPEmbSerializable(
             lang=language,
             vs=syllables,
             dim=dim,

--- a/train.py
+++ b/train.py
@@ -19,6 +19,7 @@ print(corpus)
 # 2. what tag do we want to predict?
 tag_type = "upos"
 
+
 # 3. make the tag dictionary from the corpus
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 print(tag_dictionary.idx2item)

--- a/train.py
+++ b/train.py
@@ -19,7 +19,6 @@ print(corpus)
 # 2. what tag do we want to predict?
 tag_type = "upos"
 
-
 # 3. make the tag dictionary from the corpus
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 print(tag_dictionary.idx2item)

--- a/train.py
+++ b/train.py
@@ -50,6 +50,6 @@ trainer.train(
     "resources/taggers/bpe-test",
     learning_rate=0.1,
     mini_batch_size=4,
-    max_epochs=20,
+    max_epochs=10,
     shuffle=True,
 )

--- a/train.py
+++ b/train.py
@@ -2,15 +2,21 @@ from typing import List
 
 import flair.datasets
 from flair.data import Corpus
+
+import flair
+flair.cache_root = 'hallo/'
+print(flair.cache_root)
+print(flair.device)
+flair.device = 'cpu'
+print(flair.device)
+import flair
+print(flair.device)
+print(flair.cache_root)
 from flair.embeddings import (
     TokenEmbeddings,
-    WordEmbeddings,
     StackedEmbeddings,
-    FlairEmbeddings,
-    CharacterEmbeddings, BytePairEmbeddings,
+    BytePairEmbeddings,
 )
-from flair.training_utils import EvaluationMetric
-from flair.visual.training_curves import Plotter
 
 # 1. get the corpus
 corpus: Corpus = flair.datasets.UD_ENGLISH().downsample(0.01)
@@ -25,7 +31,7 @@ print(tag_dictionary.idx2item)
 
 # initialize embeddings
 embedding_types: List[TokenEmbeddings] = [
-    BytePairEmbeddings("en"),
+    BytePairEmbeddings("en", cache_dir='different_cache/'),
 ]
 
 embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)

--- a/train.py
+++ b/train.py
@@ -49,7 +49,7 @@ trainer: ModelTrainer = ModelTrainer(tagger, corpus)
 trainer.train(
     "resources/taggers/bpe-test",
     learning_rate=0.1,
-    mini_batch_size=32,
+    mini_batch_size=4,
     max_epochs=20,
-    shuffle=False,
+    shuffle=True,
 )

--- a/train.py
+++ b/train.py
@@ -2,24 +2,18 @@ from typing import List
 
 import flair.datasets
 from flair.data import Corpus
-
-import flair
-flair.cache_root = 'hallo/'
-print(flair.cache_root)
-print(flair.device)
-flair.device = 'cpu'
-print(flair.device)
-import flair
-print(flair.device)
-print(flair.cache_root)
 from flair.embeddings import (
     TokenEmbeddings,
+    WordEmbeddings,
     StackedEmbeddings,
-    BytePairEmbeddings,
+    FlairEmbeddings,
+    CharacterEmbeddings,
 )
+from flair.training_utils import EvaluationMetric
+from flair.visual.training_curves import Plotter
 
 # 1. get the corpus
-corpus: Corpus = flair.datasets.UD_ENGLISH().downsample(0.01)
+corpus: Corpus = flair.datasets.UD_ENGLISH()
 print(corpus)
 
 # 2. what tag do we want to predict?
@@ -31,7 +25,14 @@ print(tag_dictionary.idx2item)
 
 # initialize embeddings
 embedding_types: List[TokenEmbeddings] = [
-    BytePairEmbeddings("en", cache_dir='different_cache/'),
+    WordEmbeddings("glove"),
+    # comment in this line to use character embeddings
+    # CharacterEmbeddings(),
+    # comment in these lines to use contextual string embeddings
+    #
+    # FlairEmbeddings('news-forward'),
+    #
+    # FlairEmbeddings('news-backward'),
 ]
 
 embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)
@@ -53,9 +54,13 @@ from flair.trainers import ModelTrainer
 trainer: ModelTrainer = ModelTrainer(tagger, corpus)
 
 trainer.train(
-    "resources/taggers/bpe-test",
+    "resources/taggers/example-ner",
     learning_rate=0.1,
-    mini_batch_size=4,
-    max_epochs=10,
-    shuffle=True,
+    mini_batch_size=32,
+    max_epochs=20,
+    shuffle=False,
 )
+
+plotter = Plotter()
+plotter.plot_training_curves("resources/taggers/example-ner/loss.tsv")
+plotter.plot_weights("resources/taggers/example-ner/weights.txt")

--- a/train.py
+++ b/train.py
@@ -7,13 +7,13 @@ from flair.embeddings import (
     WordEmbeddings,
     StackedEmbeddings,
     FlairEmbeddings,
-    CharacterEmbeddings,
+    CharacterEmbeddings, BytePairEmbeddings,
 )
 from flair.training_utils import EvaluationMetric
 from flair.visual.training_curves import Plotter
 
 # 1. get the corpus
-corpus: Corpus = flair.datasets.UD_ENGLISH()
+corpus: Corpus = flair.datasets.UD_ENGLISH().downsample(0.01)
 print(corpus)
 
 # 2. what tag do we want to predict?
@@ -25,14 +25,7 @@ print(tag_dictionary.idx2item)
 
 # initialize embeddings
 embedding_types: List[TokenEmbeddings] = [
-    WordEmbeddings("glove"),
-    # comment in this line to use character embeddings
-    # CharacterEmbeddings(),
-    # comment in these lines to use contextual string embeddings
-    #
-    # FlairEmbeddings('news-forward'),
-    #
-    # FlairEmbeddings('news-backward'),
+    BytePairEmbeddings("en"),
 ]
 
 embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)
@@ -54,13 +47,9 @@ from flair.trainers import ModelTrainer
 trainer: ModelTrainer = ModelTrainer(tagger, corpus)
 
 trainer.train(
-    "resources/taggers/example-ner",
+    "resources/taggers/bpe-test",
     learning_rate=0.1,
     mini_batch_size=32,
     max_epochs=20,
     shuffle=False,
 )
-
-plotter = Plotter()
-plotter.plot_training_curves("resources/taggers/example-ner/loss.tsv")
-plotter.plot_weights("resources/taggers/example-ner/weights.txt")


### PR DESCRIPTION
This PR addresses errors that occur when training a model with byte pair embeddings on one machine and loading this model on another. Also addresses the problem that the cache dir could not be overwritten. See #1563 and #1483

Closes #1563 
Closes #1483

I tested this on a setup with two linux machines and it seems to work, though cross-OS tests were not done.