### PR TITLE
Stackoverflow NER dataset cleaning

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -927,6 +927,10 @@ class STACKOVERFLOW_NER(ColumnCorpus):
                     continue
                 words.append(line_values[0])
                 lines_sentence.append(line)
+            log.info(f"File {file} processed:")
+            log.info(f"The longest sentences has {max_length} words.")
+            log.info(f"Questions: {questions} and Answers: {answers}")
+            log.info(f"Processed sentences: {sentences}.")
 
 
         super(STACKOVERFLOW_NER, self).__init__(

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -863,6 +863,16 @@ class STACKOVERFLOW_NER(ColumnCorpus):
         # column format
         columns = {0: "word", 1: "ner", 3: "markdown"}
 
+        # entity_mapping
+        entity_mapping = {"Library_Function": "Function",
+                          "Function_Name": "Function",
+                          "Class_Name": "Class",
+                          "Library_Class": "Class",
+                          "Organization": "Website",
+                          "Library_Variable": "Variable",
+                          "Variable_Name": "Variable"
+                          }
+
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
 
@@ -884,10 +894,8 @@ class STACKOVERFLOW_NER(ColumnCorpus):
             tag_to_bioes=tag_to_bioes,
             encoding="utf-8",
             in_memory=in_memory,
-            train_file="train.txt",
-            test_file="test.txt",
-            dev_file="dev.txt",
-            **corpusargs,
+            label_name_map=entity_mapping,
+            **corpusargs
         )
 
 


### PR DESCRIPTION
It adds entity mappings, removes sentences with metadata and adds questions/answers counts.
It fixes #2228.

**Expected Results:**
```py
from flair.data import Corpus
from flair.datasets import STACKOVERFLOW_NER

corpus: Corpus = STACKOVERFLOW_NER()
print(corpus)
```
Corpus: 9263 train + 2896 dev + 3108 test sentences

```py
corpus.train[0:3]
```
[Sentence: "If I would have 2 tables"   [− Tokens: 6  − Token-Labels: "If I would have 2 tables <S-Data_Structure>"],
 Sentence: "How do I get this result"   [− Tokens: 6],
 Sentence: "The following query needs to be adjusted , but I dont know how"   [− Tokens: 13]]

**Notes:**
It would be nicer to extend the parameter `comment_symbol` in the `ColumnCorpus` class or create one similar that accepts also a`list`. In this case, the new parameter would take the values in the list `disallowed_list`.


