### PR TITLE
GH-1753: Fix issues with loading models that use ELMoEmbeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -105,6 +105,7 @@ class StackedEmbeddings(TokenEmbeddings):
 
         return named_embeddings_dict
 
+
 class WordEmbeddings(TokenEmbeddings):
     """Standard static word embeddings, such as GloVe or FastText."""
 
@@ -1753,6 +1754,12 @@ class ELMoEmbeddings(TokenEmbeddings):
 
     def __str__(self):
         return self.name
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self.ee.elmo_bilm.to(device=flair.device)
+        self.ee.elmo_bilm._elmo_lstm._states = tuple(
+            [state.to(flair.device) for state in self.ee.elmo_bilm._elmo_lstm._states])
 
 
 class NILCEmbeddings(WordEmbeddings):

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1757,6 +1757,16 @@ class ELMoEmbeddings(TokenEmbeddings):
 
     def __setstate__(self, state):
         self.__dict__ = state
+
+        if re.fullmatch(r"cuda:[0-9]+", str(flair.device)):
+            cuda_device = int(str(flair.device).split(":")[-1])
+        elif str(flair.device) == "cpu":
+            cuda_device = -1
+        else:
+            cuda_device = 0
+
+        self.ee.cuda_device = cuda_device
+
         self.ee.elmo_bilm.to(device=flair.device)
         self.ee.elmo_bilm._elmo_lstm._states = tuple(
             [state.to(flair.device) for state in self.ee.elmo_bilm._elmo_lstm._states])


### PR DESCRIPTION
Fixes #1753 by checking the device when deserializing and moving the ELMo objects as needed. Tested in my local setup.