### PR TITLE
Tag name map

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -1506,7 +1506,8 @@ class DANE(ColumnCorpus):
                 print(data_path / data_file)
 
         super(DANE, self).__init__(
-            data_folder, columns,
+            data_folder,
+            columns,
             tag_to_bioes=tag_to_bioes,
             in_memory=in_memory,
             comment_symbol="#",

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -225,10 +225,10 @@ class ColumnDataset(FlairDataset):
                         tagging_format_prefix = split_at_first_hyphen[0]
                         tag_without_tagging_format = split_at_first_hyphen[1]
                         if self.label_name_map and tag_without_tagging_format in self.label_name_map.keys():
-                            tag = tagging_format_prefix + "-" + self.label_name_map[tag_without_tagging_format] # for example, transforming 'B-OBJ' to 'B-part of speech object'
+                            tag = tagging_format_prefix + "-" + self.label_name_map[tag_without_tagging_format].replace("-", " ") # for example, transforming 'B-OBJ' to 'B-part-of-speech-object'
                     else: # tag without prefix, for example tag='PPER'
                         if self.label_name_map and tag in self.label_name_map.keys():
-                            tag = self.label_name_map[tag] # for example, transforming 'PPER' to 'person'
+                            tag = self.label_name_map[tag].replace("-", " ") # for example, transforming 'PPER' to 'person'
                     token.add_label(task, tag)
                 if self.column_name_map[column] == self.SPACE_AFTER_KEY and fields[column] == '-':
                     token.whitespace_after = False


### PR DESCRIPTION
#1985 

Test: 
corpus = EUROPARL_NER_GERMAN(label_name_map={'LOC': '**location test a-b-c**', 'PPER': '**person test a-b-c**'})
print(corpus.test[83])

Output:
Sentence: "In Wien gab es eine große Konferenz ."   [− Tokens: 8  − Token-Labels: "In <in/APPR/I-PC> Wien <Wien/NE/I-PC/**S-location test a b c**> gab <geben/VVFIN/I-VC> es <es/**person test a b c**/I-NC> eine <ein/ART/B-NC> große <groß/ADJA/I-NC> Konferenz <Konferenz/NN/I-NC> . <./$.>"]

As you can see, my implementation replaces "-" with " " because e.g. the methods iob2 and iob_iobes in data.py run into problems when tags contain "-".