### PR TITLE
models: change default name for Flair models on Hugging Face model hub

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1108,7 +1108,7 @@ class SequenceTagger(flair.nn.Model):
         if not Path(model_name).exists() and not model_name.startswith("http"):
             # e.g. stefan-it/flair-ner-conll03 is a valid namespace
             # and  stefan-it/flair-ner-conll03@main supports specifying a commit/branch name
-            hf_model_name = "model.bin"
+            hf_model_name = "pytorch_model.bin"
             revision = "main"
 
             if "@" in model_name:


### PR DESCRIPTION
Hi,

as discussed with the Hugging Face team, it is better to call the model `pytorch_model.bin` instead of `model.bin` on the Hugging Face model hub.

This PR renames the expected model filename :hugs: 