### PR TITLE
Fix references to multi-X-fast Flair embedding models

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -409,8 +409,8 @@ class FlairEmbeddings(TokenEmbeddings):
             "multi-backward": f"{hu_path}/lm-jw300-backward-v0.1.pt",
             "multi-v0-forward": f"{hu_path}/lm-multi-forward-v0.1.pt",
             "multi-v0-backward": f"{hu_path}/lm-multi-backward-v0.1.pt",
-            "multi-v0-forward-fast": f"{hu_path}/lm-multi-forward-fast-v0.1.pt",
-            "multi-v0-backward-fast": f"{hu_path}/lm-multi-backward-fast-v0.1.pt",
+            "multi-forward-fast": f"{hu_path}/lm-multi-forward-fast-v0.1.pt",
+            "multi-backward-fast": f"{hu_path}/lm-multi-backward-fast-v0.1.pt",
             # English models
             "en-forward": f"{hu_path}/news-forward-0.4.1.pt",
             "en-backward": f"{hu_path}/news-backward-0.4.1.pt",


### PR DESCRIPTION
This PR fixes: https://github.com/flairNLP/flair/issues/2140.

The [documentation](https://github.com/flairNLP/flair/blob/master/resources/docs/embeddings/FLAIR_EMBEDDINGS.md) suggests that the CPU friendly mix of corpora Flair embedding models should be referenced as `multi-X-fast`, but they were defined as `multi-v0-X-fast` in the `PRETRAINED_MODEL_ARCHIVE_MAP` dict [here](https://github.com/flairNLP/flair/blob/69d7c7d523b9111956d6fecd781d0b4654a4b13a/flair/embeddings/token.py#L412).

This issue resulted in errors when loading the model using the ID mentioned in the documentation. This PR fixes this.