### PR TITLE
Added support for the Livvi dataset from UD

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -111,6 +111,7 @@ from .treebanks import UD_CHINESE
 from .treebanks import UD_KOREAN
 from .treebanks import UD_BASQUE
 from .treebanks import UD_GREEK
+from .treebanks import UD_LIVVI
 
 # Expose all text-text datasets
 from .text_text import ParallelTextCorpus

--- a/flair/datasets/treebanks.py
+++ b/flair/datasets/treebanks.py
@@ -1124,3 +1124,29 @@ class UD_GREEK(UniversalDependenciesCorpus):
         )
 
         super(UD_GREEK, self).__init__(data_folder, in_memory=in_memory)
+
+
+class UD_LIVVI(UniversalDependenciesCorpus):
+    def __init__(self, base_path: Union[str, Path] = None, in_memory: bool = True):
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        web_path = "https://raw.githubusercontent.com/hebecked/UD_Livvi-KKPP/dev"
+        #uncomment the line below and delete the line above once the pull request has been accepted and dev is merged with master
+        #web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Livvi-KKPP/master"
+        cached_path(f"{web_path}/olo_kkpp-ud-test.conllu", Path("datasets") / dataset_name)
+        cached_path(f"{web_path}/olo_kkpp-ud-train.conllu", Path("datasets") / dataset_name)
+        cached_path(f"{web_path}/olo_kkpp-ud-dev.conllu", Path("datasets") / dataset_name)
+
+        super(UD_LIVVI, self).__init__(data_folder, in_memory=in_memory)
+


### PR DESCRIPTION
This PR concludes my homework assignment.
It is not recommended to accept the PR at this time, since the data source is currently in the dev branch in my own rep (PR to UD pending) and I'm not qualified to determine if my changes have any linguistic implications.

My changes to the UD dataset:
- Swap the training and test dataset since the old test dataset was much larger than the training dataset. 
- Remove part of the (new) training dataset to create a dev dataset. (Ratios might need adjustment.)

In flair/flair/datasets/document_classification.py Line 48 and flair/flair/datasets/treebanks.py  Line 34 it is stated:
":param dev_file: the name of the dev file, if None, dev data is sampled from train."
This only holds true if the dataset is loaded manually. 
When automatically loaded from UD Line 67 in flair/flair/datasets/treebanks.py prevents this. since "assert path_to_conll_file.exists()" is called for all "path_to_conll_file", "None" or "str".