### PR TITLE
models: add support for Hugging Face model hub

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1120,7 +1120,7 @@ class SequenceTagger(flair.nn.Model):
             from transformers import file_utils
 
             url = file_utils.hf_bucket_url(model_id=model_name, revision=revision, filename=hf_model_name)
-            model_name = file_utils.cached_path(url_or_filename=url)
+            model_name = file_utils.cached_path(url_or_filename=url, cache_dir=flair.cache_root)
 
         return model_name
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scikit-learn>=0.21.3
 sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.1.1
-transformers>=3.0.0
+transformers>=3.5.0,<=3.5.1
 bpemb>=0.3.2
 regex
 tabulate


### PR DESCRIPTION
Hi,

this PR allows to use trained sequence tagging from the Hugging Face model hub :hugs: 

It is only needed to specify the namespace, like `stefan-it/flair-ner-conll03` and a model will be downloaded (incl. caching) that can be used in Flair!

Naming convention is, that the model file on the model hub is named `model.bin`.

The following code snippet shows how to use this new feature:

```python
from flair.data import Sentence
from flair.models import SequenceTagger
tagger: SequenceTagger = SequenceTagger.load("stefan-it/flair-ner-conll03")
```

It is also possible to pass a specific commit or branch name via `@`-syntax: `stefan-it/flair-ner-conll03@main`.

On the Hugging Face model hub itself, it is also possible to add a `README` file, that gives more details about a trained model:

https://huggingface.co/stefan-it/flair-ner-conll03

Many thanks to the Hugging Face team for the awesome model hub :heart: 