### PR TITLE
[Hotfix] Stop using extras_require

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ langdetect
 lxml
 ftfy
 sentencepiece!=0.1.92
-konoha[janome]<5.0.0,>=4.0.0
+konoha<5.0.0,>=4.0.0
+janome


### PR DESCRIPTION
I'm really sorry but I added the change that made the installation fail if `poetry` is used.
This failure is related to the issue (python-poetry/poetry#2676).
This PR stops using `extras_require` in `requirements.txt` and add dependencies explicitly.

### Problem

`poetry add flair` fails with the following message.

```
poetry add flair
...
[SolverProblemError]
Because no versions of flair match >0.6,<0.7
 and flair (0.6) depends on konoha (>=4.0.0,<5.0.0), flair (>=0.6,<0.7) requires konoha (>=4.0.0,<5.0.0).
And because no versions of konoha match >=4.0.0,<4.6.1 || >4.6.1,<5.0.0
 and konoha (4.6.1) depends on janome (>=0.3.10,<0.4.0), flair (>=0.6,<0.7) requires janome (>=0.3.10,<0.4.0).
So, because no versions of janome match >=0.3.10,<0.4.0
 and test depends on flair (^0.6), version solving failed.
```

### Steps to reproduce

```
pip install poetry
poetry new test_package && cd test_package
poetry add flair
```

### Workaround

Poetry users may need to install Japanese tokenizer before adding flair until this PR is merged and the flair is published.

```
poetry add janome
poetry add flair
```

---

This is the bug of `poetry` and would resolve in python-poetry/poetry#2680.
However, I needed to avoid using `extras_requires` in this time. :bow:


[update: 2020/08/17 23:55 JST]
I have also noticed that the latest version of `poetry` (>1.0) fixes the problem.
It means we can install `flair` by `poetry add flair` if we build `poetry` by `pip install --pre poetry`.