### PR TITLE
in example fixed the argument from layer_mean to use_scalar_mix

### DIFF
--- a/resources/docs/embeddings/TRANSFORMER_EMBEDDINGS.md
+++ b/resources/docs/embeddings/TRANSFORMER_EMBEDDINGS.md
@@ -129,7 +129,7 @@ example shows how to use scalar mix for a base RoBERTa model on all layers:
 from flair.embeddings import TransformerWordEmbeddings
 
 # init embedding
-embedding = TransformerWordEmbeddings("roberta-base", layers="all", layer_mean=True)
+embedding = TransformerWordEmbeddings("roberta-base", layers="all", use_scalar_mix=True)
 
 # create a sentence
 sentence = Sentence("The Oktoberfest is the world's largest Volksfest .")


### PR DESCRIPTION
In `TransformerWordEmbeddings` example with scalar_mix, updated the argument from layer_mean to use_scalar_mix