### PR TITLE
GH-2169 - Close log_handler after training is complete.

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -630,6 +630,8 @@ class ModelTrainer:
             final_score = 0
             log.info("Test data not provided setting final score to 0")
 
+        log_handler.close()
+
         log.removeHandler(log_handler)
 
         if self.use_tensorboard:


### PR DESCRIPTION
This PR fixes #2169  .
We are removing the log_handler here but not closing the handler leading to ResourceWarning: unclosed file <_io.BufferedReader name='training.log. Hence we are not able to programatically access the training.log (For ex - Unable to upload the file to s3 using botocore)