### PR TITLE
GH-1770: Added a link to a repo with examples of Flair on GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Flair is:
 
 * **A powerful NLP library.** Flair allows you to apply our state-of-the-art natural language processing (NLP)
 models to your text, such as named entity recognition (NER), part-of-speech tagging (PoS),
- sense disambiguation and classification, with support for a rapidly growing number of languages. 
- 
-* **A biomedical NER library.** Flair has special support for [biomedical data](/resources/docs/HUNFLAIR.md) with 
+ sense disambiguation and classification, with support for a rapidly growing number of languages.
+
+* **A biomedical NER library.** Flair has special support for [biomedical data](/resources/docs/HUNFLAIR.md) with
 state-of-the-art models for biomedical NER and support for over 32 biomedical datasets.
 
-* **A text embedding library.** Flair has simple interfaces that allow you to use and combine different word and 
+* **A text embedding library.** Flair has simple interfaces that allow you to use and combine different word and
 document embeddings, including our proposed **[Flair embeddings](https://www.aclweb.org/anthology/C18-1139/)**, BERT embeddings and ELMo embeddings.
 
-* **A PyTorch NLP framework.** Our framework builds directly on [PyTorch](https://pytorch.org/), making it easy to 
+* **A PyTorch NLP framework.** Our framework builds directly on [PyTorch](https://pytorch.org/), making it easy to
 train your own models and experiment with new approaches using Flair embeddings and classes.
 
 Now at [version 0.6](https://github.com/flairNLP/flair/releases)!
@@ -46,7 +46,7 @@ Flair outperforms the previous best methods on a range of NLP tasks:
 Here's how to [reproduce these numbers](/resources/docs/EXPERIMENTS.md) using Flair. You can also find detailed evaluations and discussions in our papers:
 
 * *[Contextual String Embeddings for Sequence Labeling](https://www.aclweb.org/anthology/C18-1139/).
-Alan Akbik, Duncan Blythe and Roland Vollgraf. 
+Alan Akbik, Duncan Blythe and Roland Vollgraf.
 27th International Conference on Computational Linguistics, **COLING 2018**.*
 
 * *[Pooled Contextualized Embeddings for Named Entity Recognition](https://www.aclweb.org/anthology/papers/N/N19/N19-1078/).
@@ -71,7 +71,7 @@ pip install flair
 
 ### Example Usage
 
-Let's run named entity recognition (NER) over an example sentence. All you need to do is make a `Sentence`, load 
+Let's run named entity recognition (NER) over an example sentence. All you need to do is make a `Sentence`, load
 a pre-trained model and use it to predict tags for the sentence:
 
 ```python
@@ -99,12 +99,12 @@ for entity in sentence.get_spans('ner'):
     print(entity)
 ```
 
-This should print: 
+This should print:
 
 ```console
 Sentence: "I love Berlin ." - 4 Tokens
 
-The following NER tags are found: 
+The following NER tags are found:
 
 Span [3]: "Berlin"   [− Labels: LOC (0.9992)]
 ```
@@ -121,15 +121,15 @@ We provide a set of quick tutorials to get you started with the library:
 * [Tutorial 6: Loading a Dataset](/resources/docs/TUTORIAL_6_CORPUS.md)
 * [Tutorial 7: Training a Model](/resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md)
 * [Tutorial 8: Training your own Flair Embeddings](/resources/docs/TUTORIAL_9_TRAINING_LM_EMBEDDINGS.md)
- 
+
 The tutorials explain how the base NLP classes work, how you can load pre-trained models to tag your
-text, how you can embed your text with different word or document embeddings, and how you can train your own 
+text, how you can embed your text with different word or document embeddings, and how you can train your own
 language models, sequence labeling models, and text classification models. Let us know if anything is unclear.
 
-There is also a dedicated landing page for our **[biomedical NER and datasets](/resources/docs/HUNFLAIR.md)** with 
+There is also a dedicated landing page for our **[biomedical NER and datasets](/resources/docs/HUNFLAIR.md)** with
 installation instructions and tutorials.
 
-There are also good third-party articles and posts that illustrate how to use Flair: 
+There are also good third-party articles and posts that illustrate how to use Flair:
 * [How to build a text classifier with Flair](https://towardsdatascience.com/text-classification-with-state-of-the-art-nlp-library-flair-b541d7add21f)
 * [How to build a microservice with Flair and Flask](https://shekhargulati.com/2019/01/04/building-a-sentiment-analysis-python-microservice-with-flair-and-flask/)
 * [A docker image for Flair](https://towardsdatascience.com/docker-image-for-nlp-5402c9a9069e)
@@ -137,10 +137,11 @@ There are also good third-party articles and posts that illustrate how to use Fl
 * [Visualisation tool for highlighting the extracted entities](https://github.com/lunayach/visNER)
 * [Practical approach of State-of-the-Art Flair in Named Entity Recognition](https://medium.com/analytics-vidhya/practical-approach-of-state-of-the-art-flair-in-named-entity-recognition-46a837e25e6b)
 * [Benchmarking NER algorithms](https://towardsdatascience.com/benchmark-ner-algorithm-d4ab01b2d4c3)
+* [Training a Flair text classifier on Google Cloud Platform (GCP) and serving predictions on GCP](https://github.com/robinvanschaik/flair-on-gcp)
 
 ## Citing Flair
 
-Please cite the following paper when using Flair: 
+Please cite the following paper when using Flair:
 
 ```
 @inproceedings{akbik2018coling,
@@ -164,18 +165,18 @@ If you use the pooled version of the Flair embeddings (PooledFlairEmbeddings), p
 }
 ```
 
-## Contact 
+## Contact
 
 Please email your questions or comments to [Alan Akbik](http://alanakbik.github.io/).
 
 ## Contributing
 
-Thanks for your interest in contributing! There are many ways to get involved; 
-start with our [contributor guidelines](CONTRIBUTING.md) and then 
+Thanks for your interest in contributing! There are many ways to get involved;
+start with our [contributor guidelines](CONTRIBUTING.md) and then
 check these [open issues](https://github.com/flairNLP/flair/issues) for specific tasks.
 
-For contributors looking to get deeper into the API we suggest cloning the repository and checking out the unit 
-tests for examples of how to call methods. Nearly all classes and methods are documented, so finding your way around 
+For contributors looking to get deeper into the API we suggest cloning the repository and checking out the unit
+tests for examples of how to call methods. Nearly all classes and methods are documented, so finding your way around
 the code should hopefully be easy.
 
 ### Running unit tests locally
@@ -210,4 +211,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-


### PR DESCRIPTION
This add a link to a repo I in response to a question I had in [issue 1770](https://github.com/flairNLP/flair/issues/1770).

It adds two examples:

1. Training on GCP AI platform by making use of custom containers.
2. Serving predictions on GCP Cloud Run by making use of a Docker container and FastAPI.  