### PR TITLE
GH-2035: Improve transformer serialization and prepare transformers 4 integration

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -242,6 +242,12 @@ class ColumnDataset(FlairDataset):
 
         # check if this sentence is a document boundary
         if sentence.to_original_text() == self.document_separator_token: sentence.is_document_boundary = True
+
+        if self.tag_to_bioes is not None:
+            sentence.convert_tag_scheme(
+                tag_type=self.tag_to_bioes, target_scheme="iobes"
+            )
+
         if len(sentence) > 0: return sentence
 
     def _parse_token(self, line: str) -> Token:

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1000,13 +1000,17 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
             # embed each sentence split
             hidden_states_of_all_splits = []
-            for sentence_split in sentence_splits:
+            for split_number, sentence_split in enumerate(sentence_splits):
 
                 # initialize batch tensors and mask
                 input_ids = sentence_split.unsqueeze(0).to(flair.device)
 
-                # put encoded batch through transformer model to get all hidden states of all encoder layers
-                hidden_states = self.model(input_ids)[-1]  # make the tuple a tensor; makes working with it easier.
+                if split_number < len(sentence_splits) - 1:
+                    with torch.no_grad():
+                        hidden_states = self.model(input_ids)[-1]
+                else:
+                    # put encoded batch through transformer model to get all hidden states of all encoder layers
+                    hidden_states = self.model(input_ids)[-1]  # make the tuple a tensor; makes working with it easier.
 
                 # get hidden states as single tensor
                 split_hidden_state = torch.stack(hidden_states)[:, 0, ...]

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -958,15 +958,15 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         # determine into how many subtokens each token is split
         token_subtoken_lengths = self.reconstruct_tokens_from_subtokens(sentence, subtokenized_sentence)
 
-        # get sentence as list of subtoken ids
-        subtoken_ids_sentence = self.tokenizer.convert_tokens_to_ids(subtokenized_sentence)
-
         # if sentence is too long, will be split into multiple parts
         sentence_splits = []
 
         # check if transformer version 3 is used - in this case use old handling
         import transformers
         if transformers.__version__.startswith('3'):
+
+            # get sentence as list of subtoken ids
+            subtoken_ids_sentence = self.tokenizer.convert_tokens_to_ids(subtokenized_sentence)
 
             while subtoken_ids_sentence:
                 encoded_inputs = self.tokenizer.encode_plus(subtoken_ids_sentence,

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1232,6 +1232,8 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             "layer_mean": self.layer_mean,
             "fine_tune": self.fine_tune,
             "allow_long_sentences": self.allow_long_sentences,
+            "memory_effective_training": self.memory_effective_training,
+            "respect_document_boundaries": self.respect_document_boundaries,
         }
 
         return model_state
@@ -1251,6 +1253,11 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         if 'use_context' in self.__dict__.keys():
             self.__dict__['context_length'] = 64 if self.__dict__['use_context'] == True else 0
 
+        if not 'respect_document_boundaries' in self.__dict__.keys():
+            self.__dict__['respect_document_boundaries'] = True
+        if not 'memory_effective_training' in self.__dict__.keys():
+            self.__dict__['memory_effective_training'] = True
+
         # constructor arguments
         layers = ','.join([str(idx) for idx in self.__dict__['layer_indexes']])
         subtoken_pooling = self.__dict__['subtoken_pooling']
@@ -1258,6 +1265,8 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         layer_mean = self.__dict__['layer_mean']
         fine_tune = self.__dict__['fine_tune']
         allow_long_sentences = self.__dict__['allow_long_sentences']
+        respect_document_boundaries = self.__dict__['respect_document_boundaries']
+        memory_effective_training = self.__dict__['memory_effective_training']
 
         model_name = self.__dict__['name'].split('transformer-word-')[-1]
 
@@ -1276,6 +1285,8 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                                               layer_mean=layer_mean,
                                               fine_tune=fine_tune,
                                               allow_long_sentences=allow_long_sentences,
+                                              respect_document_boundaries=respect_document_boundaries,
+                                              memory_effective_training=memory_effective_training,
                                               config=loaded_config,
                                               state_dict=d["model_state_dict"],
                                               )

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -794,6 +794,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             fine_tune: bool = False,
             allow_long_sentences: bool = True,
             use_context: Union[bool, int] = False,
+            memory_effective_training: bool = True,
             **kwargs
     ):
         """
@@ -836,6 +837,9 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         # model name
         self.name = 'transformer-word-' + str(model)
+
+        # whether to detach gradients on overlong sentences
+        self.memory_effective_training = memory_effective_training
 
         # store whether to use context (and how much)
         if type(use_context) == bool:
@@ -1005,7 +1009,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                 # initialize batch tensors and mask
                 input_ids = sentence_split.unsqueeze(0).to(flair.device)
 
-                if split_number < len(sentence_splits) - 1:
+                if self.memory_effective_training and split_number < len(sentence_splits) - 1:
                     with torch.no_grad():
                         hidden_states = self.model(input_ids)[-1]
                 else:

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -795,6 +795,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             allow_long_sentences: bool = True,
             use_context: Union[bool, int] = False,
             memory_effective_training: bool = True,
+            respect_document_boundaries: bool = True,
             **kwargs
     ):
         """
@@ -844,6 +845,9 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             self.context_length: int = 64 if use_context else 0
         if type(use_context) == int:
             self.context_length: int = use_context
+
+        # if using context, can we cross document boundaries?
+        self.respect_document_boundaries = respect_document_boundaries
 
         # when initializing, embeddings are in eval mode by default
         self.model.eval()
@@ -1089,7 +1093,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         while True:
             sentence = sentence.previous_sentence()
             if sentence is None: break
-            if sentence.is_document_boundary: break
+            if self.respect_document_boundaries and sentence.is_document_boundary: break
 
             left_context = sentence.to_tokenized_string() + ' ' + left_context
             left_context = left_context.strip()
@@ -1105,7 +1109,7 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         while True:
             sentence = sentence.next_sentence()
             if sentence is None: break
-            if sentence.is_document_boundary: break
+            if self.respect_document_boundaries and sentence.is_document_boundary: break
 
             right_context += ' ' + sentence.to_tokenized_string()
             right_context = right_context.strip()

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -787,7 +787,7 @@ class PooledFlairEmbeddings(TokenEmbeddings):
 class TransformerWordEmbeddings(TokenEmbeddings):
     def __init__(
             self,
-            model: Union[str, Tuple] = "bert-base-uncased",
+            model: str = "bert-base-uncased",
             layers: str = "all",
             subtoken_pooling: str = "first",
             layer_mean: bool = True,
@@ -816,7 +816,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
         # load tokenizer and transformer model
-        # if type(model) == str:
         self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(model, **kwargs)
         if not 'config' in kwargs:
             config = AutoConfig.from_pretrained(model, output_hidden_states=True, **kwargs)

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -276,6 +276,8 @@ class SequenceTagger(flair.nn.Model):
         if "reproject_to" in state.keys():
             reproject_embeddings = state["reproject_to"]
 
+        print(state["embeddings"])
+
         model = SequenceTagger(
             hidden_size=state["hidden_size"],
             embeddings=state["embeddings"],

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -276,8 +276,6 @@ class SequenceTagger(flair.nn.Model):
         if "reproject_to" in state.keys():
             reproject_embeddings = state["reproject_to"]
 
-        print(state["embeddings"])
-
         model = SequenceTagger(
             hidden_size=state["hidden_size"],
             embeddings=state["embeddings"],


### PR DESCRIPTION
This PR improves serialization of the `TransformerWordEmbeddings` class such that you can now train a model with one version of the transformers library and load it with another version. Previously, if you trained a model with transformers 3.5.1 and loaded it with 3.1.01, or trained with 3.5.1 and loaded with 4.1.1, or other version mismatches, there would either be errors or bad predictions. 

Closes #1747 (I believe)

This PR is in preparation for updating Flair to transformers 4. 

**Migration guide:** If you have a model that uses `TransformerWordEmbeddings` you can save it in the new version-independent format by loading the model with the same transformers version you used to train it, and then saving it again. The newly saved model is then version-independent: 

```python
# load old model, but use the *same transformer version you used when training this model*
tagger = SequenceTagger.load('path/to/old-model.pt')

# save the model. It is now version-independent and can for instance be loaded with transformers 4.
tagger.save('path/to/new-model.pt')
```

The PR also adds optional parameters to control document boundary behavior in `TransformerWordEmbeddings` and fixes a bug in the refactored `ColumnDataset` that caused BIOES conversion to not take place.

 