### PR TITLE
Added NER support for Amharic

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -7,6 +7,7 @@ from .base import MongoDataset
 # Expose all sequence labeling datasets
 from .sequence_labeling import ColumnCorpus
 from .sequence_labeling import ColumnDataset
+from .sequence_labeling import AMHARIC_NER
 from .sequence_labeling import ANER_CORP
 from .sequence_labeling import AQMAR
 from .sequence_labeling import BIOFID

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -307,6 +307,52 @@ class ColumnDataset(FlairDataset):
 
         return sentence
 
+class AMHARIC_NER(ColumnCorpus):
+    def __init__(
+            self,
+            base_path: Union[str, Path] = None,
+            tag_to_bioes: str = "ner",
+            in_memory: bool = True,
+            **corpusargs,
+    ):
+        """
+        Initialize the Amharic corpus available on https://github.com/masakhane-io/masakhane-ner/tree/main/data/amh/.
+        The first time you call this constructor it will automatically download the dataset.
+        :param base_path: Default is None, meaning that corpus gets auto-downloaded and loaded. You can override this
+        to point to a different folder but typically this should not be necessary.
+        :param tag_to_bioes: NER by default, need not be changed, but you could also select 'pos' to predict
+        POS tags instead
+        :param in_memory: If True, keeps dataset in memory giving speedups in training.
+        :param document_as_sequence: If True, all sentences of a document are read into a single Sentence object
+        """
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        # column format
+        columns = {0: "text", 1: "ner"}
+
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        ner_amharic_path = "https://raw.githubusercontent.com/masakhane-io/masakhane-ner/main/data/amh/"
+        cached_path(f"{ner_amharic_path}dev.txt", Path("datasets") / dataset_name)
+        cached_path(f"{ner_amharic_path}test.txt", Path("datasets") / dataset_name)
+        cached_path(f"{ner_amharic_path}train.txt", Path("datasets") / dataset_name)
+
+        super(AMHARIC_NER, self).__init__(
+            data_folder,
+            columns,
+            tag_to_bioes=tag_to_bioes,
+            encoding="utf-8",
+            in_memory=in_memory,
+            **corpusargs,
+        )
 
 class ANER_CORP(ColumnCorpus):
     def __init__(


### PR DESCRIPTION
Added support for the Amharic NER dataset to sequence_labeling.py
Source: https://github.com/masakhane-io/masakhane-ner/tree/main/data/amh

Encoding is set to utf-8 since the dataset uses characters from the Ethiopic unicode block.

(Introduction to NLP @ HU Berlin)