### PR TITLE
Gh 2117 more flexibility on main metric

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -128,6 +128,7 @@ class ModelTrainer:
         :param eval_on_train_shuffle: if True the train data fraction is determined on the start of training
         and kept fixed during training, otherwise it's sampled at beginning of each epoch
         :param save_model_at_each_epoch: If True, at each epoch the thus far trained model will be saved
+        :param main_score_type: Type of metric to use for best model tracking and learning rate scheduling (if dev data is available, otherwise loss will be used)
         :param kwargs: Other arguments for the Optimizer
         :return:
         """

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -93,6 +93,7 @@ class ModelTrainer:
         eval_on_train_fraction=0.0,
         eval_on_train_shuffle=False,
         save_model_at_each_epoch=False,
+        main_score_type=("micro avg", 'f1-score'),
         **kwargs,
     ) -> dict:
         """
@@ -131,6 +132,7 @@ class ModelTrainer:
         :return:
         """
 
+        self.main_score_type=main_score_type
         if self.use_tensorboard:
             try:
                 from torch.utils.tensorboard import SummaryWriter
@@ -445,6 +447,7 @@ class ModelTrainer:
                         mini_batch_size=mini_batch_chunk_size,
                         num_workers=num_workers,
                         embedding_storage_mode=embeddings_storage_mode,
+                        main_score_type=self.main_score_type
                     )
                     result_line += f"\t{train_eval_result.log_line}"
 
@@ -457,6 +460,7 @@ class ModelTrainer:
                         mini_batch_size=mini_batch_chunk_size,
                         num_workers=num_workers,
                         embedding_storage_mode=embeddings_storage_mode,
+                        main_score_type=self.main_score_type
                     )
                     result_line += (
                         f"\t{train_part_loss}\t{train_part_eval_result.log_line}"
@@ -472,6 +476,7 @@ class ModelTrainer:
                         num_workers=num_workers,
                         out_path=base_path / "dev.tsv",
                         embedding_storage_mode=embeddings_storage_mode,
+                        main_score_type=self.main_score_type
                     )
                     result_line += f"\t{dev_loss}\t{dev_eval_result.log_line}"
                     log.info(
@@ -500,6 +505,7 @@ class ModelTrainer:
                         num_workers=num_workers,
                         out_path=base_path / "test.tsv",
                         embedding_storage_mode=embeddings_storage_mode,
+                        main_score_type=self.main_score_type
                     )
                     result_line += f"\t{test_loss}\t{test_eval_result.log_line}"
                     log.info(
@@ -671,6 +677,7 @@ class ModelTrainer:
             num_workers=num_workers,
             out_path=base_path / "test.tsv",
             embedding_storage_mode="none",
+            main_score_type=self.main_score_type
         )
 
         test_results: Result = test_results
@@ -689,6 +696,7 @@ class ModelTrainer:
                         num_workers=num_workers,
                         out_path=base_path / f"{subcorpus.name}-test.tsv",
                         embedding_storage_mode="none",
+                        main_score_type=self.main_score_type
                     )
                     log.info(subcorpus.name)
                     log.info(subcorpus_results.log_line)

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -18,12 +18,13 @@ from scipy.stats import pearsonr, spearmanr
 
 class Result(object):
     def __init__(
-        self, main_score: float, log_header: str, log_line: str, detailed_results: str
+        self, main_score: float, log_header: str, log_line: str, detailed_results: str, classification_report:dict
     ):
         self.main_score: float = main_score
         self.log_header: str = log_header
         self.log_line: str = log_line
         self.detailed_results: str = detailed_results
+        self.classification_report: dict = classification_report
 
 
 class Metric(object):


### PR DESCRIPTION
Allow different metric than micro f1 as main score (calculated in the eval method of models), which is used for monitoring model performance on dev data during training, saving of best model and learning rate scheduling