### PR TITLE
add quiet=False in gdown.download

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -2507,7 +2507,7 @@ class WIKIANN(MultiCorpus):
                 url = google_drive_path + google_id
 
                 # download from google drive
-                gdown.download(url, str(language_folder / language) + '.tar.gz')
+                gdown.download(url, str(language_folder / language) + '.tar.gz', quiet=False)
 
                 # unzip
                 print("Extract data...")


### PR DESCRIPTION
a small edit that fixes this bug in WIKIANN corpus download with gdown
```
TypeError                                 Traceback (most recent call last)
<ipython-input-7-ea5a420416fe> in <module>()
----> 1 wikiann_corpus: Corpus = WIKIANN(languages=['ar'])
      2 print(wikiann_corpus)

/usr/local/lib/python3.7/dist-packages/flair/datasets/sequence_labeling.py in __init__(self, languages, base_path, tag_to_bioes, in_memory)
   2043 
   2044                 # download from google drive
-> 2045                 gdown.download(url, str(language_folder / language) + '.tar.gz')
   2046 
   2047                 # unzip

TypeError: download() missing 1 required positional argument: 'quiet'
```