### PR TITLE
pytorch-lightning experiment

### DIFF
--- a/flair-lightning.ipynb
+++ b/flair-lightning.ipynb
@@ -1,0 +1,440 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6c6822eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Optional"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "09a8365e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "from torch.utils.data import TensorDataset\n",
+    "from torch.utils.data import DataLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9ecff12c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pytorch_lightning as pl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ee527a2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flair.data import Corpus\n",
+    "from flair.datasets import TREC_6\n",
+    "from flair.embeddings import TransformerDocumentEmbeddings\n",
+    "from flair.models import TextClassifier\n",
+    "from flair.embeddings.base import Embeddings\n",
+    "from flair.data import Dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "16ff3f72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FlairData(pl.LightningDataModule):\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        corpus: Corpus,\n",
+    "        document_embeddings: Embeddings,\n",
+    "        label_dictionary: Dictionary,\n",
+    "        batch_size: int = 128,\n",
+    "    ):\n",
+    "        super().__init__()\n",
+    "        self.corpus = corpus\n",
+    "        self.document_embeddings = document_embeddings\n",
+    "        self.label_dictionary = label_dictionary\n",
+    "        self.batch_size = batch_size\n",
+    "        \n",
+    "\n",
+    "    def transfer_batch_to_device(self, batch, device):  \n",
+    "        self.document_embeddings.embed(batch)\n",
+    "        embedding_names = self.document_embeddings.get_names()\n",
+    "            \n",
+    "        text_embedding_list = [\n",
+    "            sentence.get_embedding(embedding_names).unsqueeze(0) for sentence in batch\n",
+    "        ]\n",
+    "        \n",
+    "        indices = [\n",
+    "            torch.LongTensor(\n",
+    "                [\n",
+    "                    self.label_dictionary.get_idx_for_item(label.value)\n",
+    "                    for label in sentence.get_labels()\n",
+    "                ]\n",
+    "            )\n",
+    "            for sentence in batch\n",
+    "        ]\n",
+    "        \n",
+    "        return (torch.cat(text_embedding_list, 0), torch.cat(indices, 0).to(device))\n",
+    "    \n",
+    "    def train_dataloader(self):\n",
+    "        return DataLoader(self.corpus.train.dataset, \n",
+    "                          collate_fn=list,\n",
+    "                          batch_size=self.batch_size, \n",
+    "                          shuffle=True,\n",
+    "                          num_workers=8,\n",
+    "                          pin_memory=True,\n",
+    "                         )\n",
+    "    \n",
+    "    def val_dataloader(self):\n",
+    "        return DataLoader(self.corpus.dev.dataset, \n",
+    "                          collate_fn=list,\n",
+    "                          batch_size=self.batch_size, \n",
+    "                          shuffle=False,\n",
+    "                          pin_memory=True,\n",
+    "                          num_workers=8)\n",
+    "    \n",
+    "    def test_dataloader(self):\n",
+    "        return DataLoader(self.corpus.test.dataset, \n",
+    "                          collate_fn=list,\n",
+    "                          batch_size=self.batch_size, \n",
+    "                          shuffle=False,\n",
+    "                          pin_memory=True,\n",
+    "                          num_workers=8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "c8c1ef92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FlairModel(pl.LightningModule):\n",
+    "    def __init__(self, document_embeddings, label_dictionary, learning_rate):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        self.learning_rate = learning_rate\n",
+    "        self.label_dictionary = label_dictionary\n",
+    "        self.document_embeddings = document_embeddings\n",
+    "        self.decoder = nn.Linear(\n",
+    "            self.document_embeddings.embedding_length, len(self.label_dictionary)\n",
+    "        )\n",
+    "        self.loss_function = nn.CrossEntropyLoss()\n",
+    "    \n",
+    "    def forward(self, x):\n",
+    "        return self.decoder(x)\n",
+    "    \n",
+    "    def training_step(self, batch, batch_idx):\n",
+    "        embeddings, labels = batch\n",
+    "        scores = self(embeddings)\n",
+    "        \n",
+    "        return self.loss_function(scores, labels)\n",
+    "    \n",
+    "    def validation_step(self, batch, batch_idx):\n",
+    "        embeddings, labels = batch\n",
+    "        scores = self(embeddings)\n",
+    "        loss = self.loss_function(scores, labels)\n",
+    "        self.log('val_loss', loss)\n",
+    "        return {'val_loss': loss}\n",
+    "        \n",
+    "    def configure_optimizers(self):\n",
+    "        return torch.optim.Adam(self.parameters(), lr=self.learning_rate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "2342abd2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-04-21 10:54:23,624 Reading data from /home/krasul/.flair/datasets/trec_6\n",
+      "2021-04-21 10:54:23,625 Train: /home/krasul/.flair/datasets/trec_6/train.txt\n",
+      "2021-04-21 10:54:23,626 Dev: None\n",
+      "2021-04-21 10:54:23,627 Test: /home/krasul/.flair/datasets/trec_6/test.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus = TREC_6()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "bf8ddf73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "document_embeddings = TransformerDocumentEmbeddings('distilbert-base-uncased', \n",
+    "                                                    fine_tune=True, \n",
+    "                                                    batch_size=128)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "a5466ae0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-04-21 10:54:27,955 Computing label dictionary. Progress:\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 5407/5407 [00:00<00:00, 64961.01it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-04-21 10:54:28,043 [b'DESC', b'ENTY', b'ABBR', b'HUM', b'NUM', b'LOC']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "label_dictionary = corpus.make_label_dictionary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "d2b1297d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "GPU available: True, used: True\n",
+      "TPU available: False, using: 0 TPU cores\n"
+     ]
+    }
+   ],
+   "source": [
+    "trainer = pl.Trainer(gpus=\"0\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "330c0900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = FlairModel(document_embeddings=document_embeddings,\n",
+    "                   label_dictionary=label_dictionary, \n",
+    "                   learning_rate=1e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "41581665",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dm = FlairData(corpus=corpus,\n",
+    "               document_embeddings=model.document_embeddings,\n",
+    "               label_dictionary=model.label_dictionary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "669605cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1,2,3]\n",
+      "\n",
+      "  | Name                | Type                          | Params\n",
+      "----------------------------------------------------------------------\n",
+      "0 | document_embeddings | TransformerDocumentEmbeddings | 66.4 M\n",
+      "1 | decoder             | Linear                        | 4.6 K \n",
+      "2 | loss_function       | CrossEntropyLoss              | 0     \n",
+      "----------------------------------------------------------------------\n",
+      "66.4 M    Trainable params\n",
+      "0         Non-trainable params\n",
+      "66.4 M    Total params\n",
+      "265.470   Total estimated model params size (MB)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validation sanity check: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "74225b6bb1a348c283652a79c595267c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Training: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validating: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validating: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validating: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validating: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validating: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.fit(model, datamodule=dm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19ca12c7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/flair-lightning.py
+++ b/flair-lightning.py
@@ -1,0 +1,132 @@
+from argparse import ArgumentParser
+from typing import Optional
+
+
+import torch
+import torch.nn as nn
+from torch.utils.data import TensorDataset
+from torch.utils.data import DataLoader
+
+import pytorch_lightning as pl
+
+from flair.data import Corpus
+from flair.datasets import TREC_6
+from flair.embeddings import TransformerDocumentEmbeddings
+from flair.models import TextClassifier
+from flair.embeddings.base import Embeddings
+from flair.data import Dictionary
+
+
+class FlairData(pl.LightningDataModule):
+    def __init__(
+        self,
+        corpus: Corpus,
+        document_embeddings: Embeddings,
+        label_dictionary: Dictionary,
+        batch_size: int = 128,
+    ):
+        super().__init__()
+        self.corpus = corpus
+        self.document_embeddings = document_embeddings
+        self.label_dictionary = label_dictionary
+        self.batch_size = batch_size
+
+
+    def transfer_batch_to_device(self, batch, device):
+        self.document_embeddings.embed(batch)
+        embedding_names = self.document_embeddings.get_names()
+
+        text_embedding_list = [
+            sentence.get_embedding(embedding_names).unsqueeze(0) for sentence in batch
+        ]
+
+        indices = [
+            torch.LongTensor(
+                [
+                    self.label_dictionary.get_idx_for_item(label.value)
+                    for label in sentence.get_labels()
+                ]
+            )
+            for sentence in batch
+        ]
+
+        return (torch.cat(text_embedding_list, 0), torch.cat(indices, 0).to(device))
+
+    def train_dataloader(self):
+        return DataLoader(self.corpus.train.dataset,
+                          collate_fn=list,
+                          batch_size=self.batch_size,
+                          shuffle=True,
+                          num_workers=8,
+                          pin_memory=True,
+                         )
+
+    def val_dataloader(self):
+        return DataLoader(self.corpus.dev.dataset,
+                          collate_fn=list,
+                          batch_size=self.batch_size,
+                          shuffle=False,
+                          pin_memory=True,
+                          num_workers=8)
+
+    def test_dataloader(self):
+        return DataLoader(self.corpus.test.dataset,
+                          collate_fn=list,
+                          batch_size=self.batch_size,
+                          shuffle=False,
+                          pin_memory=True,
+                          num_workers=8)
+
+
+class FlairModel(pl.LightningModule):
+    def __init__(self, document_embeddings, label_dictionary, learning_rate):
+        super().__init__()
+
+        self.learning_rate = learning_rate
+        self.label_dictionary = label_dictionary
+        self.document_embeddings = document_embeddings
+        self.decoder = nn.Linear(
+            self.document_embeddings.embedding_length, len(self.label_dictionary)
+        )
+        self.loss_function = nn.CrossEntropyLoss()
+
+    def forward(self, x):
+        return self.decoder(x)
+
+    def training_step(self, batch, batch_idx):
+        embeddings, labels = batch
+        scores = self(embeddings)
+
+        return self.loss_function(scores, labels)
+
+    def validation_step(self, batch, batch_idx):
+        embeddings, labels = batch
+        scores = self(embeddings)
+
+        self.log('val_loss', self.loss_function(scores, labels), on_step=True, on_epoch=True, sync_dist=True)
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.learning_rate)
+
+
+def cli_main():
+    corpus = TREC_6()
+    document_embeddings = TransformerDocumentEmbeddings('distilbert-base-uncased', fine_tune=True, batch_size=128)
+    label_dictionary = corpus.make_label_dictionary()
+
+    trainer = pl.Trainer(gpus=1, accelerator="horovod")
+
+    model = FlairModel(document_embeddings=document_embeddings,
+                   label_dictionary=label_dictionary, learning_rate=1e-3)
+
+    dm = FlairData(corpus=corpus,
+               document_embeddings=model.document_embeddings,
+               label_dictionary=model.label_dictionary)
+
+
+    trainer.fit(model, datamodule=dm)
+
+
+if __name__ == '__main__':
+    cli_main()
+

--- a/flair-lightning.py
+++ b/flair-lightning.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser
 from typing import Optional
 
-
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
@@ -123,7 +122,7 @@ def cli_main():
     )
     label_dictionary = corpus.make_label_dictionary()
 
-    trainer = pl.Trainer(gpus=1, accelerator="horovod")
+    trainer = pl.Trainer(gpus=[0,1,2,3], accelerator="ddp")
 
     model = FlairModel(
         document_embeddings=document_embeddings,

--- a/flair/data.py
+++ b/flair/data.py
@@ -312,8 +312,7 @@ class Token(DataPoint):
     def get_head(self):
         return self.sentence.get_token(self.head_id)
 
-    def set_embedding(self, name: str, vector: torch.tensor):
-        device = flair.device
+    def set_embedding(self, name: str, vector: torch.tensor, device=flair.device):
         if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
         if device != vector.device:
@@ -720,8 +719,7 @@ class Sentence(DataPoint):
     def embedding(self):
         return self.get_embedding()
 
-    def set_embedding(self, name: str, vector: torch.tensor):
-        device = flair.device
+    def set_embedding(self, name: str, vector: torch.tensor, device=flair.device):
         if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
         if device != vector.device:
@@ -1021,8 +1019,7 @@ class Image(DataPoint):
 
         return torch.tensor([], device=flair.device)
 
-    def set_embedding(self, name: str, vector: torch.tensor):
-        device = flair.device
+    def set_embedding(self, name: str, vector: torch.tensor, device=flair.device):
         if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
         if device != vector.device:

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -77,12 +77,12 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
 
         # when initializing, embeddings are in eval mode by default
         self.model.eval()
-        self.model.to(flair.device)
+        #self.model.to(flair.device)
 
         # embedding parameters
         if layers == 'all':
             # send mini-token through to check how many layers the model has
-            hidden_states = self.model(torch.tensor([1], device=flair.device).unsqueeze(0))[-1]
+            hidden_states = self.model(torch.tensor([1], device=self.model.device).unsqueeze(0))[-1]
             self.layer_indexes = [int(x) for x in range(len(hidden_states))]
         else:
             self.layer_indexes = [int(x) for x in layers.split(",")]
@@ -137,7 +137,7 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
                                                               )
 
                 subtokenized_sentences.append(
-                    torch.tensor(subtokenized_sentence, dtype=torch.long, device=flair.device))
+                    torch.tensor(subtokenized_sentence, dtype=torch.long, device=self.model.device))
 
             # find longest sentence in batch
             longest_sequence_in_batch: int = len(max(subtokenized_sentences, key=len))
@@ -146,12 +146,12 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
             input_ids = torch.zeros(
                 [len(sentences), longest_sequence_in_batch],
                 dtype=torch.long,
-                device=flair.device,
+                device=self.model.device,
             )
             mask = torch.zeros(
                 [len(sentences), longest_sequence_in_batch],
                 dtype=torch.long,
-                device=flair.device,
+                device=self.model.device,
             )
             for s_id, sentence in enumerate(subtokenized_sentences):
                 sequence_length = len(sentence)
@@ -195,7 +195,7 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
                     embeddings_all_layers = [sm_embeddings]
 
                 # set the extracted embedding for the token
-                sentence.set_embedding(self.name, torch.cat(embeddings_all_layers))
+                sentence.set_embedding(self.name, torch.cat(embeddings_all_layers), device=self.model.device)
 
     @property
     @abstractmethod


### PR DESCRIPTION
In this branch is my initial experiment to get flair working with pytorch-lightning.  Provided is a notebook as well as a text classification training script. CC @kishaloyhalder @jbesomi and #848


So multi-gpu training works at the moment only via:
- [x] `accelerator="ddp"` with `NCCL`:  `python flair-lightning.py`
- [x] `accelerator="ddp"` with `GLOO`:  `PL_TORCH_DISTRIBUTED_BACKEND=gloo python flair-lightning.py`
- [x] `accelerator="horovod"`: `horovodrun -np 4 python flair-lightning.py`

Some things to investigate:
- [ ] double-check that the document embedding is getting trained
- [ ] get it working with `accelerator="ddp2"`
- [ ] get the lightning learning rate finder working (at the moment it runs out of memory which indicates somehow we are accumulating some tensors somewhere...)
- [ ] at the moment we always tokenized the sentences... perhaps move that out to the `setup` part of the `pl.LightningDataModule`