### PR TITLE
Fix random seeds of dataloader workers

### DIFF
--- a/flair/datasets/base.py
+++ b/flair/datasets/base.py
@@ -51,7 +51,7 @@ class DataLoader(torch.utils.data.dataloader.DataLoader):
             num_workers = 0
 
         # Set the random seed of dataloader workers to their id
-        # else each worker will return have the same numpy/python seed
+        # else each worker will have the same numpy/python seed
         if worker_init_fn is None:
             worker_init_fn=self._worker_init_fn
 


### PR DESCRIPTION
By default all the dataloader workers (when `num_workers` > 0) will have the same numpy and python random seed meaning all the workers will return the same random numbers causing a waste in training. 

We set the seed of the workers based on the `worker_id` now via the `worker_init_fn` in the `Dataloader`