### PR TITLE
Support for UD_OLD_FRENCH added

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -118,6 +118,7 @@ from .treebanks import UD_LIVVI
 from .treebanks import UD_NORTH_SAMI
 from .treebanks import UD_MALTESE
 from .treebanks import UD_AFRIKAANS
+from .treebanks import UD_OLD_FRENCH
 
 # Expose all text-text datasets
 from .text_text import ParallelTextCorpus

--- a/flair/datasets/treebanks.py
+++ b/flair/datasets/treebanks.py
@@ -1277,3 +1277,31 @@ class UD_AFRIKAANS(UniversalDependenciesCorpus):
         )
 
         super(UD_AFRIKAANS, self).__init__(data_folder, in_memory=in_memory)
+
+
+class UD_OLD_FRENCH(UniversalDependenciesCorpus):
+    def __init__(self, base_path: Union[str, Path] = None, in_memory: bool = True):
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        web_path = "https://github.com/UniversalDependencies/UD_Old_French-SRCMF/tree/master"
+        cached_path(f"{web_path}/fro_srcmf-ud-dev.conllu", Path("datasets") / dataset_name)
+        cached_path(
+            f"{web_path}/fro_srcmf-ud-test.conllu", Path("datasets") / dataset_name
+        )
+        cached_path(
+            f"{web_path}/fro_srcmf-ud-train.conllu", Path("datasets") / dataset_name
+        )
+
+        super(UD_OLD_FRENCH, self).__init__(data_folder, in_memory=in_memory)
+

--- a/flair/datasets/treebanks.py
+++ b/flair/datasets/treebanks.py
@@ -1294,7 +1294,7 @@ class UD_OLD_FRENCH(UniversalDependenciesCorpus):
         data_folder = base_path / dataset_name
 
         # download data if necessary
-        web_path = "https://github.com/UniversalDependencies/UD_Old_French-SRCMF/tree/master"
+        web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Old_French-SRCMF/master"
         cached_path(f"{web_path}/fro_srcmf-ud-dev.conllu", Path("datasets") / dataset_name)
         cached_path(
             f"{web_path}/fro_srcmf-ud-test.conllu", Path("datasets") / dataset_name


### PR DESCRIPTION
I'm not  sure if additional formating is needed, this loads the corpus without additional reformatings of the source files.