### PR TITLE
GH-1840: move MUSE embeddings to HU server

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1437,14 +1437,14 @@ class MuseCrosslingualEmbeddings(TokenEmbeddings):
             if language_code not in self.language_embeddings:
                 log.info(f"Loading up MUSE embeddings for '{language_code}'!")
                 # download if necessary
-                webpath = "https://alan-nlp.s3.eu-central-1.amazonaws.com/resources/embeddings-muse"
+                hu_path: str = "https://flair.informatik.hu-berlin.de/resources/embeddings/muse"
                 cache_dir = Path("embeddings") / "MUSE"
                 cached_path(
-                    f"{webpath}/muse.{language_code}.vec.gensim.vectors.npy",
+                    f"{hu_path}/muse.{language_code}.vec.gensim.vectors.npy",
                     cache_dir=cache_dir,
                 )
                 embeddings_file = cached_path(
-                    f"{webpath}/muse.{language_code}.vec.gensim", cache_dir=cache_dir
+                    f"{hu_path}/muse.{language_code}.vec.gensim", cache_dir=cache_dir
                 )
 
                 # load the model

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -467,10 +467,10 @@ class TextClassifier(flair.nn.Model):
 
         # English sentiment models
         model_map["sentiment"] = "/".join(
-            [hu_path, "sentiment-curated-distilbert", "sentiment-en-mix-distillbert.pt"]
+            [hu_path, "sentiment-curated-distilbert", "sentiment-en-mix-distillbert_3.1.pt"]
         )
         model_map["en-sentiment"] = "/".join(
-            [hu_path, "sentiment-curated-distilbert", "sentiment-en-mix-distillbert.pt"]
+            [hu_path, "sentiment-curated-distilbert", "sentiment-en-mix-distillbert_3.1.pt"]
         )
         model_map["sentiment-fast"] = "/".join(
             [hu_path, "sentiment-curated-fasttext-rnn", "sentiment-en-mix-ft-rnn.pt"]


### PR DESCRIPTION
Closes #1840. Fixes URL of MUSE embeddings.

Also closes #1841 by fixing the sentiment model to have the new transformers attributes.