### PR TITLE
GH-1827: fix deserialization issues in transformer tokenizers

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -172,12 +172,20 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
             else self.model.config.hidden_size
         )
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["tokenizer"] = None
+        return state
+
     def __setstate__(self, d):
         self.__dict__ = d
 
         # reload tokenizer to get around serialization issues
         model_name = self.name.split('transformer-document-')[-1]
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        except:
+            pass
 
 
 class DocumentPoolEmbeddings(DocumentEmbeddings):

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1125,6 +1125,11 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         return length
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["tokenizer"] = None
+        return state
+
     def __setstate__(self, d):
         self.__dict__ = d
 


### PR DESCRIPTION
Switch transformer serialization to not serialize tokenizers since this was causing problems for some embeddings such as XLM. 

See #1827 