### PR TITLE
Improve evaluation for wsd task

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -508,6 +508,7 @@ class SequenceTagger(flair.nn.Model):
             embedding_storage_mode: str = "none",
             mini_batch_size: int = 32,
             num_workers: int = 8,
+            wsd_evaluation: bool = False
     ) -> (Result, float):
 
         # read Dataset into data loader (if list of sentences passed, make Dataset first)
@@ -516,7 +517,7 @@ class SequenceTagger(flair.nn.Model):
         data_loader = DataLoader(sentences, batch_size=mini_batch_size, num_workers=num_workers)
 
         # if span F1 needs to be used, use separate eval method
-        if self._requires_span_F1_evaluation():
+        if self._requires_span_F1_evaluation() and not wsd_evaluation:
             return self._evaluate_with_span_F1(data_loader, embedding_storage_mode, mini_batch_size, out_path)
 
         # else, use scikit-learn to evaluate
@@ -548,7 +549,14 @@ class SequenceTagger(flair.nn.Model):
                     y_true.append(labels.add_item(gold_tag))
 
                     # add predicted tag
-                    predicted_tag = token.get_tag('predicted').value
+                    if wsd_evaluation:
+                        if gold_tag == 'O':
+                            predicted_tag = 'O'
+                        else:
+                            predicted_tag = token.get_tag('predicted').value
+                    else:
+                        predicted_tag = token.get_tag('predicted').value
+
                     y_pred.append(labels.add_item(predicted_tag))
 
                     # for file output


### PR DESCRIPTION
Usually, in WSD evaluation wrong predictions are ignored if the gold data states no sense for a token. This was not considered yet in Flair but this PR adds the wsd_evaluation flag to the evaluate function to make this kind of evaluation possible.