### PR TITLE
HF model hub improvements

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1134,10 +1134,12 @@ class SequenceTagger(flair.nn.Model):
                 model_name = model_name_splitted[0]
 
             # Lazy import
-            from transformers import file_utils
+            from huggingface_hub import file_download
 
-            url = file_utils.hf_bucket_url(model_id=model_name, revision=revision, filename=hf_model_name)
-            model_name = file_utils.cached_path(url_or_filename=url, cache_dir=flair.cache_root)
+            url = file_download.hf_hub_url(model_id=model_name, revision=revision, filename=hf_model_name)
+            model_name = file_download.cached_download(url=url, library_name="flair",
+                                                       library_version=flair.__version__,
+                                                       cache_dir=flair.cache_root)
 
         return model_name
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1139,7 +1139,7 @@ class SequenceTagger(flair.nn.Model):
             url = hf_hub_url(model_id=model_name, revision=revision, filename=hf_model_name)
             model_name = cached_download(url=url, library_name="flair",
                                          library_version=flair.__version__,
-                                         cache_dir=flair.cache_root)
+                                         cache_dir=flair.cache_root / 'models')
 
         return model_name
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1136,8 +1136,8 @@ class SequenceTagger(flair.nn.Model):
             # Lazy import
             from huggingface_hub import hf_hub_url, cached_download
 
-            url = file_download.hf_hub_url(model_id=model_name, revision=revision, filename=hf_model_name)
-            model_name = file_download.cached_download(url=url, library_name="flair",
+            url = hf_hub_url(model_id=model_name, revision=revision, filename=hf_model_name)
+            model_name = cached_download(url=url, library_name="flair",
                                                        library_version=flair.__version__,
                                                        cache_dir=flair.cache_root)
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1134,7 +1134,7 @@ class SequenceTagger(flair.nn.Model):
                 model_name = model_name_splitted[0]
 
             # Lazy import
-            from huggingface_hub import file_download
+            from huggingface_hub import hf_hub_url, cached_download
 
             url = file_download.hf_hub_url(model_id=model_name, revision=revision, filename=hf_model_name)
             model_name = file_download.cached_download(url=url, library_name="flair",

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1138,8 +1138,8 @@ class SequenceTagger(flair.nn.Model):
 
             url = hf_hub_url(model_id=model_name, revision=revision, filename=hf_model_name)
             model_name = cached_download(url=url, library_name="flair",
-                                                       library_version=flair.__version__,
-                                                       cache_dir=flair.cache_root)
+                                         library_version=flair.__version__,
+                                         cache_dir=flair.cache_root)
 
         return model_name
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ konoha<5.0.0,>=4.0.0
 janome
 gdown
 numpy<1.20.0
+huggingface-hub


### PR DESCRIPTION
Hi,

with this PR, some improvements in the Hugging Face model hub logic are done:

* We use the shiny new client library `huggingface-hub` for downloading Flair-specific models
* Additionally, we pass a Flair-specific user agent information (`flair` and the used version) to the Hugging Face infrastructure

Notice: the new Hugging Face model hub feature is a secret (hidden) feature now. Expect an official announcement in the next upcoming *0.8* version.

Thanks to the Hugging Face team for their great support and providing the hosting infrastructure :heart: 