### PR TITLE
GH-2137: fix serialization bugs and prepare Flair 0.8.1 release

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -25,7 +25,7 @@ from .training_utils import AnnealOnPlateau
 
 import logging.config
 
-__version__ = "0.8.0.post1"
+__version__ = "0.8.1"
 
 logging.config.dictConfig(
     {

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -591,6 +591,7 @@ class FlairEmbeddings(TokenEmbeddings):
         if "chars_per_chunk" not in self.__dict__:
             self.chars_per_chunk = 512
 
+        # unless fine-tuning is set, do not set language model to train() in order to disallow language model dropout
         if not self.fine_tune:
             pass
         else:

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -399,6 +399,56 @@ class LanguageModel(nn.Module):
 
         return perplexity
 
+    def __getstate__(self):
+        # special handling for serializing transformer models
+        state_dict = self.state_dict()
+
+        # serialize the transformer models and the constructor arguments (but nothing else)
+        model_state = {
+            "state_dict": state_dict,
+
+            "dictionary": self.dictionary,
+            "is_forward_lm": self.is_forward_lm,
+            "hidden_size": self.hidden_size,
+            "nlayers": self.nlayers,
+            "embedding_size": self.embedding_size,
+            "nout": self.nout,
+            "document_delimiter": self.document_delimiter,
+            "dropout": self.dropout,
+        }
+
+        return model_state
+
+    def __setstate__(self, d):
+
+        # special handling for deserializing transformer models
+        if "state_dict" in d:
+
+            # re-initialize language model with constructor arguments
+            language_model = LanguageModel(
+                dictionary=d['dictionary'],
+                is_forward_lm=d['is_forward_lm'],
+                hidden_size=d['hidden_size'],
+                nlayers=d['nlayers'],
+                embedding_size=d['embedding_size'],
+                nout=d['nout'],
+                document_delimiter=d['document_delimiter'],
+                dropout=d['dropout'],
+            )
+
+            language_model.load_state_dict(d['state_dict'])
+
+            # copy over state dictionary to self
+            for key in language_model.__dict__.keys():
+                self.__dict__[key] = language_model.__dict__[key]
+
+            # set the language model to eval() by default (this is necessary since FlairEmbeddings "protect" the LM
+            # in their "self.train()" method)
+            self.eval()
+
+        else:
+            self.__dict__ = d
+
     def _apply(self, fn):
 
         # models that were serialized using torch versions older than 1.4.0 lack the _flat_weights_names attribute

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -400,12 +400,10 @@ class LanguageModel(nn.Module):
         return perplexity
 
     def __getstate__(self):
-        # special handling for serializing transformer models
-        state_dict = self.state_dict()
 
-        # serialize the transformer models and the constructor arguments (but nothing else)
+        # serialize the language models and the constructor arguments (but nothing else)
         model_state = {
-            "state_dict": state_dict,
+            "state_dict": self.state_dict(),
 
             "dictionary": self.dictionary,
             "is_forward_lm": self.is_forward_lm,
@@ -421,7 +419,7 @@ class LanguageModel(nn.Module):
 
     def __setstate__(self, d):
 
-        # special handling for deserializing transformer models
+        # special handling for deserializing language models
         if "state_dict" in d:
 
             # re-initialize language model with constructor arguments

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil>=2.6.1
-torch>=1.5.0,<=1.7.1
+torch>=1.5.0
 gensim>=3.4.0,<=3.8.3
 tqdm>=4.26.0
 segtok>=1.5.7
@@ -20,5 +20,4 @@ sentencepiece==0.1.95
 konoha<5.0.0,>=4.0.0
 janome
 gdown==3.12.2
-numpy<1.20.0
 huggingface-hub

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="flair",
-    version="0.8.0.post1",
+    version="0.8.1",
     description="A very simple framework for state-of-the-art NLP",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR addresses the problems in the language model serialization and so addresses #2137 (for a full fix, all models need to be updated on the model hub). 

To make your models trained with an older torch run with torch 1.8.0 you need to load the models with torch <1.8.0 and save them again. This newly saved model is then capable of running with any torch version: 

```python
# load with torch 1.7.1 for instance
tagger = SequenceTagger.load('your/model.pt')

# save the model. It is now saved in a format that torch 1.8.0 can use
tagger.save('your/model/updated.pt')
```

It also rearranges the requirements to allow torch 1.8.0 again and also remove the numpy requirement (fixes #2138). 

