### PR TITLE
Conditional flatten_parameters for quantization

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -75,7 +75,8 @@ class LanguageModel(nn.Module):
         encoded = self.encoder(input)
         emb = self.drop(encoded)
 
-        self.rnn.flatten_parameters()
+        if hasttr(self.rnn, "flatten_parameters"):
+            self.rnn.flatten_parameters()
 
         output, hidden = self.rnn(emb, hidden)
 

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -75,7 +75,7 @@ class LanguageModel(nn.Module):
         encoded = self.encoder(input)
         emb = self.drop(encoded)
 
-        if hasttr(self.rnn, "flatten_parameters"):
+        if hasattr(self.rnn, "flatten_parameters"):
             self.rnn.flatten_parameters()
 
         output, hidden = self.rnn(emb, hidden)


### PR DESCRIPTION
This is only change required to get dynamic PyTorch quantization working. This is because the DynamicQuantizedLSTM that Pytorch replaces the LSTM layer doesn't implement the flatten_parameters method in it's RnnBase class. 

So now, standard dynamic quantization will work. Quantizing both the LSTM and Linear layers results in about 4X decrease in model size and 3-4X increase in inference speed on CPU. (I don't have any concrete benchmark on inference speed as I've just been testing on my laptop but the 3-4X is consistent with more official benchmarks from Pytorch and others)

e.g.
```python
import os

from flair.models import SequenceTagger
import torch


tagger = SequenceTagger.load('ner')
tagger.cpu() # Dynamic Quantization currently only works on CPU

quantized_tagger = torch.quantization.quantize_dynamic(
    tagger, {torch.nn.LSTM, torch.nn.Linear}, dtype=torch.qint8
)

def print_size_of_model(model):
    torch.save(model.state_dict(), "temp.p")
    print('Size (MB):', os.path.getsize("temp.p")/1e6)
    os.remove('temp.p')

print("TAGGER: ner")
print_size_of_model(tagger)
print_size_of_model(quantized_tagger)

# Outputs:
# TAGGER: ner
# Size (MB): 253.036663
# Size (MB): 63.571843
```