### PR TITLE
GH-2033: More options for splits in corpora and training

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1351,7 +1351,7 @@ class Corpus:
 
 
 class MultiCorpus(Corpus):
-    def __init__(self, corpora: List[Corpus], name: str = "multicorpus"):
+    def __init__(self, corpora: List[Corpus], name: str = "multicorpus", **corpusargs):
         self.corpora: List[Corpus] = corpora
 
         train_parts = []
@@ -1367,10 +1367,14 @@ class MultiCorpus(Corpus):
             ConcatDataset(dev_parts) if len(dev_parts) > 0 else None,
             ConcatDataset(test_parts) if len(test_parts) > 0 else None,
             name=name,
+            **corpusargs,
         )
 
     def __str__(self):
-        output = f"MultiCorpus: {len(self.train)} train + {len(self.dev)} dev + {len(self.test)} test sentences\n - "
+        output = f"MultiCorpus: " \
+                 f"{len(self.train) if self.train else 0} train + " \
+                 f"{len(self.dev) if self.dev else 0} dev + " \
+                 f"{len(self.test) if self.test else 0} test sentences\n - "
         output += "\n - ".join([f'{type(corpus).__name__} {str(corpus)}' for corpus in self.corpora])
         return output
 

--- a/flair/data.py
+++ b/flair/data.py
@@ -1053,12 +1053,13 @@ class Corpus:
             dev: FlairDataset = None,
             test: FlairDataset = None,
             name: str = "corpus",
+            sample_missing_splits: bool = True,
     ):
         # set name
         self.name: str = name
 
         # sample test data if none is provided
-        if test is None:
+        if test is None and sample_missing_splits:
             train_length = len(train)
             test_size: int = round(train_length / 10)
             splits = randomly_split_into_two_datasets(train, test_size)
@@ -1066,7 +1067,7 @@ class Corpus:
             train = splits[1]
 
         # sample dev data if none is provided
-        if dev is None:
+        if dev is None and sample_missing_splits:
             train_length = len(train)
             dev_size: int = round(train_length / 10)
             splits = randomly_split_into_two_datasets(train, dev_size)
@@ -1279,9 +1280,9 @@ class Corpus:
 
     def __str__(self) -> str:
         return "Corpus: %d train + %d dev + %d test sentences" % (
-            len(self.train),
-            len(self.dev),
-            len(self.test),
+            len(self.train) if self.train else 0,
+            len(self.dev) if self.dev else 0,
+            len(self.test) if self.test else 0,
         )
 
     def make_label_dictionary(self, label_type: str = None) -> Dictionary:
@@ -1330,7 +1331,11 @@ class Corpus:
         return class_to_count
 
     def get_all_sentences(self) -> Dataset:
-        return ConcatDataset([self.train, self.dev, self.test])
+        parts = []
+        if self.train: parts.append(self.train)
+        if self.dev: parts.append(self.dev)
+        if self.test: parts.append(self.test)
+        return ConcatDataset(parts)
 
     def make_tag_dictionary(self, tag_type: str) -> Dictionary:
 

--- a/flair/data.py
+++ b/flair/data.py
@@ -1354,10 +1354,18 @@ class MultiCorpus(Corpus):
     def __init__(self, corpora: List[Corpus], name: str = "multicorpus"):
         self.corpora: List[Corpus] = corpora
 
+        train_parts = []
+        dev_parts = []
+        test_parts = []
+        for corpus in self.corpora:
+            if corpus.train: train_parts.append(corpus.train)
+            if corpus.dev: dev_parts.append(corpus.dev)
+            if corpus.test: test_parts.append(corpus.test)
+
         super(MultiCorpus, self).__init__(
-            ConcatDataset([corpus.train for corpus in self.corpora]),
-            ConcatDataset([corpus.dev for corpus in self.corpora]),
-            ConcatDataset([corpus.test for corpus in self.corpora]),
+            ConcatDataset(train_parts) if len(train_parts) > 0 else None,
+            ConcatDataset(dev_parts) if len(dev_parts) > 0 else None,
+            ConcatDataset(test_parts) if len(test_parts) > 0 else None,
             name=name,
         )
 

--- a/flair/datasets/base.py
+++ b/flair/datasets/base.py
@@ -249,7 +249,7 @@ class MongoDataset(FlairDataset):
             return sentence
 
 
-def find_train_dev_test_files(data_folder, dev_file, test_file, train_file):
+def find_train_dev_test_files(data_folder, dev_file, test_file, train_file, autofind_splits=True):
     if type(data_folder) == str:
         data_folder: Path = Path(data_folder)
 
@@ -263,7 +263,7 @@ def find_train_dev_test_files(data_folder, dev_file, test_file, train_file):
     suffixes_to_ignore = {".gz", ".swp"}
 
     # automatically identify train / test / dev files
-    if train_file is None:
+    if train_file is None and autofind_splits:
         for file in data_folder.iterdir():
             file_name = file.name
             if not suffixes_to_ignore.isdisjoint(file.suffixes):
@@ -278,7 +278,7 @@ def find_train_dev_test_files(data_folder, dev_file, test_file, train_file):
                 test_file = file
 
         # if no test file is found, take any file with 'test' in name
-        if test_file is None:
+        if test_file is None and autofind_splits:
             for file in data_folder.iterdir():
                 file_name = file.name
                 if not suffixes_to_ignore.isdisjoint(file.suffixes):

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -29,6 +29,7 @@ class ColumnCorpus(Corpus):
             skip_first_line: bool = False,
             in_memory: bool = True,
             label_name_map: Dict[str, str] = None,
+            **corpusargs,
     ):
         """
         Instantiates a Corpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
@@ -94,7 +95,7 @@ class ColumnCorpus(Corpus):
             label_name_map=label_name_map,
         ) if dev_file is not None else None
 
-        super(ColumnCorpus, self).__init__(train, dev, test, name=str(data_folder))
+        super(ColumnCorpus, self).__init__(train, dev, test, name=str(data_folder), **corpusargs)
 
 
 class ColumnDataset(FlairDataset):
@@ -380,7 +381,6 @@ class BIOFID(ColumnCorpus):
 
 
 class BIOSCOPE(ColumnCorpus):
-
     def __init__(
             self,
             base_path: Union[str, Path] = None,
@@ -416,7 +416,6 @@ class CONLL_03(ColumnCorpus):
             base_path: Union[str, Path] = None,
             tag_to_bioes: str = "ner",
             in_memory: bool = True,
-            document_as_sequence: bool = False,
             **corpusargs,
     ):
         """
@@ -469,7 +468,6 @@ class CONLL_03_GERMAN(ColumnCorpus):
             base_path: Union[str, Path] = None,
             tag_to_bioes: str = "ner",
             in_memory: bool = True,
-            document_as_sequence: bool = False,
             **corpusargs,
     ):
         """
@@ -511,7 +509,7 @@ class CONLL_03_GERMAN(ColumnCorpus):
             columns,
             tag_to_bioes=tag_to_bioes,
             in_memory=in_memory,
-            document_separator_token=None if not document_as_sequence else "-DOCSTART-",
+            document_separator_token="-DOCSTART-",
             **corpusargs,
         )
 
@@ -522,7 +520,6 @@ class CONLL_03_DUTCH(ColumnCorpus):
             base_path: Union[str, Path] = None,
             tag_to_bioes: str = "ner",
             in_memory: bool = True,
-            document_as_sequence: bool = False,
             **corpusargs,
     ):
         """
@@ -561,7 +558,7 @@ class CONLL_03_DUTCH(ColumnCorpus):
             tag_to_bioes=tag_to_bioes,
             encoding="latin-1",
             in_memory=in_memory,
-            document_separator_token=None if not document_as_sequence else "-DOCSTART-",
+            document_separator_token="-DOCSTART-",
             **corpusargs,
         )
 
@@ -1122,7 +1119,6 @@ class MIT_RESTAURANT_NER(ColumnCorpus):
             base_path: Union[str, Path] = None,
             tag_to_bioes: str = "ner",
             in_memory: bool = True,
-            document_as_sequence: bool = False,
             **corpusargs,
     ):
         """
@@ -1160,7 +1156,6 @@ class MIT_RESTAURANT_NER(ColumnCorpus):
             tag_to_bioes=tag_to_bioes,
             encoding="latin-1",
             in_memory=in_memory,
-            document_separator_token=None if not document_as_sequence else "-DOCSTART-",
             **corpusargs,
         )
 
@@ -1419,7 +1414,6 @@ class TURKU_NER(ColumnCorpus):
             base_path: Union[str, Path] = None,
             tag_to_bioes: str = "ner",
             in_memory: bool = True,
-            document_as_sequence: bool = False,
             **corpusargs,
     ):
         """
@@ -1465,7 +1459,7 @@ class TURKU_NER(ColumnCorpus):
             tag_to_bioes=tag_to_bioes,
             encoding="latin-1",
             in_memory=in_memory,
-            document_separator_token=None if not document_as_sequence else "-DOCSTART-",
+            document_separator_token="-DOCSTART-",
             **corpusargs,
         )
 
@@ -1476,7 +1470,6 @@ class TWITTER_NER(ColumnCorpus):
             base_path: Union[str, Path] = None,
             tag_to_bioes: str = "ner",
             in_memory: bool = True,
-            document_as_sequence: bool = False,
             **corpusargs,
     ):
         """
@@ -1516,7 +1509,6 @@ class TWITTER_NER(ColumnCorpus):
             encoding="latin-1",
             train_file="ner.txt",
             in_memory=in_memory,
-            document_separator_token=None if not document_as_sequence else "-DOCSTART-",
             **corpusargs,
         )
 
@@ -1738,11 +1730,11 @@ class WSD_UFSAC(ColumnCorpus):
             self,
             base_path: Union[str, Path] = None,
             in_memory: bool = True,
-            document_as_sequence: bool = False,
             train_file: str = None,
             dev_file: str = None,
             test_file: str = None,
-            cut_multisense: bool = True
+            cut_multisense: bool = True,
+            **corpusargs,
     ):
         """
         Initialize a custom corpus with any two WSD datasets in the UFSAC format. This is only possible if you've
@@ -1807,40 +1799,10 @@ class WSD_UFSAC(ColumnCorpus):
             tag_to_bioes=None,
             encoding="latin-1",
             in_memory=in_memory,
-            document_separator_token=None if not document_as_sequence else "-DOCSTART-",
             train_file=train_file,
             dev_file=dev_file,
-            test_file=test_file
-        )
-
-
-class BIOSCOPE(ColumnCorpus):
-
-    def __init__(
-            self,
-            base_path: Union[str, Path] = None,
-            in_memory: bool = True,
-    ):
-        if type(base_path) == str:
-            base_path: Path = Path(base_path)
-
-        # column format
-        columns = {0: "text", 1: "tag"}
-
-        # this dataset name
-        dataset_name = self.__class__.__name__.lower()
-
-        # default dataset folder is the cache root
-        if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
-        data_folder = base_path / dataset_name
-
-        # download data if necessary
-        bioscope_path = "https://raw.githubusercontent.com/whoisjones/BioScopeSequenceLabelingData/master/sequence_labeled/"
-        cached_path(f"{bioscope_path}output.txt", Path("datasets") / dataset_name)
-
-        super(BIOSCOPE, self).__init__(
-            data_folder, columns, in_memory=in_memory, train_file="output.txt"
+            test_file=test_file,
+            **corpusargs,
         )
 
 

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -29,6 +29,7 @@ class ColumnCorpus(Corpus):
             skip_first_line: bool = False,
             in_memory: bool = True,
             label_name_map: Dict[str, str] = None,
+            autofind_splits: bool = True,
             **corpusargs,
     ):
         """
@@ -51,7 +52,7 @@ class ColumnCorpus(Corpus):
 
         # find train, dev and test files if not specified
         dev_file, test_file, train_file = \
-            find_train_dev_test_files(data_folder, dev_file, test_file, train_file)
+            find_train_dev_test_files(data_folder, dev_file, test_file, train_file, autofind_splits)
 
         # get train data
         train = ColumnDataset(
@@ -65,7 +66,7 @@ class ColumnCorpus(Corpus):
             document_separator_token=document_separator_token,
             skip_first_line=skip_first_line,
             label_name_map=label_name_map,
-        )
+        ) if train_file is not None else None
 
         # read in test file if exists
         test = ColumnDataset(

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -682,13 +682,15 @@ class ModelTrainer:
             for subcorpus in self.corpus.corpora:
                 log_line(log)
                 if subcorpus.test:
-                    self.model.evaluate(
+                    subcorpus_results, subcorpus_loss = self.model.evaluate(
                         subcorpus.test,
                         mini_batch_size=eval_mini_batch_size,
                         num_workers=num_workers,
                         out_path=base_path / f"{subcorpus.name}-test.tsv",
                         embedding_storage_mode="none",
                     )
+                    log.info(subcorpus.name)
+                    log.info(subcorpus_results.log_line)
 
         # get and return the final test score of best model
         final_score = test_results.main_score

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -681,13 +681,14 @@ class ModelTrainer:
         if type(self.corpus) is MultiCorpus:
             for subcorpus in self.corpus.corpora:
                 log_line(log)
-                self.model.evaluate(
-                    subcorpus.test,
-                    mini_batch_size=eval_mini_batch_size,
-                    num_workers=num_workers,
-                    out_path=base_path / f"{subcorpus.name}-test.tsv",
-                    embedding_storage_mode="none",
-                )
+                if subcorpus.test:
+                    self.model.evaluate(
+                        subcorpus.test,
+                        mini_batch_size=eval_mini_batch_size,
+                        num_workers=num_workers,
+                        out_path=base_path / f"{subcorpus.name}-test.tsv",
+                        embedding_storage_mode="none",
+                    )
 
         # get and return the final test score of best model
         final_score = test_results.main_score


### PR DESCRIPTION
Closes #2033 

For various reasons, we might want to have a `Corpus` that does not define all three splits (train/dev/test). For instance, we might want to train a model over the entire dataset and not hold out any data for validation/evaluation. 

This PR adds several ways of doing so.

1. If a dataset has predefined splits, like most NLP datasets, you can pass the arguments `train_with_test` and `train_with_dev` to the `ModelTrainer`. This causes the trainer to train over all three splits (and do no evaluation):

```python
trainer.train(f"path/to/your/folder",
    learning_rate=0.1,
    mini_batch_size=16,
    train_with_dev=True,
    train_with_test=True,
)
```

2. You can also now create a Corpus with fewer splits without having all three splits automatically sampled. Pass `sample_missing_splits=False` as argument to do this. For instance, to load SemCor WSD corpus only as training data, do:

```python
semcor = WSD_UFSAC(train_file='semcor.xml', sample_missing_splits=False, autofind_splits=False)
```

