### PR TITLE
Fix the evaluate() method in the SimilarityLearner class

### DIFF
--- a/flair/models/similarity_learning_model.py
+++ b/flair/models/similarity_learning_model.py
@@ -271,11 +271,15 @@ class SimilarityLearner(flair.nn.Model):
 
     def evaluate(
         self,
-        data_loader: DataLoader,
+        data_pairs: DataPair,
         out_path: Path = None,
         embedding_storage_mode="none",
+        mini_batch_size=32,
+        num_workers=8,
     ) -> (Result, float):
         # assumes that for each data pair there's at least one embedding per modality
+
+        data_loader = DataLoader(data_pairs, batch_size=mini_batch_size, num_workers=num_workers)
 
         with torch.no_grad():
             # pre-compute embeddings for all targets in evaluation dataset
@@ -357,7 +361,7 @@ class SimilarityLearner(flair.nn.Model):
                 epoch_results_str,
                 detailed_results,
             ),
-            0,
+            torch.tensor(0),
         )
 
     def _get_state_dict(self):


### PR DESCRIPTION
The evaluate method does not have a similar function signature as other models, which is causing errors when training it.