### PR TITLE
global: add possibility to set flair seed

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -1,6 +1,7 @@
 import os
 import torch
 from pathlib import Path
+from transformers import set_seed as hf_set_seed
 
 # global variable: cache_root
 cache_root = os.getenv('FLAIR_CACHE_ROOT', Path(Path.home(), ".flair"))
@@ -46,3 +47,6 @@ logging.config.dictConfig(
 )
 
 logger = logging.getLogger("flair")
+
+def set_seed(seed: int):
+    hf_set_seed(seed)


### PR DESCRIPTION
Hi,

this PR adds the possibility to set a seed via wrapping the Hugging Face Transformers library helper method.

By specifying a seed with:

```python
import flair

flair.set_seed(42)
```

more reproducable experiments are possible. The wrapped `set_seed` method sets seeds for `random`, `numpy` and `torch`. More details [here](https://github.com/huggingface/transformers/blob/08f534d2da47875a4b7eb1c125cfa7f0f3b79642/src/transformers/trainer_utils.py#L29-L48).