### PR TITLE
GH-2056: fix regression prediction errors

### DIFF
--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -180,13 +180,16 @@ class TextRegressor(flair.models.TextClassifier):
         model_state = {
             "state_dict": self.state_dict(),
             "document_embeddings": self.document_embeddings,
+            "label_name": self.label_type,
         }
         return model_state
 
     @staticmethod
     def _init_model_with_state_dict(state):
 
-        model = TextRegressor(document_embeddings=state["document_embeddings"])
+        label_name = state["label_name"] if "label_name" in state.keys() else None
+
+        model = TextRegressor(document_embeddings=state["document_embeddings"], label_name=label_name)
 
         model.load_state_dict(state["state_dict"])
         return model


### PR DESCRIPTION
Closes #2056  

This PR does a quick fix of two problems in the regression model: 
- the predict() method was unable to set labels and threw errors (see #2056) 
- predicted labels had no label name 

Now, you can set a label name either in the predict method or during instantiation of the regression model you want to train. So the full code for training a regression model and using it to predict is: 

```python
# load regression dataset
corpus = WASSA_JOY()

# make simple document embeddings
embeddings = DocumentPoolEmbeddings([WordEmbeddings('glove')], fine_tune_mode='linear')

# init model and give name to label
model = TextRegressor(embeddings, label_name='happiness')

# target folder
output_folder = 'resources/taggers/regression_test/'

# run training
trainer = ModelTrainer(model, corpus)
trainer.train(
    output_folder,
    mini_batch_size=16,
    max_epochs=10,
)

# load model
model = TextRegressor.load(output_folder + 'best-model.pt')

# predict for sentence
sentence = Sentence('I am so happy')
model.predict(sentence)

# print sentence and prediction
print(sentence)
```

In my example run, this prints the following sentence + predicted value: 
~~~
Sentence: "I am so happy"   [− Tokens: 4  − Sentence-Labels: {'happiness': [0.9239126443862915 (1.0)]}]
~~~