### PR TITLE
GH-1827: Pretrained TARS model and small fixes

### DIFF
--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -34,14 +34,14 @@ class TextClassifier(flair.nn.Model):
     """
 
     def __init__(
-        self,
-        document_embeddings: flair.embeddings.DocumentEmbeddings,
-        label_dictionary: Dictionary,
-        label_type: str = None,
-        multi_label: bool = None,
-        multi_label_threshold: float = 0.5,
-        beta: float = 1.0,
-        loss_weights: Dict[str, float] = None,
+            self,
+            document_embeddings: flair.embeddings.DocumentEmbeddings,
+            label_dictionary: Dictionary,
+            label_type: str = None,
+            multi_label: bool = None,
+            multi_label_threshold: float = 0.5,
+            beta: float = 1.0,
+            loss_weights: Dict[str, float] = None,
     ):
         """
         Initializes a TextClassifier
@@ -142,7 +142,7 @@ class TextClassifier(flair.nn.Model):
         return model
 
     def forward_loss(
-        self, data_points: Union[List[Sentence], Sentence]
+            self, data_points: Union[List[Sentence], Sentence]
     ) -> torch.tensor:
 
         scores = self.forward(data_points)
@@ -167,14 +167,14 @@ class TextClassifier(flair.nn.Model):
         return scores, loss
 
     def predict(
-        self,
-        sentences: Union[List[Sentence], Sentence],
-        mini_batch_size: int = 32,
-        multi_class_prob: bool = False,
-        verbose: bool = False,
-        label_name: Optional[str] = None,
-        return_loss = False,
-        embedding_storage_mode="none",
+            self,
+            sentences: Union[List[Sentence], Sentence],
+            mini_batch_size: int = 32,
+            multi_class_prob: bool = False,
+            verbose: bool = False,
+            label_name: Optional[str] = None,
+            return_loss=False,
+            embedding_storage_mode="none",
     ):
         """
         Predicts the class labels for the given sentences. The labels are directly added to the sentences.
@@ -255,12 +255,12 @@ class TextClassifier(flair.nn.Model):
                 return overall_loss / batch_no
 
     def evaluate(
-        self,
-        sentences: Union[List[DataPoint], Dataset],
-        out_path: Union[str, Path] = None,
-        embedding_storage_mode: str = "none",
-        mini_batch_size: int = 32,
-        num_workers: int = 8,
+            self,
+            sentences: Union[List[DataPoint], Dataset],
+            out_path: Union[str, Path] = None,
+            embedding_storage_mode: str = "none",
+            mini_batch_size: int = 32,
+            num_workers: int = 8,
     ) -> (Result, float):
 
         # read Dataset into data loader (if list of sentences passed, make Dataset first)
@@ -302,9 +302,9 @@ class TextClassifier(flair.nn.Model):
                 predictions = [sentence.get_labels('predicted') for sentence in batch]
 
                 for sentence, prediction, true_value in zip(
-                    sentences_for_batch,
-                    predictions,
-                    true_values_for_batch,
+                        sentences_for_batch,
+                        predictions,
+                        true_values_for_batch,
                 ):
                     eval_line = "{}\t{}\t{}\n".format(
                         sentence, true_value, prediction
@@ -312,7 +312,7 @@ class TextClassifier(flair.nn.Model):
                     lines.append(eval_line)
 
                 for predictions_for_sentence, true_values_for_sentence in zip(
-                    predictions, true_values_for_batch
+                        predictions, true_values_for_batch
                 ):
 
                     true_values_for_sentence = [label.value for label in true_values_for_sentence]
@@ -348,9 +348,11 @@ class TextClassifier(flair.nn.Model):
                                                                   target_names=target_names, zero_division=0)
 
             # get scores
-            micro_f_score = round(metrics.fbeta_score(y_true, y_pred, beta=self.beta, average='micro', zero_division=0), 4)
+            micro_f_score = round(metrics.fbeta_score(y_true, y_pred, beta=self.beta, average='micro', zero_division=0),
+                                  4)
             accuracy_score = round(metrics.accuracy_score(y_true, y_pred), 4)
-            macro_f_score = round(metrics.fbeta_score(y_true, y_pred, beta=self.beta, average='macro', zero_division=0), 4)
+            macro_f_score = round(metrics.fbeta_score(y_true, y_pred, beta=self.beta, average='macro', zero_division=0),
+                                  4)
             precision_score = round(metrics.precision_score(y_true, y_pred, average='macro', zero_division=0), 4)
             recall_score = round(metrics.recall_score(y_true, y_pred, average='macro', zero_division=0), 4)
 
@@ -396,7 +398,7 @@ class TextClassifier(flair.nn.Model):
         return filtered_sentences
 
     def _obtain_labels(
-        self, scores: List[List[float]], predict_prob: bool = False
+            self, scores: List[List[float]], predict_prob: bool = False
     ) -> List[List[Label]]:
         """
         Predicts the labels of sentences.
@@ -487,8 +489,8 @@ class TextClassifier(flair.nn.Model):
         model_map["sentiment-fast"] = "/".join(
             [hu_path, "sentiment-curated-fasttext-rnn", "sentiment-en-mix-ft-rnn.pt"]
         )
-        
-        #Communicative Functions Model
+
+        # Communicative Functions Model
         model_map["communicative-functions"] = "/".join(
             [hu_path, "comfunc", "communicative-functions-v0.5b.pt"]
         )
@@ -593,7 +595,7 @@ class TARSClassifier(TextClassifier):
 
     def add_and_switch_to_new_task(self,
                                    task_name,
-                                   label_dictionary: Union[List, Set, Dictionary],
+                                   label_dictionary: Union[List, Set, Dictionary, str],
                                    multi_label: bool = None,
                                    multi_label_threshold: float = 0.5,
                                    label_type: str = None,
@@ -612,7 +614,7 @@ class TARSClassifier(TextClassifier):
         if task_name in self.task_specific_attributes:
             log.warning("Task `%s` already exists in TARS model. Switching to it.", task_name)
         else:
-            if isinstance(label_dictionary, (list, set)):
+            if isinstance(label_dictionary, (list, set, str)):
                 if multi_label is None:
                     multi_label = False
                 label_dictionary = TARSClassifier._make_ad_hoc_label_dictionary(label_dictionary,
@@ -670,7 +672,7 @@ class TARSClassifier(TextClassifier):
             for column_index, other_label in enumerate(all_labels):
                 if label != other_label:
                     negative_label_probabilities[label][other_label] = \
-                    similarity_matrix[row_index][column_index]
+                        similarity_matrix[row_index][column_index]
         self.label_nearest_map = negative_label_probabilities
 
     def train(self, mode=True):
@@ -705,7 +707,6 @@ class TARSClassifier(TextClassifier):
             plausible_label_probabilities += 1e-08
             plausible_label_probabilities /= np.sum(plausible_label_probabilities)
 
-            
             if len(plausible_labels) > 0:
                 num_samples = min(self.num_negative_labels_to_sample, len(plausible_labels))
                 sampled_negative_labels = np.random.choice(plausible_labels,
@@ -853,8 +854,8 @@ class TARSClassifier(TextClassifier):
         return [Label(label, conf.item())]
 
     @staticmethod
-    def _make_ad_hoc_label_dictionary(candidate_label_set: set = None,
-                                      multi_label=True) -> Dictionary:
+    def _make_ad_hoc_label_dictionary(candidate_label_set: Union[List[str], Set[str], str],
+                                      multi_label: bool = True) -> Dictionary:
         """
         Creates a dictionary given a set of candidate labels
         :return: dictionary of labels
@@ -862,6 +863,11 @@ class TARSClassifier(TextClassifier):
         label_dictionary: Dictionary = Dictionary(add_unk=False)
         label_dictionary.multi_label = multi_label
 
+        # make list if only one candidate label is passed
+        if isinstance(candidate_label_set, str):
+            candidate_label_set = {candidate_label_set}
+
+        # if list is passed, convert to set
         if not isinstance(candidate_label_set, set):
             candidate_label_set = set(candidate_label_set)
 
@@ -880,7 +886,10 @@ class TARSClassifier(TextClassifier):
         else:
             log.warning("No task exists with the name `%s`.", task_name)
 
-    def predict_zero_shot(self, sentences, candidate_label_set, multi_label=False):
+    def predict_zero_shot(self,
+                          sentences: Union[List[Sentence], Sentence],
+                          candidate_label_set: Union[List[str], Set[str], str],
+                          multi_label: bool = False):
         """
         Method to make zero shot predictions from the TARS model
         :param sentences: input sentence objects to classify
@@ -894,8 +903,7 @@ class TARSClassifier(TextClassifier):
             log.warning("Provided candidate_label_set is empty")
             return
 
-        label_dictionary = TARSClassifier._make_ad_hoc_label_dictionary(candidate_label_set,
-                                                                        multi_label)
+        label_dictionary = TARSClassifier._make_ad_hoc_label_dictionary(candidate_label_set, multi_label)
 
         # note current task
         existing_current_task = self.current_task
@@ -905,7 +913,7 @@ class TARSClassifier(TextClassifier):
                                         label_dictionary, multi_label)
 
         try:
-            #make zero shot predictions
+            # make zero shot predictions
             self.predict(sentences)
         except:
             log.error("Something went wrong during prediction. Ensure you pass Sentence objects.")

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -925,3 +925,17 @@ class TARSClassifier(TextClassifier):
             self._drop_task(TARSClassifier.static_adhoc_task_identifier)
 
         return
+
+    @staticmethod
+    def _fetch_model(model_name) -> str:
+
+        model_map = {}
+        hu_path: str = "https://nlp.informatik.hu-berlin.de/resources/models"
+
+        model_map["tars-base"] = "/".join([hu_path, "tars-base", "tars-base.pt"])
+
+        cache_dir = Path("models")
+        if model_name in model_map:
+            model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
+
+        return model_name

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scikit-learn>=0.21.3
 sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.1.1
-transformers>=3.0.0
+transformers>=3.0.0,<=3.5.1
 bpemb>=0.3.2
 regex
 tabulate

--- a/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+++ b/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
@@ -130,7 +130,7 @@ is because TARS remembers the last task it was trained to do and will do this by
 Of course, more than 4 training examples works even better. Try it out! 
 
 
-## Use Case #3: Training your own Base TARS Model
+## Use Case #3: Training Your Own Base TARS Model
 
 Our base TARS model was trained for English using the bert-base-uncased model with 9 text classification
 datasets. But for many reasons you might

--- a/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+++ b/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
@@ -1,13 +1,14 @@
-# Tutorial 10: Training a Zero-shot Classifier (TARS)
+# Tutorial 10: Few-Shot and Zero-Shot Classification (TARS)
 
 Task-aware representation of sentences (TARS) was introduced by Halder et al. (2020) as a simple and effective 
-method for **few-shot and even zero-shot learning for text classification**. 
+method for **few-shot and even zero-shot learning for text classification**. This means you can classify
+text without (m)any training examples. 
 This model is implemented in Flair by the `TARSClassifier` class.
  
 In this tutorial, we will show you different ways of using TARS: 
 
     
-## Use Case #1: As a Zero-shot Predictor for New Classes
+## Use Case #1: Classify Text Without Training Data (Zero-Shot)
 
 In some cases, you might not have any training data for the text classification task you want to solve. In this case, 
 you can load our default TARS model and do zero-shot prediction. That is, you use the `predict_zero_shot` method
@@ -42,7 +43,7 @@ So the label "happy" was chosen for this sentence.
 Try it out with some other labels! Zero-shot prediction will sometimes (*but not always*) work remarkably well. 
 
 
-## Use Case #2: As a Few-shot Predictor for New Classes
+## Use Case #2: Classify Text With Very Little Training Data (Few-Shot)
  
 While TARS can predict new classes even without training data, it's always better to provide some training examples.
 TARS can learn remarkably well from as few as 1 - 10 training examples. 
@@ -54,14 +55,14 @@ For instance, assume you want to predict whether a text talks about "food" or "d
 tars = TARSClassifier.load('tars-base')
 
 # 2. Prepare a test sentence
-sentence = flair.data.Sentence("I am so glad you like coffee!")
+sentence = flair.data.Sentence("I am so glad you like burritos!")
 
 # 3. Predict zero-shot for classes "food" and "drink", and print results 
 tars.predict_zero_shot(sentence, ["food", "drink"])
 print(sentence)
 ```
 
-In this case, zero-shot prediction fails to predict "drink" for the sentence "I am so glad you like coffee!". 
+In this case, zero-shot prediction false predicts "drink" for the sentence "I am so glad you like burritos!". 
 
 To improve this, let's first create a small corpus of 4 training and 2 testing examples: 
 
@@ -130,7 +131,7 @@ is because TARS remembers the last task it was trained to do and will do this by
 Of course, more than 4 training examples works even better. Try it out! 
 
 
-## Use Case #3: Training Your Own Base TARS Model
+## Use Case #3: Train Your Own Base TARS Model
 
 Our base TARS model was trained for English using the bert-base-uncased model with 9 text classification
 datasets. But for many reasons you might

--- a/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+++ b/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
@@ -1,24 +1,173 @@
 # Tutorial 10: Training a Zero-shot Classifier (TARS)
 
-* __NOTE: (23.10.2020)__ *At the moment you would need to install flair from master branch to be able to follow this.*
+Task-aware representation of sentences (TARS) was introduced by Halder et al. (2020) as a simple and effective 
+method for **few-shot and even zero-shot learning for text classification**. 
+This model is implemented in Flair by the `TARSClassifier` class.
+ 
+In this tutorial, we will show you different ways of using TARS: 
 
-Task Aware Representation of Sentences (TARS) was introduced by Halder et. al. It formulates the
-traditional document level text classification problem as a universal binary text classification
-problem. It uses the label names in the classification process, and leverages on the attention mechanism
-of transformer based language models. This model is implemented by the `TARSClassifier` class. In this
-tutorial, we will show you how to use this class in different scenarios involving training, testing on
-unseen datasets.
+ 1. [Use case 1: Use pre-trained TARS as zero-shot classifier.](#use-case-1-as-a-regular-text-classifier) 
+    Sometimes you need to classify text but have no training data at all. Zero-shot TARS might be able to help.
+    
+ 2. [Use case 2: Use pre-trained TARS as few-shot classifier.](#use-case-1-as-a-regular-text-classifier) 
+    While TARS can do zero-shot, even labeling a handful of examples for your task will greatly improve accuracy.
+    Follow these instructions to train TARS with a few examples to do new text classification tasks.
+    
+ 3. [Use case 3: Training your own base TARS model.](#use-case-1-as-a-regular-text-classifier) For many reasons, 
+    you might want to train your own base TARS model, using a different transformer or for a new language.
+    
+## Use Case #1: As a Zero-shot Predictor for New Classes
 
-Once a TARS classification model is trained on one (or multiple) dataset(s), the final 
-model can be used in many different ways such as:
- 1. [A regular text classifier.](#use-case-1-as-a-regular-text-classifier)
- 2. [A Zero-shot predictor on an arbitrary ad-hoc set of labels.](#use-case-2-as-a-zero-shot-predictor-on-arbitrary-ad-hoc-set-of-labels)
- 3. [A Zero-shot predictor on a previously unseen classification dataset.](#use-case-3-as-a-zero-shot-predictor-on-an-unseen-task)
- 4. [A base model to continue training on other datasets.](#use-case-4-as-a-base-model-to-continue-training-on-other-datasets)
+In some cases, you might not have any training data for the text classification task you want to solve. In this case, 
+you can load our default TARS model and do zero-shot prediction. That is, you use the `predict_zero_shot` method
+of TARS and give it a list of label names. TARS will then try to match one of these labels to the text.
 
-## Training a TARS Classification Model
+For instance, say you want to predict whether text is "happy" or "sad" but you have no training data for this. 
+Just use TARS with this snippet:
+
 ```python
-import flair
+# 1. Load our pre-trained TARS model for English
+tars = TARSClassifier.load('tars-base')
+
+# 2. Prepare a test sentence
+sentence = flair.data.Sentence("I am so glad you liked it!")
+
+# 3. Define some classes that you want to predict using descriptive names
+classes = ["happy", "sad"]
+
+#4. Predict for these classes
+tars.predict_zero_shot(sentence, classes)
+
+# Print sentence with predicted labels
+print(sentence)
+```
+The output should look like:
+```
+Sentence: "I am so glad you liked it !"   [− Tokens: 8  − Sentence-Labels: {'label': [happy (0.9312)]}]
+```
+
+So the label "happy" was chosen for this sentence. 
+
+Try it out with some other labels! Zero-shot prediction will sometimes (*but not always*) work remarkably well. 
+
+
+## Use Case #2: As a Few-shot Predictor for New Classes
+ 
+While TARS can predict new classes even without training data, it's always better to provide some training examples.
+TARS can learn remarkably well from as few as 1 - 10 training examples. 
+
+For instance, assume you want to predict whether a text talks about "food" or "drink". Let's try zero-shot first: 
+
+```python
+# 1. Load our pre-trained TARS model for English
+tars = TARSClassifier.load('tars-base')
+
+# 2. Prepare a test sentence
+sentence = flair.data.Sentence("I am so glad you like coffee!")
+
+# 3. Predict zero-shot for classes "food" and "drink", and print results 
+tars.predict_zero_shot(sentence, ["food", "drink"])
+print(sentence)
+```
+
+In this case, zero-shot prediction fails to predict "drink" for the sentence "I am so glad you like coffee!". 
+
+To improve this, let's first create a small corpus of 4 training and 2 testing examples: 
+
+```python
+# training dataset consisting of four sentences (2 labeled as "food" and 2 labeled as "drink")
+train = SentenceDataset(
+    [
+        Sentence('I eat pizza').add_label('food_or_drink', 'food'),
+        Sentence('Hamburgers are great').add_label('food_or_drink', 'food'),
+        Sentence('I love drinking tea').add_label('food_or_drink', 'drink'),
+        Sentence('Beer is great').add_label('food_or_drink', 'drink')
+    ])
+
+# test dataset consisting of two sentences (1 labeled as "food" and 1 labeled as "drink")
+test = SentenceDataset(
+    [
+        Sentence('I ordered pasta').add_label('food_or_drink', 'food'),
+        Sentence('There was fresh juice').add_label('food_or_drink', 'drink')
+    ])
+
+# make a corpus with train and test split
+corpus = Corpus(train=train, test=test)
+```
+
+Here, we've named the label class "food_or_drink" with values "food" or "drink". So we want to learn to predict
+whether a sentence mentions food or drink. 
+
+Now, let's take the Corpus we created and do few-shot learning with our pre-trained TARS: 
+
+```python
+# 1. load base TARS
+tars = TARSClassifier.load('tars-base')
+
+# 2. make the model aware of the desired set of labels from the new corpus
+tars.add_and_switch_to_new_task("FOOD_DRINK", label_dictionary=corpus.make_label_dictionary())
+
+# 3. initialize the text classifier trainer with your corpus
+trainer = ModelTrainer(tars, corpus)
+
+# 4. train model
+trainer.train(base_path='resources/taggers/food_drink', # path to store the model artifacts
+              learning_rate=0.02, # use very small learning rate
+              mini_batch_size=1, # small mini-batch size since corpus is tiny
+              max_epochs=10, # terminate after 10 epochs
+              train_with_dev=True,
+              )
+```
+
+Done! Let's load the newly trained model and see if it does better: 
+
+```python
+# 1. Load few-shot TARS model
+tars = TARSClassifier.load('resources/taggers/food_drink/final-model.pt')
+
+# 2. Prepare a test sentence
+sentence = flair.data.Sentence("I am so glad you like coffee")
+
+# 3. Predict for food and drink
+tars.predict(sentence)
+print(sentence)
+```
+
+The model should work much better now! Note that now we just used `predict` instead of `predict_zero_shot`. This 
+is because TARS remembers the last task it was trained to do and will do this by default.
+
+Of course, more than 4 training examples works even better. Try it out! 
+
+The output should look like:
+```
+Sentence: "I am so glad you liked it !"   [− Tokens: 8  − Sentence-Labels: {'label': [happy (0.9312)]}]
+```
+
+So the label "happy" was chosen for this sentence. 
+
+Try it out with some other labels! Zero-shot prediction will sometimes (*but not always*) work remarkably well. 
+
+
+
+## Use Case #3: Training your own Base TARS Model
+
+Our base TARS model was trained for English using the bert-base-uncased model with 9 text classification
+datasets. But for many reasons you might
+ want to train your own base TARS model: you may wish to train using more (or different) text classification
+datasets, train models for other languages or domains, etc. 
+
+Here's how to do this: 
+
+### How to train with one dataset
+
+Training with one dataset is almost exactly like training a normal text classifier in Flair. The only 
+difference is that it sometimes makes sense to rephrase label names into natural language descriptions. 
+For instance, the TREC dataset defines labels like "ENTY" that we rephrase to "question about entity".
+Better descriptions help TARS learn.
+
+The full training code is then as follows:
+
+```python
 from flair.data import Corpus
 from flair.datasets import TREC_6
 from flair.models.text_classification_model import TARSClassifier
@@ -38,10 +187,10 @@ label_name_map = {'ENTY':'question about entity',
 corpus: Corpus = TREC_6(label_name_map=label_name_map)
 
 # 3. create a TARS classifier
-classifier = TARSClassifier(task_name='TREC_6', label_dictionary=corpus.make_label_dictionary())
+tars = TARSClassifier(task_name='TREC_6', label_dictionary=corpus.make_label_dictionary())
 
 # 4. initialize the text classifier trainer
-trainer = ModelTrainer(classifier, corpus)
+trainer = ModelTrainer(tars, corpus)
 
 # 5. start the training
 trainer.train(base_path='resources/taggers/trec', # path to store the model artifacts
@@ -50,84 +199,35 @@ trainer.train(base_path='resources/taggers/trec', # path to store the model arti
               mini_batch_chunk_size=4, # optionally set this if transformer is too much for your machine
               max_epochs=10, # terminate after 10 epochs
               )
-
-
 ```
 
-## Use Case #1: As a Regular Text Classifier
-```python
-
-# 1. Load the trained model
-classifier = TARSClassifier.load('resources/taggers/trec/best-model.pt')
-
-# 2. Prepare a test sentence
-sentence = flair.data.Sentence("What is the full form of NASA?")
-classifier.predict(sentence)
-print(sentence)
-
-```
-The output should look like:
-```
-loading file resources/taggers/trec/best-model.pt
-Sentence: "What is the full form of NASA ?"   [− Tokens: 8  − Sentence-Labels: {'label': [question about abbreviation (0.9922)]}]
-```
-
-## Use Case #2: As a Zero-shot Predictor on Arbitrary Ad-hoc Set of Labels
-```python
-
-# 1. Load the trained model
-classifier = TARSClassifier.load('resources/taggers/trec/best-model.pt')
-
-# 2. Prepare a test sentence
-sentence = flair.data.Sentence("I am so glad you liked it!")
-classifier.predict_zero_shot(sentence, ["happy", "sad"])
-print(sentence)
-
-```
-The output should look like:
-```
-loading file resources/taggers/trec/best-model.pt
-Sentence: "I am so glad you liked it !"   [− Tokens: 8  − Sentence-Labels: {'label': [happy (0.9874)]}]
-```
+Done! This trains a classifier for one task that you can now either use as a normal classifier, or as basis for 
+few-shot and zero-shot prediction. 
 
 
-## Use Case #3: As a Zero-shot Predictor on an Unseen Task
-```python
+### How to train with multiple datasets
 
-# 1. Load the trained model
-classifier = TARSClassifier.load('resources/taggers/trec/best-model.pt')
+TARS gets better at few-shot and zero-shot prediction if it learns from more than one classification task. 
 
-# 2. Define a new task
-classifier.add_and_switch_to_new_task("sentiment", label_dictionary=["happy", "sad"])
+For instance, lets continue training the model we trained for TREC_6 with the GO_EMOTIONS dataset. The code
+again looks very similar, with the difference that we now call `add_and_switch_to_new_task` to make the model
+aware that it should train GO_EMOTIONS now instead of TREC_6:
 
-# 3. Prepare a test sentence
-sentence = flair.data.Sentence("I am so glad you liked it!") # no need to provide the labels in this way
-classifier.predict(sentence)
-print(sentence)
-
-```
-The output should look like:
-```
-loading file resources/taggers/trec/best-model.pt
-Sentence: "I am so glad you liked it !"   [− Tokens: 8  − Sentence-Labels: {'label': [happy (0.9874)]}]
-```
-
-## Use Case #4: As a Base Model to Continue Training on other Datasets
 ```python
 from flair.datasets import GO_EMOTIONS
 
 # 1. Load the trained model
-classifier = TARSClassifier.load('resources/taggers/trec/best-model.pt')
+tars = TARSClassifier.load('resources/taggers/trec/best-model.pt')
 
 # 2. load a new flair corpus e.g., GO_EMOTIONS, SENTIMENT_140 etc
 new_corpus = GO_EMOTIONS()
 
 # 3. make the model aware of the desired set of labels from the new corpus
-classifier.add_and_switch_to_new_task( "GO_EMOTIONS",
+tars.add_and_switch_to_new_task( "GO_EMOTIONS",
                                      label_dictionary=new_corpus.make_label_dictionary())
 
 # 4. initialize the text classifier trainer
-trainer = ModelTrainer(classifier, new_corpus)
+trainer = ModelTrainer(tars, new_corpus)
 
 # 5. start the training
 trainer.train(base_path='resources/taggers/go_emotions', # path to store the model artifacts
@@ -136,9 +236,12 @@ trainer.train(base_path='resources/taggers/go_emotions', # path to store the mod
               mini_batch_chunk_size=4, # optionally set this if transformer is too much for your machine
               max_epochs=10, # terminate after 10 epochs
               )
-
 ```
-At the end of this training, the resultant model should be able make predictions for both TREC_6 and GO_EMOTIONS tasks with full supervision accuracy.
+
+At the end of this training, the resulting model can make high quality predictions for 
+both TREC_6 and GO_EMOTIONS and is an even better basis for few-shot learning than before.
+
+
 
 ## Switching between Tasks
 
@@ -150,7 +253,7 @@ tasks a TARS model was trained on, and then switch to one of them as needed.
 ```python
 
 # 1. Load a pre-trained TARS model
-classifier = TARSClassifier.load('resources/taggers/go_emotions/best-model.pt')
+classifier = TARSClassifier.load('tars-base')
 
 # 2. Check out what datasets it was trained on
 classifier.list_existing_tasks()

--- a/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+++ b/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
@@ -1,6 +1,6 @@
 # Tutorial 10: Few-Shot and Zero-Shot Classification (TARS)
 
-Task-aware representation of sentences (TARS) was introduced by Halder et al. (2020) as a simple and effective 
+Task-aware representation of sentences (TARS) was introduced by [Halder et al. (2020)](https://kishaloyhalder.github.io/pdfs/tars_coling2020.pdf) as a simple and effective 
 method for **few-shot and even zero-shot learning for text classification**. This means you can classify
 text without (m)any training examples. 
 This model is implemented in Flair by the `TARSClassifier` class.
@@ -235,17 +235,17 @@ tasks a TARS model was trained on, and then switch to one of them as needed.
 ```python
 
 # 1. Load a pre-trained TARS model
-classifier = TARSClassifier.load('tars-base')
+tars = TARSClassifier.load('tars-base')
 
 # 2. Check out what datasets it was trained on
-classifier.list_existing_tasks()
+print(tars.list_existing_tasks())
 
 # 3. Switch to a particular task that exists in the above list
-classifier.switch_to_task("GO_EMOTIONS")
+tars.switch_to_task("GO_EMOTIONS")
 
 # 4. Prepare a test sentence
 sentence = flair.data.Sentence("I absolutely love this!")
-classifier.predict(sentence)
+tars.predict(sentence)
 print(sentence)
 ```
 The output should look like:

--- a/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+++ b/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
@@ -6,15 +6,6 @@ This model is implemented in Flair by the `TARSClassifier` class.
  
 In this tutorial, we will show you different ways of using TARS: 
 
- 1. [Use case 1: Use pre-trained TARS as zero-shot classifier.](#use-case-1-as-a-regular-text-classifier) 
-    Sometimes you need to classify text but have no training data at all. Zero-shot TARS might be able to help.
-    
- 2. [Use case 2: Use pre-trained TARS as few-shot classifier.](#use-case-1-as-a-regular-text-classifier) 
-    While TARS can do zero-shot, even labeling a handful of examples for your task will greatly improve accuracy.
-    Follow these instructions to train TARS with a few examples to do new text classification tasks.
-    
- 3. [Use case 3: Training your own base TARS model.](#use-case-1-as-a-regular-text-classifier) For many reasons, 
-    you might want to train your own base TARS model, using a different transformer or for a new language.
     
 ## Use Case #1: As a Zero-shot Predictor for New Classes
 
@@ -42,7 +33,7 @@ tars.predict_zero_shot(sentence, classes)
 print(sentence)
 ```
 The output should look like:
-```
+```console
 Sentence: "I am so glad you liked it !"   [− Tokens: 8  − Sentence-Labels: {'label': [happy (0.9312)]}]
 ```
 
@@ -137,16 +128,6 @@ The model should work much better now! Note that now we just used `predict` inst
 is because TARS remembers the last task it was trained to do and will do this by default.
 
 Of course, more than 4 training examples works even better. Try it out! 
-
-The output should look like:
-```
-Sentence: "I am so glad you liked it !"   [− Tokens: 8  − Sentence-Labels: {'label': [happy (0.9312)]}]
-```
-
-So the label "happy" was chosen for this sentence. 
-
-Try it out with some other labels! Zero-shot prediction will sometimes (*but not always*) work remarkably well. 
-
 
 
 ## Use Case #3: Training your own Base TARS Model

--- a/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+++ b/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
@@ -22,7 +22,7 @@ Just use TARS with this snippet:
 tars = TARSClassifier.load('tars-base')
 
 # 2. Prepare a test sentence
-sentence = flair.data.Sentence("I am so glad you liked it!")
+sentence = Sentence("I am so glad you liked it!")
 
 # 3. Define some classes that you want to predict using descriptive names
 classes = ["happy", "sad"]
@@ -55,7 +55,7 @@ For instance, assume you want to predict whether a text talks about "food" or "d
 tars = TARSClassifier.load('tars-base')
 
 # 2. Prepare a test sentence
-sentence = flair.data.Sentence("I am so glad you like burritos!")
+sentence = Sentence("I am so glad you like burritos!")
 
 # 3. Predict zero-shot for classes "food" and "drink", and print results 
 tars.predict_zero_shot(sentence, ["food", "drink"])
@@ -118,7 +118,7 @@ Done! Let's load the newly trained model and see if it does better:
 tars = TARSClassifier.load('resources/taggers/food_drink/final-model.pt')
 
 # 2. Prepare a test sentence
-sentence = flair.data.Sentence("I am so glad you like coffee")
+sentence = Sentence("I am so glad you like coffee")
 
 # 3. Predict for food and drink
 tars.predict(sentence)
@@ -238,22 +238,20 @@ tasks a TARS model was trained on, and then switch to one of them as needed.
 tars = TARSClassifier.load('tars-base')
 
 # 2. Check out what datasets it was trained on
-print(tars.list_existing_tasks())
+existing_tasks = tars.list_existing_tasks()
+print(f"Existing tasks are: {existing_tasks}")
 
 # 3. Switch to a particular task that exists in the above list
 tars.switch_to_task("GO_EMOTIONS")
 
 # 4. Prepare a test sentence
-sentence = flair.data.Sentence("I absolutely love this!")
+sentence = Sentence("I absolutely love this!")
 tars.predict(sentence)
 print(sentence)
 ```
 The output should look like:
 ```
-loading file resources/taggers/go_emotions/best-model.pt
-Existing tasks are:
-TREC_6
-GO_EMOTIONS
+Existing tasks are: {'AGNews', 'DBPedia', 'IMDB', 'SST', 'TREC_6', 'NEWS_CATEGORY', 'Amazon', 'Yelp', 'GO_EMOTIONS'}
 Sentence: "I absolutely love this !"   [− Tokens: 5  − Sentence-Labels: {'label': [LOVE (0.9708)]}]
 ```
 

--- a/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+++ b/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
@@ -62,7 +62,7 @@ tars.predict_zero_shot(sentence, ["food", "drink"])
 print(sentence)
 ```
 
-In this case, zero-shot prediction false predicts "drink" for the sentence "I am so glad you like burritos!". 
+In this case, zero-shot prediction falsely predicts "drink" for the sentence "I am so glad you like burritos!". 
 
 To improve this, let's first create a small corpus of 4 training and 2 testing examples: 
 

--- a/tests/test_tars.py
+++ b/tests/test_tars.py
@@ -1,0 +1,39 @@
+from flair.data import Corpus
+from flair.datasets import ClassificationCorpus
+from flair.models.text_classification_model import TARSClassifier
+
+
+def test_init_tars_and_switch(tasks_base_path):
+
+    # test corpus
+    corpus = ClassificationCorpus(tasks_base_path / "imdb")
+
+    # create a TARS classifier
+    tars = TARSClassifier(task_name='2_CLASS', label_dictionary=corpus.make_label_dictionary())
+
+    # check if right number of classes
+    assert(len(tars.label_dictionary) == 2)
+
+    # switch to task with only one label
+    tars.add_and_switch_to_new_task('1_CLASS', 'one class')
+
+    # check if right number of classes
+    assert(len(tars.label_dictionary) == 1)
+
+    # switch to task with three labels provided as list
+    tars.add_and_switch_to_new_task('3_CLASS', ['list 1', 'list 2', 'list 3'])
+
+    # check if right number of classes
+    assert(len(tars.label_dictionary) == 3)
+
+    # switch to task with four labels provided as set
+    tars.add_and_switch_to_new_task('4_CLASS', {'set 1', 'set 2', 'set 3', 'set 4'})
+
+    # check if right number of classes
+    assert(len(tars.label_dictionary) == 4)
+
+    # switch to task with two labels provided as Dictionary
+    tars.add_and_switch_to_new_task('2_CLASS_AGAIN', corpus.make_label_dictionary())
+
+    # check if right number of classes
+    assert(len(tars.label_dictionary) == 2)


### PR DESCRIPTION
This PR adds a pretrained TARS model (closes #1977). Load and use for zero-shot like this: 

```python
# 1. Load our pre-trained TARS model for English
tars = TARSClassifier.load('tars-base')

# 2. Prepare a test sentence
sentence = flair.data.Sentence("I am so glad you liked it!")

# 3. Define some classes that you want to predict using descriptive names
classes = ["happy", "sad"]

#4. Predict for these classes
tars.predict_zero_shot(sentence, classes)

# Print sentence with predicted labels
print(sentence)
```

It also adapts the single label prediction logic so that confidence must be above threshold 0.5 (@kishaloyhalder does this make sense?), a convenience function to predict all TARS tasks at once, a convenience method to pass just one label as string instead of a list and updates the TARS tutorial.