### PR TITLE
huggingface_hub: drop the first param name

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1136,7 +1136,7 @@ class SequenceTagger(flair.nn.Model):
             # Lazy import
             from huggingface_hub import hf_hub_url, cached_download
 
-            url = hf_hub_url(model_id=model_name, revision=revision, filename=hf_model_name)
+            url = hf_hub_url(model_name, revision=revision, filename=hf_model_name)
             model_name = cached_download(url=url, library_name="flair",
                                          library_version=flair.__version__,
                                          cache_dir=flair.cache_root / 'models')


### PR DESCRIPTION
for compatibility with huggingface_hub>=0.0.2

we handle datasets now using the same git-based system so that first param is now named repo_id not model_id 😇

