### PR TITLE
Memory leak word embeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1,11 +1,9 @@
 import hashlib
-import pickle
 import inspect
 from abc import abstractmethod
 from pathlib import Path
 from typing import List, Union, Dict
 from collections import Counter
-from methodtools import lru_cache
 
 import torch
 from bpemb import BPEmb
@@ -21,7 +19,7 @@ import numpy as np
 
 from flair.data import Sentence, Token, Corpus, Dictionary
 from flair.embeddings.base import Embeddings, ScalarMix
-from flair.file_utils import cached_path, open_inside_zip
+from flair.file_utils import cached_path, open_inside_zip, instance_lru_cache
 
 log = logging.getLogger("flair")
 
@@ -212,7 +210,7 @@ class WordEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    @lru_cache(maxsize=10000, typed=False)
+    @instance_lru_cache(maxsize=10000, typed=False)
     def get_cached_vec(self, word: str) -> torch.Tensor:
         if word in self.precomputed_word_embeddings:
             word_embedding = self.precomputed_word_embeddings[word]
@@ -1222,7 +1220,7 @@ class FastTextEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    @lru_cache(maxsize=10000, typed=False)
+    @instance_lru_cache(maxsize=10000, typed=False)
     def get_cached_vec(self, word: str) -> torch.Tensor:
         try:
             word_embedding = self.precomputed_word_embeddings[word]
@@ -1430,7 +1428,7 @@ class MuseCrosslingualEmbeddings(TokenEmbeddings):
         self.language_embeddings = {}
         super().__init__()
 
-    @lru_cache(maxsize=10000, typed=False)
+    @instance_lru_cache(maxsize=10000, typed=False)
     def get_cached_vec(self, language_code: str, word: str) -> torch.Tensor:
         current_embedding_model = self.language_embeddings[language_code]
         if word in current_embedding_model:

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import List, Union, Dict
 from collections import Counter
-from functools import lru_cache
+from methodtools import lru_cache
 
 import torch
 from bpemb import BPEmb

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -9,6 +9,7 @@ import logging
 import shutil
 import tempfile
 import re
+import functools
 from urllib.parse import urlparse
 
 import mmap
@@ -319,3 +320,14 @@ class Tqdm:
         new_kwargs = {"mininterval": Tqdm.default_mininterval, **kwargs}
 
         return _tqdm(*args, **new_kwargs)
+
+def instance_lru_cache(*cache_args, **cache_kwargs):
+    def decorator(func):
+        @functools.wraps(func)
+        def create_cache(self, *args, **kwargs):
+            instance_cache = functools.lru_cache(*cache_args, **cache_kwargs)(func)
+            instance_cache = instance_cache.__get__(self, self.__class__)
+            setattr(self, func.__name__, instance_cache)
+            return instance_cache(*args, **kwargs)
+        return create_cache
+    return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ konoha<5.0.0,>=4.0.0
 janome
 gdown
 numpy<1.20.0
+methodtools

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ konoha<5.0.0,>=4.0.0
 janome
 gdown
 numpy<1.20.0
-methodtools


### PR DESCRIPTION
functools lru_cache doesn't follow self object's lifetime, thus the memory leak. replaced with methodtools.
closes GH-2013.