### PR TITLE
GH-1768: turn on tokenizer by default in Sentence object

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -529,7 +529,7 @@ class Sentence(DataPoint):
     def __init__(
         self,
         text: str = None,
-        use_tokenizer: Union[bool, Tokenizer] = False,
+        use_tokenizer: Union[bool, Tokenizer] = True,
         language_code: str = None,
         start_position: int = None
     ):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -53,7 +53,7 @@ def test_create_sentence_on_empty_string():
 
 
 def test_create_sentence_without_tokenizer():
-    sentence: Sentence = Sentence("I love Berlin.")
+    sentence: Sentence = Sentence("I love Berlin.", use_tokenizer=False)
 
     assert 3 == len(sentence.tokens)
     assert 0 == sentence.tokens[0].start_pos


### PR DESCRIPTION
The Sentence object now executes tokenization by default, e.g.: 

```python
# Tokenizes by default
sentence = Sentence("I love Berlin.")
print(sentence)

# i.e. this is equivalent to
sentence = Sentence("I love Berlin.", use_tokenizer=False)
print(sentence)

# i.e. if you don't want to use tokenization, set it to False
sentence = Sentence("I love Berlin.", use_tokenizer=False)
print(sentence)
```

Closes #1768 