### PR TITLE
GH-2137: hotfix for torch 1.8.0 error

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -25,7 +25,7 @@ from .training_utils import AnnealOnPlateau
 
 import logging.config
 
-__version__ = "0.8"
+__version__ = "0.8.0.post1"
 
 logging.config.dictConfig(
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil>=2.6.1
-torch>=1.5.0
+torch>=1.5.0,<=1.7.1
 gensim>=3.4.0,<=3.8.3
 tqdm>=4.26.0
 segtok>=1.5.7

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="flair",
-    version="0.8",
+    version="0.8.0.post1",
     description="A very simple framework for state-of-the-art NLP",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Hotfix for #2137 by limiting torch version to maximum 1.7.1. 

(A bigger fix to enable Flair for torch 1.8.0 is in the works.)