### PR TITLE
pip: restrict numpy version to < 1.20 for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           python-version: 3.6
       - name: Install Flair dependencies
-        run: python setup.py develop -q
+        run: |
+          pip install -r requirements.txt
+          python setup.py develop -q
       - name: Install unittest dependencies
         run: pip install pytest
       - name: Run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ sentencepiece<=0.1.91
 konoha<5.0.0,>=4.0.0
 janome
 gdown
+numpy<1.20.0


### PR DESCRIPTION
Hi,

`numpy` in upcoming versions just dropped Python 3.6 support, see [here](https://github.com/numpy/numpy/pull/17895).

As we have a lot of users that are using Python 3.6, we restrict the `numpy` version to < 1.20.0.

You can of course use newer `numpy` versions, when you have Python >= 3.7. This PR also fixes our current failing CI builds.

----

Thanks to the awesome `scikit-learn` contributors for their help and very usefuls hints, see [here](https://github.com/scikit-learn/scikit-learn/pull/18956)!