### PR TITLE
Fix linear input dimension if the reproject 

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -213,7 +213,7 @@ class SequenceTagger(flair.nn.Model):
             )
         else:
             self.linear = torch.nn.Linear(
-                self.embeddings.embedding_length, len(tag_dictionary)
+                rnn_input_dim, len(tag_dictionary)
             )
 
         if self.use_crf:


### PR DESCRIPTION
is set to different dimension than length of embeddings.