### PR TITLE
Adding support for the UD_Livvi dataset

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -111,6 +111,7 @@ from .treebanks import UD_CHINESE
 from .treebanks import UD_KOREAN
 from .treebanks import UD_BASQUE
 from .treebanks import UD_GREEK
+from .treebanks import UD_LIVVI
 
 # Expose all text-text datasets
 from .text_text import ParallelTextCorpus

--- a/flair/datasets/treebanks.py
+++ b/flair/datasets/treebanks.py
@@ -1124,3 +1124,29 @@ class UD_GREEK(UniversalDependenciesCorpus):
         )
 
         super(UD_GREEK, self).__init__(data_folder, in_memory=in_memory)
+
+
+class UD_LIVVI(UniversalDependenciesCorpus):
+    def __init__(self, base_path: Union[str, Path] = None, in_memory: bool = True):
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        web_path = "https://raw.githubusercontent.com/hebecked/UD_Livvi-KKPP/dev"
+        #uncomment the line below and delete the line above once the pull request has been accepted and dev is merged with master
+        #web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Livvi-KKPP/master"
+        cached_path(f"{web_path}/olo_kkpp-ud-test.conllu", Path("datasets") / dataset_name)
+        cached_path(f"{web_path}/olo_kkpp-ud-train.conllu", Path("datasets") / dataset_name)
+        cached_path(f"{web_path}/olo_kkpp-ud-dev.conllu", Path("datasets") / dataset_name)
+
+        super(UD_LIVVI, self).__init__(data_folder, in_memory=in_memory)
+

--- a/flair/datasets/treebanks.py
+++ b/flair/datasets/treebanks.py
@@ -1141,12 +1141,9 @@ class UD_LIVVI(UniversalDependenciesCorpus):
         data_folder = base_path / dataset_name
 
         # download data if necessary
-        web_path = "https://raw.githubusercontent.com/hebecked/UD_Livvi-KKPP/dev"
-        #uncomment the line below and delete the line above once the pull request has been accepted and dev is merged with master
-        #web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Livvi-KKPP/master"
+        web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Livvi-KKPP/master"
         cached_path(f"{web_path}/olo_kkpp-ud-test.conllu", Path("datasets") / dataset_name)
         cached_path(f"{web_path}/olo_kkpp-ud-train.conllu", Path("datasets") / dataset_name)
-        cached_path(f"{web_path}/olo_kkpp-ud-dev.conllu", Path("datasets") / dataset_name)
 
         super(UD_LIVVI, self).__init__(data_folder, in_memory=in_memory)
 


### PR DESCRIPTION
Added support for UD_Levvi from UD, based on the original splits. (see previous PR)
Merged with the current upstream changes and tested.
The upstream changes now allow for operation without a dev set file, creating a dev set on the fly based on the training set file.