### PR TITLE
Fix XLNet and Transformer-XL Execution

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -833,6 +833,8 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             self.max_subtokens_sequence_length = self.tokenizer.model_max_length
             self.stride = self.tokenizer.model_max_length // 2 if allow_long_sentences else 0
         else:
+            # in the end, these models don't need this configuration
+            self.allow_long_sentences = False
             self.truncate = False
             self.max_subtokens_sequence_length = None
             self.stride = 0

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1001,7 +1001,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         # else if current transformer is used, use default handling
         else:
-            print(tokenized_string)
             encoded_inputs = self.tokenizer.encode_plus(tokenized_string,
                                                         max_length=self.max_subtokens_sequence_length,
                                                         stride=self.stride,
@@ -1028,7 +1027,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             if propagate_gradients and self.memory_effective_training and split_number < len(sentence_splits) - 1:
                 propagate_gradients = False
 
-            print(input_ids)
             # put encoded batch through transformer model to get all hidden states of all encoder layers
             if propagate_gradients:
                 hidden_states = self.model(input_ids)[-1]  # make the tuple a tensor; makes working with it easier.


### PR DESCRIPTION
If you execute the following snippet exception `OverflowError: int too big to convert` is thrown:

```python
from flair.embeddings import TransformerWordEmbeddings
from flair.data import Sentence

model = TransformerWordEmbeddings("xlnet-large-cased", "all", "mean", layer_mean=False)
model.embed(Sentence("This is a test that will not work"))
```

This happens because both XLNet and Transformer-XL do not have a max sequence length and `tokenizer.model_max_length` comes with a very big integer.
