### PR TITLE
GH-1774: get max subtokens from transformer model

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -110,12 +110,14 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
 
             # subtokenize sentences
             for sentence in sentences:
-                # tokenize and truncate to 512 subtokens (TODO: check better truncation strategies)
+
+                # tokenize and truncate to max subtokens (TODO: check better truncation strategies)
                 subtokenized_sentence = self.tokenizer.encode(sentence.to_tokenized_string(),
                                                               add_special_tokens=True,
-                                                              max_length=512,
+                                                              max_length=self.tokenizer.model_max_length,
                                                               truncation=True,
                                                               )
+
                 subtokenized_sentences.append(
                     torch.tensor(subtokenized_sentence, dtype=torch.long, device=flair.device))
 


### PR DESCRIPTION
Previously, the `TransformerDocumentEmbeddings` truncated all text to 512 subtokens. But some transformer models can handle longer text. With this PR, the max number of subtokens is read from the transformer model and it is only truncated accordingly. 

Closes #1774 