### PR TITLE
GH-2015: refactor FLERT

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -583,6 +583,7 @@ class Sentence(DataPoint):
 
         self.tokenized = None
 
+        # some sentences represent a document boundary (but most do not)
         self.is_document_boundary: bool = False
 
     def get_token(self, token_id: int) -> Token:

--- a/flair/data.py
+++ b/flair/data.py
@@ -1344,12 +1344,6 @@ class Corpus:
         tag_dictionary.add_item("<STOP>")
         return tag_dictionary
 
-    def contextualize(self, tokens: int, max_sentences: int = 24):
-        contextualize(tokens, sentences=self.train, max_sentences=max_sentences)
-        contextualize(tokens, sentences=self.dev, max_sentences=max_sentences)
-        contextualize(tokens, sentences=self.test, max_sentences=max_sentences)
-        return self
-
 
 class MultiCorpus(Corpus):
     def __init__(self, corpora: List[Corpus], name: str = "multicorpus"):

--- a/flair/data.py
+++ b/flair/data.py
@@ -940,6 +940,32 @@ class Sentence(DataPoint):
 
         return re.sub(r"[\u0080-\u0099]", to_windows_1252, text)
 
+    def next_sentence(self):
+
+        if '_next_sentence' in self.__dict__.keys():
+            return self._next_sentence
+
+        if '_position_in_dataset' in self.__dict__.keys():
+            dataset = self._position_in_dataset[0]
+            index = self._position_in_dataset[1] + 1
+            if index < len(dataset):
+                return dataset[index]
+
+        return None
+
+    def previous_sentence(self):
+
+        if '_previous_sentence' in self.__dict__.keys():
+            return self._previous_sentence
+
+        if '_position_in_dataset' in self.__dict__.keys():
+            dataset = self._position_in_dataset[0]
+            index = self._position_in_dataset[1] - 1
+            if index >= 0:
+                return dataset[index]
+
+        return None
+
 
 class Image(DataPoint):
 

--- a/flair/data.py
+++ b/flair/data.py
@@ -524,11 +524,11 @@ class Sentence(DataPoint):
     """
 
     def __init__(
-        self,
-        text: Union[str, List[str]] = None,
-        use_tokenizer: Union[bool, Tokenizer] = True,
-        language_code: str = None,
-        start_position: int = None
+            self,
+            text: Union[str, List[str]] = None,
+            use_tokenizer: Union[bool, Tokenizer] = True,
+            language_code: str = None,
+            start_position: int = None
     ):
         """
         Class to hold all meta related to a text (tokens, predictions, language code, ...)
@@ -944,7 +944,10 @@ class Sentence(DataPoint):
         return re.sub(r"[\u0080-\u0099]", to_windows_1252, text)
 
     def next_sentence(self):
-
+        """
+        Get the next sentence in the document (works only if context is set through dataloader or elsewhere)
+        :return: next Sentence in document if set, otherwise None
+        """
         if '_next_sentence' in self.__dict__.keys():
             return self._next_sentence
 
@@ -957,7 +960,10 @@ class Sentence(DataPoint):
         return None
 
     def previous_sentence(self):
-
+        """
+        Get the previous sentence in the document (works only if context is set through dataloader or elsewhere)
+        :return: previous Sentence in document if set, otherwise None
+        """
         if '_previous_sentence' in self.__dict__.keys():
             return self._previous_sentence
 
@@ -968,6 +974,13 @@ class Sentence(DataPoint):
                 return dataset[index]
 
         return None
+
+    def is_context_set(self) -> bool:
+        """
+        Return True or False depending on whether context is set (for instance in dataloader or elsewhere)
+        :return: True if context is set, else False
+        """
+        return '_previous_sentence' in self.__dict__.keys() or '_position_in_dataset' in self.__dict__.keys()
 
 
 class Image(DataPoint):
@@ -1126,7 +1139,6 @@ class Corpus:
         subset = Subset(dataset, non_empty_sentence_indices)
 
         return subset
-
 
     @staticmethod
     def _filter_empty_sentences(dataset) -> Dataset:
@@ -1357,7 +1369,6 @@ class MultiCorpus(Corpus):
 
 
 def contextualize(tokens: int, sentences: Union[FlairDataset, List[Sentence]], max_sentences: int = 24):
-
     # go through each sentence
     for index, sentence in enumerate(sentences):
         left_sentences = []
@@ -1430,8 +1441,8 @@ def iob_iobes(tags):
             raise Exception("Invalid IOB format!")
     return new_tags
 
-def randomly_split_into_two_datasets(dataset, length_of_first):
 
+def randomly_split_into_two_datasets(dataset, length_of_first):
     import random
     indices = [i for i in range(len(dataset))]
     random.shuffle(indices)

--- a/flair/data.py
+++ b/flair/data.py
@@ -583,6 +583,8 @@ class Sentence(DataPoint):
 
         self.tokenized = None
 
+        self.is_document_boundary: bool = False
+
     def get_token(self, token_id: int) -> Token:
         for token in self.tokens:
             if token.idx == token_id:

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -193,10 +193,18 @@ class ColumnDataset(FlairDataset):
             if self.in_memory:
                 self.sentences: List[Sentence] = []
 
+                # pointer to previous
+                previous_sentence = None
                 while True:
                     sentence = self._convert_lines_to_sentence(self._read_next_sentence(file))
                     if not sentence: break
+                    sentence._previous_sentence = previous_sentence
+                    sentence._next_sentence = None
+
+                    if previous_sentence: previous_sentence._next_sentence = sentence
+
                     self.sentences.append(sentence)
+                    previous_sentence = sentence
 
                 self.total_sentence_count = len(self.sentences)
 
@@ -311,8 +319,8 @@ class ColumnDataset(FlairDataset):
         # if in memory, retrieve parsed sentence
         if self.in_memory:
             sentence = self.sentences[index]
-            sentence._next_sentence = self.sentences[index + 1] if index < self.total_sentence_count - 1 else None
-            sentence._previous_sentence = self.sentences[index - 1] if index > 0 else None
+            # sentence._next_sentence = self.sentences[index + 1] if index < self.total_sentence_count - 1 else None
+            # sentence._previous_sentence = self.sentences[index - 1] if index > 0 else None
 
         # else skip to position in file where sentence begins
         else:

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -293,9 +293,6 @@ class ColumnDataset(FlairDataset):
 
         return sentence
 
-    def __none(self):
-        return None
-
 
 class ANER_CORP(ColumnCorpus):
     def __init__(
@@ -461,7 +458,6 @@ class CONLL_03(ColumnCorpus):
             columns,
             tag_to_bioes=tag_to_bioes,
             in_memory=in_memory,
-            # document_as_sequence=document_as_sequence,
             document_separator_token="-DOCSTART-",
             **corpusargs,
         )

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1047,7 +1047,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         while True:
             sentence = sentence.previous_sentence()
             if sentence is None: break
-            # if sentence.is_document_boundary: break
+            if sentence.is_document_boundary: break
 
             left_context = sentence.to_tokenized_string() + ' ' + left_context
             left_context = left_context.strip()
@@ -1064,7 +1064,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         while True:
             sentence = sentence.next_sentence()
             if sentence is None: break
-            # if sentence.is_document_boundary: break
+            if sentence.is_document_boundary: break
 
             right_context += ' ' + sentence.to_tokenized_string()
             right_context = right_context.strip()

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -788,10 +788,9 @@ class TransformerWordEmbeddings(TokenEmbeddings):
     def __init__(
             self,
             model: str = "bert-base-uncased",
-            layers: str = "-1,-2,-3,-4",
+            layers: str = "all",
             pooling_operation: str = "first",
-            batch_size: int = 1,
-            use_scalar_mix: bool = False,
+            use_scalar_mix: bool = True,
             fine_tune: bool = False,
             allow_long_sentences: bool = True,
             use_context: Union[bool, int] = False,
@@ -804,8 +803,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         :param layers: string indicating which layers to take for embedding (-1 is topmost layer)
         :param pooling_operation: how to get from token piece embeddings to token embedding. Either take the first
         subtoken ('first'), the last subtoken ('last'), both first and last ('first_last') or a mean over all ('mean')
-        :param batch_size: How many sentence to push through transformer at once. Set to 1 by default since transformer
-        models tend to be huge.
         :param use_scalar_mix: If True, uses a scalar mix of layers as embedding
         :param fine_tune: If True, allows transformers to be fine-tuned during training
         """
@@ -856,7 +853,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         self.use_scalar_mix = use_scalar_mix
         self.fine_tune = fine_tune
         self.static_embeddings = not self.fine_tune
-        self.batch_size = batch_size
 
         self.special_tokens = []
         # check if special tokens exist to circumvent error message
@@ -875,19 +871,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             self.begin_offset = 0
         if type(self.tokenizer) == TransfoXLTokenizer:
             self.begin_offset = 0
-
-    # def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
-    #     """Add embeddings to all words in a list of sentences."""
-    #
-    #     # split into micro batches of size self.batch_size before pushing through transformer
-    #     sentence_batches = [sentences[i * self.batch_size:(i + 1) * self.batch_size]
-    #                         for i in range((len(sentences) + self.batch_size - 1) // self.batch_size)]
-    #
-    #     # embed each micro-batch
-    #     for batch in sentence_batches:
-    #         self._add_embeddings_to_sentences(batch)
-
-    # return sentences
 
     @staticmethod
     def _remove_special_markup(text: str):

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1047,6 +1047,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         while True:
             sentence = sentence.previous_sentence()
             if sentence is None: break
+            # if sentence.is_document_boundary: break
 
             left_context = sentence.to_tokenized_string() + ' ' + left_context
             left_context = left_context.strip()
@@ -1063,6 +1064,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         while True:
             sentence = sentence.next_sentence()
             if sentence is None: break
+            # if sentence.is_document_boundary: break
 
             right_context += ' ' + sentence.to_tokenized_string()
             right_context = right_context.strip()

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -933,8 +933,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         for sentence in sentences:
 
-            print(sentence)
-
             original_sentences.append(sentence)
 
             # if we also use context, first expand sentence to include context

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -933,6 +933,8 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         for sentence in sentences:
 
+            print(sentence)
+
             original_sentences.append(sentence)
 
             # if we also use context, first expand sentence to include context
@@ -952,8 +954,9 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                     if len(left_context.split(" ")) > self.context_length:
                         left_context = " ".join(left_context.split(" ")[-self.context_length:])
                         break
-                context_length = len(left_context.split(" ")) if not left_context == '' else 0
+                context_length = len(left_context.split(" "))
                 context_offsets.append(context_length)
+                original_sentence.left_context = left_context
 
                 # get right context
                 sentence = original_sentence
@@ -967,6 +970,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                     if len(right_context.split(" ")) > self.context_length:
                         right_context = " ".join(right_context.split(" ")[:self.context_length])
                         break
+                original_sentence.right_context = right_context
 
                 # make expanded sentence
                 sentence = Sentence()

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -933,6 +933,8 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         for sentence in sentences:
 
+            original_sentences.append(sentence)
+
             # if we also use context, first expand sentence to include context
             if self.context_length > 0:
 
@@ -971,8 +973,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                 sentence.tokens = [Token(token) for token in left_context.split(" ") +
                                    original_sentence.to_tokenized_string().split(" ") +
                                    right_context.split(" ")]
-
-                original_sentences.append(sentence)
 
             tokenized_string = sentence.to_tokenized_string()
 

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -848,7 +848,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             self.layer_indexes = [int(x) for x in range(len(hidden_states))]
         else:
             self.layer_indexes = [int(x) for x in layers.split(",")]
-        # self.mix = ScalarMix(mixture_size=len(self.layer_indexes), trainable=False)
+
         self.pooling_operation = subtoken_pooling
         self.layer_mean = layer_mean
         self.fine_tune = fine_tune
@@ -1055,7 +1055,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                 left_context = " ".join(left_context.split(" ")[-self.context_length:])
                 break
         context_length = len(left_context.split(" "))
-        # context_offsets.append(context_length)
         original_sentence.left_context = left_context
 
         # get right context

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -876,18 +876,18 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         if type(self.tokenizer) == TransfoXLTokenizer:
             self.begin_offset = 0
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
-        """Add embeddings to all words in a list of sentences."""
+    # def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    #     """Add embeddings to all words in a list of sentences."""
+    #
+    #     # split into micro batches of size self.batch_size before pushing through transformer
+    #     sentence_batches = [sentences[i * self.batch_size:(i + 1) * self.batch_size]
+    #                         for i in range((len(sentences) + self.batch_size - 1) // self.batch_size)]
+    #
+    #     # embed each micro-batch
+    #     for batch in sentence_batches:
+    #         self._add_embeddings_to_sentences(batch)
 
-        # split into micro batches of size self.batch_size before pushing through transformer
-        sentence_batches = [sentences[i * self.batch_size:(i + 1) * self.batch_size]
-                            for i in range((len(sentences) + self.batch_size - 1) // self.batch_size)]
-
-        # embed each micro-batch
-        for batch in sentence_batches:
-            self._add_embeddings_to_sentences(batch)
-
-        return sentences
+    # return sentences
 
     @staticmethod
     def _remove_special_markup(text: str):
@@ -906,14 +906,17 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         token_text = token_text.lower()
         return token_text
 
-    def _add_embeddings_to_sentences(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+        """Add embeddings to all words in a list of sentences."""
+
+        # embed each sentence separately
+        for sentence in sentences:
+            self._add_embeddings_to_sentence(sentence)
+
+        return sentences
+
+    def _add_embeddings_to_sentence(self, sentence: Sentence):
         """Match subtokenization to Flair tokenization and extract embeddings from transformers for each token."""
-
-        # first, subtokenize each sentence and find out into how many subtokens each token was divided
-        subtokenized_sentences = []
-        subtokenized_sentences_token_lengths = []
-
-        sentence_parts_lengths = []
 
         # TODO: keep for backwards compatibility, but remove in future
         # some pretrained models do not have this property, applying default settings now.
@@ -923,222 +926,186 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             self.allow_long_sentences = False
             self.stride = 0
 
-        # list to filter between empty and non-empty sentences
-        non_empty_sentences = []
-        empty_sentences = []
+        # if we also use context, first expand sentence to include context
+        if self.context_length > 0:
 
-        # in case of contextualization, we must remember non-expanded sentences and each sentence length of left context
-        original_sentences = []
-        context_offsets = []
+            # in case of contextualization, we must remember non-expanded sentence
+            original_sentence = sentence
 
-        for sentence in sentences:
+            # create expanded sentence and remember context offsets
+            expanded_sentence, context_offset = self._expand_sentence_with_context(sentence)
 
-            original_sentences.append(sentence)
+            # overwrite sentence with expanded sentence
+            sentence = expanded_sentence
 
-            # if we also use context, first expand sentence to include context
-            if self.context_length > 0:
+        # subtokenize the sentence
+        tokenized_string = sentence.to_tokenized_string()
 
-                # remember original sentence
-                original_sentence = sentence
+        # method 1: subtokenize sentence
+        # subtokenized_sentence = self.tokenizer.encode(tokenized_string, add_special_tokens=True)
 
-                # get left context
-                left_context = ''
-                while True:
-                    sentence = sentence.previous_sentence()
-                    if sentence is None: break
+        # method 2:
+        # transformer specific tokenization
+        subtokenized_sentence = self.tokenizer.tokenize(tokenized_string)
 
-                    left_context = sentence.to_tokenized_string() + ' ' + left_context
-                    left_context = left_context.strip()
-                    if len(left_context.split(" ")) > self.context_length:
-                        left_context = " ".join(left_context.split(" ")[-self.context_length:])
-                        break
-                context_length = len(left_context.split(" "))
-                context_offsets.append(context_length)
-                original_sentence.left_context = left_context
-
-                # get right context
-                sentence = original_sentence
-                right_context = ''
-                while True:
-                    sentence = sentence.next_sentence()
-                    if sentence is None: break
-
-                    right_context += ' ' + sentence.to_tokenized_string()
-                    right_context = right_context.strip()
-                    if len(right_context.split(" ")) > self.context_length:
-                        right_context = " ".join(right_context.split(" ")[:self.context_length])
-                        break
-                original_sentence.right_context = right_context
-
-                # make expanded sentence
-                sentence = Sentence()
-                sentence.tokens = [Token(token) for token in left_context.split(" ") +
-                                   original_sentence.to_tokenized_string().split(" ") +
-                                   right_context.split(" ")]
-
-            tokenized_string = sentence.to_tokenized_string()
-
-            # method 1: subtokenize sentence
-            # subtokenized_sentence = self.tokenizer.encode(tokenized_string, add_special_tokens=True)
-
-            # method 2:
-            # transformer specific tokenization
-            subtokenized_sentence = self.tokenizer.tokenize(tokenized_string)
-            if len(subtokenized_sentence) == 0:
-                empty_sentences.append(sentence)
-                continue
-            else:
-                non_empty_sentences.append(sentence)
-
-            token_subtoken_lengths = self.reconstruct_tokens_from_subtokens(sentence, subtokenized_sentence)
-            subtokenized_sentences_token_lengths.append(token_subtoken_lengths)
-
-            subtoken_ids_sentence = self.tokenizer.convert_tokens_to_ids(subtokenized_sentence)
-
-            nr_sentence_parts = 0
-
-            while subtoken_ids_sentence:
-                nr_sentence_parts += 1
-                encoded_inputs = self.tokenizer.encode_plus(subtoken_ids_sentence,
-                                                            max_length=self.max_subtokens_sequence_length,
-                                                            stride=self.stride,
-                                                            return_overflowing_tokens=self.allow_long_sentences,
-                                                            truncation=True,
-                                                            )
-
-                subtoken_ids_split_sentence = encoded_inputs['input_ids']
-                subtokenized_sentences.append(torch.tensor(subtoken_ids_split_sentence, dtype=torch.long))
-
-                if 'overflowing_tokens' in encoded_inputs:
-                    subtoken_ids_sentence = encoded_inputs['overflowing_tokens']
-                else:
-                    subtoken_ids_sentence = None
-
-            sentence_parts_lengths.append(nr_sentence_parts)
-
-        # empty sentences get zero embeddings
-        for sentence in empty_sentences:
+        # set zero embeddings for empty sentences and return
+        if len(subtokenized_sentence) == 0:
             for token in sentence:
                 token.set_embedding(self.name, torch.zeros(self.embedding_length))
+            return
 
-        # only embed non-empty sentences and if there is at least one
-        sentences = non_empty_sentences
-        if len(sentences) == 0: return
+        # determine into how many subtokens each token is split
+        token_subtoken_lengths = self.reconstruct_tokens_from_subtokens(sentence, subtokenized_sentence)
 
-        # find longest sentence in batch
-        longest_sequence_in_batch: int = len(max(subtokenized_sentences, key=len))
+        # get sentence as list of subtoken ids
+        subtoken_ids_sentence = self.tokenizer.convert_tokens_to_ids(subtokenized_sentence)
 
-        total_sentence_parts = sum(sentence_parts_lengths)
+        # if sentence is too long, will be split into multiple parts
+        sentence_splits = []
+        while subtoken_ids_sentence:
+            encoded_inputs = self.tokenizer.encode_plus(subtoken_ids_sentence,
+                                                        max_length=self.max_subtokens_sequence_length,
+                                                        stride=self.stride,
+                                                        return_overflowing_tokens=self.allow_long_sentences,
+                                                        truncation=True,
+                                                        )
 
-        # initialize batch tensors and mask
-        input_ids = torch.zeros(
-            [total_sentence_parts, longest_sequence_in_batch],
-            dtype=torch.long,
-            device=flair.device,
-        )
-        mask = torch.zeros(
-            [total_sentence_parts, longest_sequence_in_batch],
-            dtype=torch.long,
-            device=flair.device,
-        )
-        for s_id, sentence in enumerate(subtokenized_sentences):
-            sequence_length = len(sentence)
-            input_ids[s_id][:sequence_length] = sentence
-            mask[s_id][:sequence_length] = torch.ones(sequence_length)
+            sentence_splits.append(torch.tensor(encoded_inputs['input_ids'], dtype=torch.long))
 
-        # put encoded batch through transformer model to get all hidden states of all encoder layers
-        if type(self.tokenizer) == TransfoXLTokenizer:
-            hidden_states = self.model(input_ids)[-1]
-        else:
-            hidden_states = self.model(input_ids, attention_mask=mask)[
-                -1]  # make the tuple a tensor; makes working with it easier.
-
-        hidden_states = torch.stack(hidden_states)
-
-        sentence_idx_offset = 0
+            if 'overflowing_tokens' in encoded_inputs:
+                subtoken_ids_sentence = encoded_inputs['overflowing_tokens']
+            else:
+                subtoken_ids_sentence = None
 
         # gradients are enabled if fine-tuning is enabled
         gradient_context = torch.enable_grad() if (self.fine_tune and self.training) else torch.no_grad()
-
         with gradient_context:
 
-            # iterate over all subtokenized sentences
-            for sentence_idx, (sentence, subtoken_lengths, nr_sentence_parts) in enumerate(
-                    zip(sentences, subtokenized_sentences_token_lengths, sentence_parts_lengths)):
+            # embed each sentence split
+            hidden_states_of_all_splits = []
+            for split_number, sentence_split in enumerate(sentence_splits):
 
-                sentence_hidden_state = hidden_states[:, sentence_idx + sentence_idx_offset, ...]
+                # initialize batch tensors and mask
+                input_ids = sentence_split.unsqueeze(0).to(flair.device)
 
-                for i in range(1, nr_sentence_parts):
-                    sentence_idx_offset += 1
-                    remainder_sentence_hidden_state = hidden_states[:, sentence_idx + sentence_idx_offset, ...]
-                    # remove stride_size//2 at end of sentence_hidden_state, and half at beginning of remainder,
-                    # in order to get some context into the embeddings of these words.
-                    # also don't include the embedding of the extra [CLS] and [SEP] tokens.
-                    sentence_hidden_state = torch.cat((sentence_hidden_state[:, :-1 - self.stride // 2, :],
-                                                       remainder_sentence_hidden_state[:, 1 + self.stride // 2:, :]), 1)
+                # put encoded batch through transformer model to get all hidden states of all encoder layers
+                hidden_states = self.model(input_ids)[-1]  # make the tuple a tensor; makes working with it easier.
 
-                subword_start_idx = self.begin_offset
+                # get hidden states as single tensor
+                split_hidden_state = torch.stack(hidden_states)[:, 0, ...]
+                hidden_states_of_all_splits.append(split_hidden_state)
 
-                # for each token, get embedding
-                for token_idx, (token, number_of_subtokens) in enumerate(zip(sentence, subtoken_lengths)):
+            # put splits back together into one tensor using overlapping strides
+            hidden_states = hidden_states_of_all_splits[0]
+            for i in range(1, len(hidden_states_of_all_splits)):
+                hidden_states = hidden_states[:, :-1 - self.stride // 2, :]
+                next_split = hidden_states_of_all_splits[i]
+                next_split = next_split[:, 1 + self.stride // 2:, :]
+                hidden_states = torch.cat([hidden_states, next_split], 1)
 
-                    # some tokens have no subtokens at all (if omitted by BERT tokenizer) so return zero vector
-                    if number_of_subtokens == 0:
-                        token.set_embedding(self.name, torch.zeros(self.embedding_length))
-                        continue
+            subword_start_idx = self.begin_offset
 
-                    subword_end_idx = subword_start_idx + number_of_subtokens
+            # for each token, get embedding
+            for token_idx, (token, number_of_subtokens) in enumerate(zip(sentence, token_subtoken_lengths)):
 
-                    subtoken_embeddings: List[torch.FloatTensor] = []
+                # some tokens have no subtokens at all (if omitted by BERT tokenizer) so return zero vector
+                if number_of_subtokens == 0:
+                    token.set_embedding(self.name, torch.zeros(self.embedding_length))
+                    continue
 
-                    # get states from all selected layers, aggregate with pooling operation
-                    for layer in self.layer_indexes:
-                        current_embeddings = sentence_hidden_state[layer][subword_start_idx:subword_end_idx]
+                subword_end_idx = subword_start_idx + number_of_subtokens
 
-                        if self.pooling_operation == "first":
-                            final_embedding: torch.FloatTensor = current_embeddings[0]
+                subtoken_embeddings: List[torch.FloatTensor] = []
 
-                        if self.pooling_operation == "last":
-                            final_embedding: torch.FloatTensor = current_embeddings[-1]
+                # get states from all selected layers, aggregate with pooling operation
+                for layer in self.layer_indexes:
+                    current_embeddings = hidden_states[layer][subword_start_idx:subword_end_idx]
 
-                        if self.pooling_operation == "first_last":
-                            final_embedding: torch.Tensor = torch.cat([current_embeddings[0], current_embeddings[-1]])
+                    if self.pooling_operation == "first":
+                        final_embedding: torch.FloatTensor = current_embeddings[0]
 
-                        if self.pooling_operation == "mean":
-                            all_embeddings: List[torch.FloatTensor] = [
-                                embedding.unsqueeze(0) for embedding in current_embeddings
-                            ]
-                            final_embedding: torch.Tensor = torch.mean(torch.cat(all_embeddings, dim=0), dim=0)
+                    if self.pooling_operation == "last":
+                        final_embedding: torch.FloatTensor = current_embeddings[-1]
 
-                        subtoken_embeddings.append(final_embedding)
+                    if self.pooling_operation == "first_last":
+                        final_embedding: torch.Tensor = torch.cat([current_embeddings[0], current_embeddings[-1]])
 
-                    # use scalar mix of embeddings if so selected
-                    if self.use_scalar_mix:
-                        sm_embeddings = torch.mean(torch.stack(subtoken_embeddings, dim=1), dim=1)
-                        # sm_embeddings = self.mix(subtoken_embeddings)
+                    if self.pooling_operation == "mean":
+                        all_embeddings: List[torch.FloatTensor] = [
+                            embedding.unsqueeze(0) for embedding in current_embeddings
+                        ]
+                        final_embedding: torch.Tensor = torch.mean(torch.cat(all_embeddings, dim=0), dim=0)
 
-                        subtoken_embeddings = [sm_embeddings]
+                    subtoken_embeddings.append(final_embedding)
 
-                    # set the extracted embedding for the token
-                    token.set_embedding(self.name, torch.cat(subtoken_embeddings))
+                # use scalar mix of embeddings if so selected
+                if self.use_scalar_mix:
+                    sm_embeddings = torch.mean(torch.stack(subtoken_embeddings, dim=1), dim=1)
+                    # sm_embeddings = self.mix(subtoken_embeddings)
 
-                    # move embeddings from context back to original sentence (if using context)
-                    if self.context_length > 0:
+                    subtoken_embeddings = [sm_embeddings]
 
-                        sentence_without_context = original_sentences[sentence_idx]
+                # set the extracted embedding for the token
+                token.set_embedding(self.name, torch.cat(subtoken_embeddings))
 
-                        # get context offset
-                        offset = context_offsets[sentence_idx]
-
-                        # set embeddings for non-context sentences
-                        if offset <= token_idx < offset + len(sentence_without_context.tokens):
-                            sentence_without_context.tokens[token_idx - offset]\
-                                .set_embedding(self.name, torch.cat(subtoken_embeddings))
-
-                    subword_start_idx += number_of_subtokens
-
+                # move embeddings from context back to original sentence (if using context)
                 if self.context_length > 0:
-                    sentence = sentence_without_context
+
+                    sentence_without_context = original_sentence
+
+                    # get context offset
+                    offset = context_offset
+
+                    # set embeddings for non-context sentences
+                    if offset <= token_idx < offset + len(sentence_without_context.tokens):
+                        sentence_without_context.tokens[token_idx - offset] \
+                            .set_embedding(self.name, torch.cat(subtoken_embeddings))
+
+                subword_start_idx += number_of_subtokens
+
+            if self.context_length > 0:
+                sentence = sentence_without_context
+
+    def _expand_sentence_with_context(self, sentence):
+
+        # remember original sentence
+        original_sentence = sentence
+
+        # get left context
+        left_context = ''
+        while True:
+            sentence = sentence.previous_sentence()
+            if sentence is None: break
+
+            left_context = sentence.to_tokenized_string() + ' ' + left_context
+            left_context = left_context.strip()
+            if len(left_context.split(" ")) > self.context_length:
+                left_context = " ".join(left_context.split(" ")[-self.context_length:])
+                break
+        context_length = len(left_context.split(" "))
+        # context_offsets.append(context_length)
+        original_sentence.left_context = left_context
+
+        # get right context
+        sentence = original_sentence
+        right_context = ''
+        while True:
+            sentence = sentence.next_sentence()
+            if sentence is None: break
+
+            right_context += ' ' + sentence.to_tokenized_string()
+            right_context = right_context.strip()
+            if len(right_context.split(" ")) > self.context_length:
+                right_context = " ".join(right_context.split(" ")[:self.context_length])
+                break
+        original_sentence.right_context = right_context
+
+        # make expanded sentence
+        expanded_sentence = Sentence()
+        expanded_sentence.tokens = [Token(token) for token in left_context.split(" ") +
+                                    original_sentence.to_tokenized_string().split(" ") +
+                                    right_context.split(" ")]
+        return expanded_sentence, context_length
 
     def reconstruct_tokens_from_subtokens(self, sentence, subtokens):
         word_iterator = iter(sentence)

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -937,7 +937,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                 # get left context
                 left_context = ''
                 while True:
-                    sentence = sentence.previous()
+                    sentence = sentence.previous_sentence()
                     if sentence is None: break
 
                     left_context = sentence.to_tokenized_string() + ' ' + left_context
@@ -950,7 +950,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                 sentence = original_sentence
                 right_context = ''
                 while True:
-                    sentence = sentence.next()
+                    sentence = sentence.next_sentence()
                     if sentence is None: break
 
                     right_context += ' ' + sentence.to_tokenized_string()

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -330,6 +330,15 @@ class SequenceTagger(flair.nn.Model):
             if isinstance(sentences, Sentence):
                 sentences = [sentences]
 
+            # set context if not set already
+            previous_sentence = None
+            for sentence in sentences:
+                if sentence.is_context_set(): continue
+                sentence._previous_sentence = previous_sentence
+                sentence._next_sentence = None
+                if previous_sentence: previous_sentence._next_sentence = sentence
+                previous_sentence = sentence
+
             # reverse sort all sequences by their length
             rev_order_len_index = sorted(
                 range(len(sentences)), key=lambda k: len(sentences[k]), reverse=True

--- a/resources/docs/embeddings/TRANSFORMER_EMBEDDINGS.md
+++ b/resources/docs/embeddings/TRANSFORMER_EMBEDDINGS.md
@@ -129,7 +129,7 @@ example shows how to use scalar mix for a base RoBERTa model on all layers:
 from flair.embeddings import TransformerWordEmbeddings
 
 # init embedding
-embedding = TransformerWordEmbeddings("roberta-base", layers="all", use_scalar_mix=True)
+embedding = TransformerWordEmbeddings("roberta-base", layers="all", layer_mean=True)
 
 # create a sentence
 sentence = Sentence("The Oktoberfest is the world's largest Volksfest .")

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -90,7 +90,7 @@ def test_transformer_word_embeddings():
         assert len(token.get_embedding()) == 0
     del embeddings
 
-    embeddings = TransformerWordEmbeddings('distilbert-base-uncased', layers='all', use_scalar_mix=True)
+    embeddings = TransformerWordEmbeddings('distilbert-base-uncased', layers='all', layer_mean=True)
 
     embeddings.embed(sentence)
 
@@ -105,7 +105,7 @@ def test_transformer_word_embeddings():
 
 def test_transformer_weird_sentences():
 
-    embeddings = TransformerWordEmbeddings('distilbert-base-uncased', layers='all', use_scalar_mix=True)
+    embeddings = TransformerWordEmbeddings('distilbert-base-uncased', layers='all', layer_mean=True)
 
     sentence = Sentence("Hybrid mesons , qq ̄ states with an admixture")
     embeddings.embed(sentence)


### PR DESCRIPTION
Various refactorings of FLERT approach: 

1. `Sentence` objects now have `next_sentence()` and `previous_sentence()` methods that are set automatically if loaded through `ColumnCorpus`. This is a pointer system to navigate through sentences in a corpus: 
```python
# load corpus
corpus = MIT_MOVIE_NER_SIMPLE(in_memory=False)

# get a sentence
sentence = corpus.test[123]
print(sentence)
# get the previous sentence
print(sentence.previous_sentence())
# get the sentence after that
print(sentence.next_sentence())
# get the sentence after the next sentence
print(sentence.next_sentence().next_sentence())
```
This allows dynamic computation of contexts in the embedding classes. 

2.  `Sentence` objects now have the `is_document_boundary` field which is set through the `ColumnCorpus`. In some datasets, there are sentences like "-DOCSTART-" that just indicate document boundaries. This is now recorded as a boolean in the object.

3. `TransformerWordEmbeddings` refactored for dynamic context, robustness to long sentences and readability. The names of some constructor arguments have changed for clarity: `pooling_operation` is now `subtoken_pooling` (to make clear that we pool subtokens), `use_scalar_mean` is now `layer_mean` (we only do a simple layer mean) and `use_context` can now optionally take an integer to indicate the length of the context.

For instance, to create embeddings with a document-level context of 64 subtokens, init like this:
```python
embeddings = TransformerWordEmbeddings(
    model='bert-base-uncased',
    layers="-1",
    subtoken_pooling="first",
    fine_tune=True,
    use_context=64,
)
```

From my testing, it also seems that the new implementation is a bit faster. 

