### PR TITLE
ci: introduce GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install Flair dependencies
+        run: python setup.py develop -q
+      - name: Install unittest dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: |
+          cd tests
+          pip freeze
+          pytest --runintegration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dateutil>=2.6.1
 torch>=1.1.0
-gensim>=3.4.0
+gensim>=3.4.0,<=3.8.3
 tqdm>=4.26.0
 segtok>=1.5.7
 matplotlib>=2.2.3


### PR DESCRIPTION
Hi,

this PR uses GitHub Actions for running our (future) tests.

CI pipeline is only triggered, when creating a new PR in order to save credits.

The CI steps are mainly copied from (old) Travis CI configuration: Python 3.6 is again used (we could also define a build matrix for other Python versions).