### PR TITLE
Add ANERcorp for MSA training

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -47,6 +47,7 @@ from .sequence_labeling import UP_GERMAN
 from .sequence_labeling import UP_ITALIAN
 from .sequence_labeling import UP_SPANISH
 from .sequence_labeling import UP_SPANISH_ANCORA
+from .sequence_labeling import ANER_CORP
 
 # Expose all document classification datasets
 from .document_classification import ClassificationCorpus

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -1575,6 +1575,55 @@ class LER_GERMAN(ColumnCorpus):
             train_file='ler.conll'
         )
 
+class ANER_CORP(ColumnCorpus):
+    def __init__(
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+            document_as_sequence: bool = False,
+    ):
+        """
+        Initialize a preprocessed version of the Arabic Named Entity Recognition Corpus (ANERCorp) dataset available
+        from https://github.com/EmnamoR/Arabic-named-entity-recognition/blob/master/ANERCorp.rar.
+        http://curtis.ml.cmu.edu/w/courses/index.php/ANERcorp
+        Column order is swapped
+        The first time you call this constructor it will automatically download the dataset.
+        :param base_path: Default is None, meaning that corpus gets auto-downloaded and loaded. You can override this
+        to point to a different folder but typically this should not be necessary.
+        :param tag_to_bioes: NER by default, need not be changed, but you could also select 'pos' to predict
+        POS tags instead
+        :param in_memory: If True, keeps dataset in memory giving speedups in training.
+        :param document_as_sequence: If True, all sentences of a document are read into a single Sentence object
+        """
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "ner"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        anercorp_path = "https://megantosh.s3.eu-central-1.amazonaws.com/ANERcorp/"
+        # cached_path(f"{anercorp_path}test.txt", Path("datasets") / dataset_name)
+        cached_path(f"{anercorp_path}train.txt", Path("datasets") / dataset_name)
+
+        super(ANER_CORP, self).__init__(
+            data_folder,
+            columns,
+            # tag_to_bioes=tag_to_bioes,
+            encoding="utf-8",
+            in_memory=in_memory,
+            document_separator_token=None if not document_as_sequence else "-DOCSTART-",
+        )
+
 
 class NER_BASQUE(ColumnCorpus):
     def __init__(


### PR DESCRIPTION
**NER Dataset**

Embeddings used:
- GloVe Word Embeddings
- Flair Embeddings (ar-forward, ar-backward)
Initial model delivers following results:

0.8421	- 	0.8268	-	0.8344

Results:
- F1-score (micro) 0.8344
- F1-score (macro) 0.7901

By class:
LOC        tp: 369 - fp: 48 - fn: 37 - precision: 0.8849 - recall: 0.9089 - f1-score: 0.8967
MISC       tp: 62 - fp: 22 - fn: 37 - precision: 0.7381 - recall: 0.6263 - f1-score: 0.6776
ORG        tp: 131 - fp: 32 - fn: 64 - precision: 0.8037 - recall: 0.6718 - f1-score: 0.7318
PERS       tp: 302 - fp: 60 - fn: 43 - precision: 0.8343 - recall: 0.8754 - f1-score: 0.8543


<img width="608" alt="Screenshot ANERcorp predict" src="https://user-images.githubusercontent.com/4587828/95451202-bea99b80-0967-11eb-96cf-2a54eb0c6dbe.png">

This example "الجامعة الألمانية بالقاهرة " (German University in Cairo) demonstrates a partially correct tagging. The model only understands Cairo as a LOC, but not the whole entity as a an ORG