### PR TITLE
GH-2116: Add FLERT models

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1010,6 +1010,12 @@ class SequenceTagger(flair.nn.Model):
             "ner-fast": "flair/ner-english-fast",
             "ner-ontonotes": "flair/ner-english-ontonotes",
             "ner-ontonotes-fast": "flair/ner-english-ontonotes-fast",
+            # Large NER models,
+            "ner-large": "flair/ner-english-large",
+            "ner-ontonotes-large": "flair/ner-english-ontonotes-large",
+            "de-ner-large": "flair/ner-german-large",
+            "nl-ner-large": "flair/ner-dutch-large",
+            "es-ner-large": "flair/ner-spanish-large",
             # Multilingual NER models
             "ner-multi": "flair/ner-multi",
             "multi-ner": "flair/ner-multi",


### PR DESCRIPTION
This PR adds our new very powerful and very slow FLERT models for NER for four languages. Closes #2116 

Load for instance with: 

```python
from flair.data import Sentence
from flair.models import SequenceTagger

# load tagger
tagger = SequenceTagger.load("ner-large")

# make example sentence
sentence = Sentence("George Washington went to Washington")

# predict NER tags
tagger.predict(sentence)

# print sentence
print(sentence)

# print predicted NER spans
print('The following NER tags are found:')
# iterate over entities and print
for entity in sentence.get_spans('ner'):
    print(entity)
```