### PR TITLE
GH-2159: Fixing ID for Slovene word embeddings in the doc

### DIFF
--- a/resources/docs/embeddings/CLASSIC_WORD_EMBEDDINGS.md
+++ b/resources/docs/embeddings/CLASSIC_WORD_EMBEDDINGS.md
@@ -65,7 +65,7 @@ The following embeddings are currently supported:
 | 'pl' | Polish | Polish FastText embeddings |
 | 'cz' | Czech | Czech FastText embeddings |
 | 'sk' | Slovak | Slovak FastText embeddings |
-| 'si' | Slovenian | Slovenian FastText embeddings |
+| 'sl' | Slovenian | Slovenian FastText embeddings |
 | 'sr' | Serbian | Serbian FastText embeddings |
 | 'hr' | Croatian | Croatian FastText embeddings |
 | 'bg' | Bulgarian | Bulgarian FastText embeddings |


### PR DESCRIPTION
This PR fixes https://github.com/flairNLP/flair/issues/2159 .
The ID for Slovene embeddings in the doc is incorrect and raises an error if passed to the `WordEmbeddings` constructor. This PR fixes it.

I also checked other pars of Flair documentation for references to Slovene and they seem to be correct.