### PR TITLE
Moving Path construction of flair.cache_root

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from transformers import set_seed as hf_set_seed
 
 # global variable: cache_root
-cache_root = os.getenv('FLAIR_CACHE_ROOT', Path(Path.home(), ".flair"))
+cache_root = Path(os.getenv('FLAIR_CACHE_ROOT', Path(Path.home(), ".flair")))
 
 # global variable: device
 device = None

--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -145,7 +145,7 @@ class NLPTaskDataFetcher:
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -653,7 +653,7 @@ class NLPTaskDataFetcher:
         # conll 2000 chunking task
         if task == NLPTask.CONLL_2000:
             conll_2000_path = "https://www.clips.uantwerpen.be/conll2000/chunking/"
-            data_file = Path(flair.cache_root) / "datasets" / task.value / "train.txt"
+            data_file = flair.cache_root / "datasets" / task.value / "train.txt"
             if not data_file.is_file():
                 cached_path(
                     f"{conll_2000_path}train.txt.gz", Path("datasets") / task.value
@@ -664,27 +664,27 @@ class NLPTaskDataFetcher:
                 import gzip, shutil
 
                 with gzip.open(
-                    Path(flair.cache_root) / "datasets" / task.value / "train.txt.gz",
+                    flair.cache_root / "datasets" / task.value / "train.txt.gz",
                     "rb",
                 ) as f_in:
                     with open(
-                        Path(flair.cache_root) / "datasets" / task.value / "train.txt",
+                        flair.cache_root / "datasets" / task.value / "train.txt",
                         "wb",
                     ) as f_out:
                         shutil.copyfileobj(f_in, f_out)
                 with gzip.open(
-                    Path(flair.cache_root) / "datasets" / task.value / "test.txt.gz",
+                    flair.cache_root / "datasets" / task.value / "test.txt.gz",
                     "rb",
                 ) as f_in:
                     with open(
-                        Path(flair.cache_root) / "datasets" / task.value / "test.txt",
+                        flair.cache_root / "datasets" / task.value / "test.txt",
                         "wb",
                     ) as f_out:
                         shutil.copyfileobj(f_in, f_out)
 
         if task == NLPTask.NER_BASQUE:
             ner_basque_path = "http://ixa2.si.ehu.eus/eiec/"
-            data_path = Path(flair.cache_root) / "datasets" / task.value
+            data_path = flair.cache_root / "datasets" / task.value
             data_file = data_path / "named_ent_eu.train"
             if not data_file.is_file():
                 cached_path(
@@ -693,7 +693,7 @@ class NLPTaskDataFetcher:
                 import tarfile, shutil
 
                 with tarfile.open(
-                    Path(flair.cache_root) / "datasets" / task.value / "eiec_v1.0.tgz",
+                    flair.cache_root / "datasets" / task.value / "eiec_v1.0.tgz",
                     "r:gz",
                 ) as f_in:
                     corpus_files = (
@@ -708,14 +708,14 @@ class NLPTaskDataFetcher:
             imdb_acl_path = (
                 "http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
             )
-            data_path = Path(flair.cache_root) / "datasets" / task.value
+            data_path = flair.cache_root / "datasets" / task.value
             data_file = data_path / "train.txt"
             if not data_file.is_file():
                 cached_path(imdb_acl_path, Path("datasets") / task.value)
                 import tarfile
 
                 with tarfile.open(
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / task.value
                     / "aclImdb_v1.tar.gz",
@@ -760,7 +760,7 @@ class NLPTaskDataFetcher:
                     Path("datasets") / task.value / "original",
                 )
 
-            data_path = Path(flair.cache_root) / "datasets" / task.value
+            data_path = flair.cache_root / "datasets" / task.value
             data_file = data_path / new_filenames[0]
 
             if not data_file.is_file():
@@ -827,7 +827,7 @@ class NLPTaskDataFetcher:
                 lc = "ru"
 
             data_file = (
-                Path(flair.cache_root)
+                flair.cache_root
                 / "datasets"
                 / task.value
                 / f"aij-wikiner-{lc}-wp3.train"
@@ -842,14 +842,14 @@ class NLPTaskDataFetcher:
 
                 # unpack and write out in CoNLL column-like format
                 bz_file = bz2.BZ2File(
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / task.value
                     / f"aij-wikiner-{lc}-wp3.bz2",
                     "rb",
                 )
                 with bz_file as f, open(
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / task.value
                     / f"aij-wikiner-{lc}-wp3.train",
@@ -1321,7 +1321,7 @@ class NLPTaskDataFetcher:
             for split in ["train", "dev", "test"]:
 
                 data_file = (
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / task.value
                     / f"{emotion}-{split}.txt"
@@ -1366,7 +1366,7 @@ class NLPTaskDataFetcher:
                 f"{ud_path}UD_German-HDT/dev/de_hdt-ud-train-b.conllu",
                 Path("datasets") / task.value / "original",
             )
-            data_path = Path(flair.cache_root) / "datasets" / task.value
+            data_path = flair.cache_root / "datasets" / task.value
 
             train_filenames = ["de_hdt-ud-train-a.conllu", "de_hdt-ud-train-b.conllu"]
 

--- a/flair/datasets/biomedical.py
+++ b/flair/datasets/biomedical.py
@@ -494,7 +494,7 @@ class HunerDataset(ColumnCorpus, ABC):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         self.sentence_splitter = self.get_corpus_sentence_splitter()
@@ -583,7 +583,7 @@ class BIO_INFER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         train_file = data_folder / "train.conll"
@@ -737,7 +737,7 @@ class JNLPBA(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         train_file = data_folder / "train.conll"
@@ -967,7 +967,7 @@ class CELL_FINDER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         train_file = data_folder / f"{sentence_splitter.name}_train.conll"
@@ -1108,7 +1108,7 @@ class MIRNA(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         sentence_separator = " "
@@ -1487,7 +1487,7 @@ class CLL(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         train_file = data_folder / "train.conll"
@@ -1556,7 +1556,7 @@ class GELLUS(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         train_file = data_folder / "train.conll"
@@ -1645,7 +1645,7 @@ class LOCTEXT(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -1759,7 +1759,7 @@ class CHEMDNER(ColumnCorpus):
           https://jcheminf.biomedcentral.com/articles/10.1186/1758-2946-7-S1-S2
     """
 
-    default_dir = Path(flair.cache_root) / "datasets" / "CHEMDNER"
+    default_dir = flair.cache_root / "datasets" / "CHEMDNER"
 
     def __init__(
         self,
@@ -1907,7 +1907,7 @@ class IEPA(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if tokenizer is None:
@@ -1998,7 +1998,7 @@ class LINNEAUS(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if tokenizer is None:
@@ -2109,7 +2109,7 @@ class CDR(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -2254,7 +2254,7 @@ class VARIOME(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -2422,7 +2422,7 @@ class NCBI_DISEASE(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -2588,7 +2588,7 @@ class ScaiCorpus(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -2813,7 +2813,7 @@ class OSIRIS(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -2949,7 +2949,7 @@ class S800(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -3054,7 +3054,7 @@ class GPRO(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -3206,7 +3206,7 @@ class DECA(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -3317,7 +3317,7 @@ class FSU(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         sentence_splitter = TagSentenceSplitter(
@@ -3502,7 +3502,7 @@ class CRAFT(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -3600,7 +3600,7 @@ class BIOSEMANTICS(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -3744,7 +3744,7 @@ class BC2GM(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -3896,7 +3896,7 @@ class CEMP(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -4066,7 +4066,7 @@ class CHEBI(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -4249,7 +4249,7 @@ class BioNLPCorpus(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -4440,7 +4440,7 @@ class ANAT_EM(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if tokenizer is None:
@@ -4632,7 +4632,7 @@ class BIOBERT_CHEMICAL_BC4CHEMD(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4670,7 +4670,7 @@ class BIOBERT_GENE_BC2GM(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4707,7 +4707,7 @@ class BIOBERT_GENE_JNLPBA(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4744,7 +4744,7 @@ class BIOBERT_CHEMICAL_BC5CDR(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4781,7 +4781,7 @@ class BIOBERT_DISEASE_BC5CDR(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4817,7 +4817,7 @@ class BIOBERT_DISEASE_NCBI(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4854,7 +4854,7 @@ class BIOBERT_SPECIES_LINNAEUS(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4891,7 +4891,7 @@ class BIOBERT_SPECIES_S800(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         data_folder = base_path / dataset_name
 
@@ -4943,7 +4943,7 @@ class CRAFT_V4(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:
@@ -5263,7 +5263,7 @@ class AZDZ(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if tokenizer is None:
@@ -5380,7 +5380,7 @@ class PDR(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if sentence_splitter is None:

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -613,7 +613,7 @@ class AMAZON_REVIEWS(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower() + '_' + str(split_max) + '_' + str(fraction_of_5_star_reviews)
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if not (data_folder / "train.txt").is_file():
@@ -702,7 +702,7 @@ class AMAZON_REVIEWS(ClassificationCorpus):
             write_count = 0
             review_5_count = 0
             # download senteval datasets if necessary und unzip
-            with gzip.open(Path(flair.cache_root) / "datasets" / 'Amazon_Product_Reviews' / part_name, "rb", ) as f_in:
+            with gzip.open(flair.cache_root / "datasets" / 'Amazon_Product_Reviews' / part_name, "rb", ) as f_in:
                 for line in f_in:
                     parsed_json = json.loads(line)
                     if 'reviewText' not in parsed_json:
@@ -757,7 +757,7 @@ class IMDB(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         # download data if necessary
         imdb_acl_path = "http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
@@ -765,7 +765,7 @@ class IMDB(ClassificationCorpus):
         if rebalance_corpus:
             dataset_name = dataset_name + '-rebalanced'
         data_folder = base_path / dataset_name
-        data_path = Path(flair.cache_root) / "datasets" / dataset_name
+        data_path = flair.cache_root / "datasets" / dataset_name
         train_data_file = data_path / "train.txt"
         test_data_file = data_path / "test.txt"
 
@@ -776,7 +776,7 @@ class IMDB(ClassificationCorpus):
             import tarfile
 
             with tarfile.open(
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / dataset_name
                     / "aclImdb_v1.tar.gz",
@@ -847,14 +847,14 @@ class NEWSGROUPS(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
         twenty_newsgroups_path = (
             "http://qwone.com/~jason/20Newsgroups/20news-bydate.tar.gz"
         )
-        data_path = Path(flair.cache_root) / "datasets" / dataset_name
+        data_path = flair.cache_root / "datasets" / dataset_name
         data_file = data_path / "20news-bydate-train.txt"
         if not data_file.is_file():
             cached_path(
@@ -864,7 +864,7 @@ class NEWSGROUPS(ClassificationCorpus):
             import tarfile
 
             with tarfile.open(
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / dataset_name
                     / "original"
@@ -956,7 +956,7 @@ class SENTIMENT_140(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower()
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if True or not (data_folder / "train.txt").is_file():
@@ -964,7 +964,7 @@ class SENTIMENT_140(ClassificationCorpus):
             # download senteval datasets if necessary und unzip
             sentiment_url = "https://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip"
             cached_path(sentiment_url, Path("datasets") / dataset_name / 'raw')
-            senteval_folder = Path(flair.cache_root) / "datasets" / dataset_name / 'raw'
+            senteval_folder = flair.cache_root / "datasets" / dataset_name / 'raw'
             unzip_file(senteval_folder / "trainingandtestdata.zip", senteval_folder)
 
             # create dataset directory if necessary
@@ -1023,7 +1023,7 @@ class SENTEVAL_CR(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower()
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if not (data_folder / "train.txt").is_file():
@@ -1031,7 +1031,7 @@ class SENTEVAL_CR(ClassificationCorpus):
             # download senteval datasets if necessary und unzip
             senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
             cached_path(senteval_path, Path("datasets") / "senteval")
-            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            senteval_folder = flair.cache_root / "datasets" / "senteval"
             unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
 
             # create dataset directory if necessary
@@ -1077,7 +1077,7 @@ class SENTEVAL_MR(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower()
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if not (data_folder / "train.txt").is_file():
@@ -1085,7 +1085,7 @@ class SENTEVAL_MR(ClassificationCorpus):
             # download senteval datasets if necessary und unzip
             senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
             cached_path(senteval_path, Path("datasets") / "senteval")
-            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            senteval_folder = flair.cache_root / "datasets" / "senteval"
             unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
 
             # create dataset directory if necessary
@@ -1131,7 +1131,7 @@ class SENTEVAL_SUBJ(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower()
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if not (data_folder / "train.txt").is_file():
@@ -1139,7 +1139,7 @@ class SENTEVAL_SUBJ(ClassificationCorpus):
             # download senteval datasets if necessary und unzip
             senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
             cached_path(senteval_path, Path("datasets") / "senteval")
-            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            senteval_folder = flair.cache_root / "datasets" / "senteval"
             unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
 
             # create dataset directory if necessary
@@ -1185,7 +1185,7 @@ class SENTEVAL_MPQA(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower()
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if not (data_folder / "train.txt").is_file():
@@ -1193,7 +1193,7 @@ class SENTEVAL_MPQA(ClassificationCorpus):
             # download senteval datasets if necessary und unzip
             senteval_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/datasmall_NB_ACL12.zip"
             cached_path(senteval_path, Path("datasets") / "senteval")
-            senteval_folder = Path(flair.cache_root) / "datasets" / "senteval"
+            senteval_folder = flair.cache_root / "datasets" / "senteval"
             unzip_file(senteval_folder / "datasmall_NB_ACL12.zip", senteval_folder)
 
             # create dataset directory if necessary
@@ -1239,7 +1239,7 @@ class SENTEVAL_SST_BINARY(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower() + '_v2'
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if not (data_folder / "train.txt").is_file():
@@ -1291,7 +1291,7 @@ class SENTEVAL_SST_GRANULAR(ClassificationCorpus):
         dataset_name = self.__class__.__name__.lower()
 
         # default dataset folder is the cache root
-        data_folder = Path(flair.cache_root) / "datasets" / dataset_name
+        data_folder = flair.cache_root / "datasets" / dataset_name
 
         # download data if necessary
         if not (data_folder / "train.txt").is_file():
@@ -1381,7 +1381,7 @@ class GO_EMOTIONS(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -1401,7 +1401,7 @@ class GO_EMOTIONS(ClassificationCorpus):
             if not os.path.exists(data_folder):
                 os.makedirs(data_folder)
 
-            data_path = Path(flair.cache_root) / "datasets" / dataset_name / 'raw'
+            data_path = flair.cache_root / "datasets" / dataset_name / 'raw'
             # create correctly formated txt files
             for name in ["train", "test", "dev"]:
                 with open(data_folder / (name + '.txt'), "w", encoding='utf-8') as txt_file:
@@ -1453,7 +1453,7 @@ class TREC_50(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1528,7 +1528,7 @@ class TREC_6(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1602,7 +1602,7 @@ class YAHOO_ANSWERS(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1619,7 +1619,7 @@ class YAHOO_ANSWERS(ClassificationCorpus):
                      '9': 'Family_&_Relationships',
                      '10': 'Politics_&_Government'}
 
-        original = Path(flair.cache_root) / "datasets" / dataset_name / "original"
+        original = flair.cache_root / "datasets" / dataset_name / "original"
 
         if not (data_folder / "train.txt").is_file():
             cached_path(url, original)
@@ -1681,7 +1681,7 @@ class GERMEVAL_2018_OFFENSIVE_LANGUAGE(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1761,7 +1761,7 @@ class COMMUNICATIVE_FUNCTIONS(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         original_filenames = ["background.tsv", "discussion.tsv", "introduction.tsv", "method.tsv", "result.tsv"]
@@ -1846,7 +1846,7 @@ class WASSA_ANGER(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1882,7 +1882,7 @@ class WASSA_FEAR(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1918,7 +1918,7 @@ class WASSA_JOY(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1954,7 +1954,7 @@ class WASSA_SADNESS(ClassificationCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -336,7 +336,7 @@ class AMHARIC_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -386,7 +386,7 @@ class ANER_CORP(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -445,7 +445,7 @@ class AQMAR(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -484,7 +484,7 @@ class BIOFID(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -516,7 +516,7 @@ class BIOSCOPE(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -566,7 +566,7 @@ class CONLL_03(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if entity_linking:
@@ -638,7 +638,7 @@ class CONLL_03_GERMAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # check if data there
@@ -689,7 +689,7 @@ class CONLL_03_DUTCH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -761,7 +761,7 @@ class ICELANDIC_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         if not os.path.isfile(data_folder / 'icelandic_ner.txt'):
@@ -826,7 +826,7 @@ class JAPANESE_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data from github if necessary (hironsan.txt, ja.wikipedia.conll)
@@ -924,7 +924,7 @@ class STACKOVERFLOW_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1023,7 +1023,7 @@ class BUSINESS_HUN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # If the extracted corpus file is not yet present in dir
@@ -1185,7 +1185,7 @@ class CONLL_03_SPANISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1231,12 +1231,12 @@ class CONLL_2000(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
         conll_2000_path = "https://www.clips.uantwerpen.be/conll2000/chunking/"
-        data_file = Path(flair.cache_root) / "datasets" / dataset_name / "train.txt"
+        data_file = flair.cache_root / "datasets" / dataset_name / "train.txt"
         if not data_file.is_file():
             cached_path(
                 f"{conll_2000_path}train.txt.gz", Path("datasets") / dataset_name
@@ -1247,19 +1247,19 @@ class CONLL_2000(ColumnCorpus):
             import gzip, shutil
 
             with gzip.open(
-                    Path(flair.cache_root) / "datasets" / dataset_name / "train.txt.gz",
+                    flair.cache_root / "datasets" / dataset_name / "train.txt.gz",
                     "rb",
             ) as f_in:
                 with open(
-                        Path(flair.cache_root) / "datasets" / dataset_name / "train.txt",
+                        flair.cache_root / "datasets" / dataset_name / "train.txt",
                         "wb",
                 ) as f_out:
                     shutil.copyfileobj(f_in, f_out)
             with gzip.open(
-                    Path(flair.cache_root) / "datasets" / dataset_name / "test.txt.gz", "rb"
+                    flair.cache_root / "datasets" / dataset_name / "test.txt.gz", "rb"
             ) as f_in:
                 with open(
-                        Path(flair.cache_root) / "datasets" / dataset_name / "test.txt",
+                        flair.cache_root / "datasets" / dataset_name / "test.txt",
                         "wb",
                 ) as f_out:
                     shutil.copyfileobj(f_in, f_out)
@@ -1288,11 +1288,11 @@ class DANE(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
-        data_path = Path(flair.cache_root) / "datasets" / dataset_name
+        data_path = flair.cache_root / "datasets" / dataset_name
         train_data_file = data_path / "ddt.train.conllu"
         if not train_data_file.is_file():
             temp_file = cached_path(
@@ -1355,7 +1355,7 @@ class EUROPARL_NER_GERMAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1405,7 +1405,7 @@ class GERMEVAL_14(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # check if data there
@@ -1446,7 +1446,7 @@ class INSPEC(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         inspec_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/Inspec"
@@ -1490,7 +1490,7 @@ class LER_GERMAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1536,7 +1536,7 @@ class LUO_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1581,7 +1581,7 @@ class MIT_MOVIE_NER_SIMPLE(ColumnCorpus):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
         if not base_path:
-            base_path: Path = Path(flair.cache_root) / "datasets"
+            base_path: Path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1629,7 +1629,7 @@ class MIT_MOVIE_NER_COMPLEX(ColumnCorpus):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
         if not base_path:
-            base_path: Path = Path(flair.cache_root) / "datasets"
+            base_path: Path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1679,7 +1679,7 @@ class MIT_RESTAURANT_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1726,7 +1726,7 @@ class IGBO_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1774,7 +1774,7 @@ class HAUSA_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1823,7 +1823,7 @@ class NER_YORUBA(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1861,7 +1861,7 @@ class KINYARWANDA_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1910,7 +1910,7 @@ class NAIJA_PIDGIN_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
         
         corpus_path = "https://raw.githubusercontent.com/masakhane-io/masakhane-ner/main/data/pcm/"
@@ -1947,12 +1947,12 @@ class NER_BASQUE(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
         ner_basque_path = "http://ixa2.si.ehu.eus/eiec/"
-        data_path = Path(flair.cache_root) / "datasets" / dataset_name
+        data_path = flair.cache_root / "datasets" / dataset_name
         data_file = data_path / "named_ent_eu.train"
         if not data_file.is_file():
             cached_path(
@@ -1961,7 +1961,7 @@ class NER_BASQUE(ColumnCorpus):
             import tarfile, shutil
 
             with tarfile.open(
-                    Path(flair.cache_root) / "datasets" / dataset_name / "eiec_v1.0.tgz",
+                    flair.cache_root / "datasets" / dataset_name / "eiec_v1.0.tgz",
                     "r:gz",
             ) as f_in:
                 corpus_files = (
@@ -1996,7 +1996,7 @@ class NER_FINNISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2049,7 +2049,7 @@ class NER_SWEDISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2090,7 +2090,7 @@ class SEC_FILLINGS(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2131,7 +2131,7 @@ class SEMEVAL2017(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         semeval2017_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/SemEval-2017"
@@ -2164,7 +2164,7 @@ class SEMEVAL2010(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         semeval2010_path = "https://raw.githubusercontent.com/midas-research/keyphrase-extraction-as-sequence-labeling-data/master/processed_semeval-2010"
@@ -2205,7 +2205,7 @@ class TURKU_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2263,7 +2263,7 @@ class TWITTER_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2543,7 +2543,7 @@ class WSD_UFSAC(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # check if data there
@@ -2582,7 +2582,7 @@ def _download_wikiner(language_code: str, dataset_name: str):
     lc = language_code
 
     data_file = (
-            Path(flair.cache_root)
+            flair.cache_root
             / "datasets"
             / dataset_name
             / f"aij-wikiner-{lc}-wp3.train"
@@ -2621,7 +2621,7 @@ class UP_CHINESE(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2672,7 +2672,7 @@ class UP_ENGLISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2723,7 +2723,7 @@ class UP_FRENCH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2774,7 +2774,7 @@ class UP_FINNISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2825,7 +2825,7 @@ class UP_GERMAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2876,7 +2876,7 @@ class UP_ITALIAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2927,7 +2927,7 @@ class UP_SPANISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -2978,7 +2978,7 @@ class UP_SPANISH_ANCORA(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3031,7 +3031,7 @@ class WEIBO_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3095,7 +3095,7 @@ class WIKIANN(MultiCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # For each language in languages, the file is downloaded if not existent
@@ -3507,7 +3507,7 @@ class WIKIGOLD_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3545,7 +3545,7 @@ class WIKINER_ENGLISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3575,7 +3575,7 @@ class WIKINER_GERMAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3605,7 +3605,7 @@ class WIKINER_DUTCH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3635,7 +3635,7 @@ class WIKINER_FRENCH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3665,7 +3665,7 @@ class WIKINER_ITALIAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3695,7 +3695,7 @@ class WIKINER_SPANISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3725,7 +3725,7 @@ class WIKINER_PORTUGUESE(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3755,7 +3755,7 @@ class WIKINER_POLISH(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3785,7 +3785,7 @@ class WIKINER_RUSSIAN(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3815,7 +3815,7 @@ class WNUT_17(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3860,7 +3860,7 @@ class WNUT_2020_NER(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -3910,7 +3910,7 @@ def _download_wikiner(language_code: str, dataset_name: str):
     lc = language_code
 
     data_file = (
-            Path(flair.cache_root)
+            flair.cache_root
             / "datasets"
             / dataset_name
             / f"aij-wikiner-{lc}-wp3.train"
@@ -3924,14 +3924,14 @@ def _download_wikiner(language_code: str, dataset_name: str):
 
         # unpack and write out in CoNLL column-like format
         bz_file = bz2.BZ2File(
-            Path(flair.cache_root)
+            flair.cache_root
             / "datasets"
             / dataset_name
             / f"aij-wikiner-{lc}-wp3.bz2",
             "rb",
         )
         with bz_file as f, open(
-                Path(flair.cache_root)
+                flair.cache_root
                 / "datasets"
                 / dataset_name
                 / f"aij-wikiner-{lc}-wp3.train",
@@ -3994,7 +3994,7 @@ class XTREME(MultiCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # For each language in languages, the file is downloaded if not existent
@@ -4092,7 +4092,7 @@ class REDDIT_EL_GOLD(ColumnCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download and parse data if necessary

--- a/flair/datasets/text_text.py
+++ b/flair/datasets/text_text.py
@@ -84,14 +84,14 @@ class OpusParallelCorpus(ParallelTextCorpus):
             link = f"https://object.pouta.csc.fi/OPUS-Tatoeba/v20190709/moses/{l1}-{l2}.txt.zip"
 
             l1_file = (
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / dataset
                     / f"{l1}-{l2}"
                     / f"Tatoeba.{l1}-{l2}.{l1}"
             )
             l2_file = (
-                    Path(flair.cache_root)
+                    flair.cache_root
                     / "datasets"
                     / dataset
                     / f"{l1}-{l2}"
@@ -102,7 +102,7 @@ class OpusParallelCorpus(ParallelTextCorpus):
         if not l1_file.exists():
             path = cached_path(link, Path("datasets") / dataset / f"{l1}-{l2}")
             unzip_file(
-                path, Path(flair.cache_root) / Path("datasets") / dataset / f"{l1}-{l2}"
+                path, flair.cache_root / Path("datasets") / dataset / f"{l1}-{l2}"
             )
 
         # instantiate corpus
@@ -452,7 +452,7 @@ class GLUE_RTE(DataPairCorpus):
 
         # if no base_path provided take cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         data_file = data_folder / "RTE/train.tsv"
@@ -539,7 +539,7 @@ class SUPERGLUE_RTE(DataPairCorpus):
 
         # if no base_path provided take cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         data_file = data_folder / "RTE/train.tsv"

--- a/flair/datasets/treebanks.py
+++ b/flair/datasets/treebanks.py
@@ -236,7 +236,7 @@ class UD_ENGLISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -263,7 +263,7 @@ class UD_ANCIENT_GREEK(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -290,7 +290,7 @@ class UD_KAZAKH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -316,7 +316,7 @@ class UD_OLD_CHURCH_SLAVONIC(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -343,7 +343,7 @@ class UD_ARMENIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -369,7 +369,7 @@ class UD_ESTONIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -396,7 +396,7 @@ class UD_GERMAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -421,7 +421,7 @@ class UD_GERMAN_HDT(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -443,7 +443,7 @@ class UD_GERMAN_HDT(UniversalDependenciesCorpus):
                 f"{ud_path}/{train_file}", Path("datasets") / dataset_name / "original"
             )
 
-        data_path = Path(flair.cache_root) / "datasets" / dataset_name
+        data_path = flair.cache_root / "datasets" / dataset_name
 
         new_train_file: Path = data_path / "de_hdt-ud-train-all.conllu"
 
@@ -467,7 +467,7 @@ class UD_DUTCH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -499,7 +499,7 @@ class UD_FAROESE(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -528,7 +528,7 @@ class UD_FRENCH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -552,7 +552,7 @@ class UD_ITALIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -578,7 +578,7 @@ class UD_SPANISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -602,7 +602,7 @@ class UD_PORTUGUESE(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -630,7 +630,7 @@ class UD_ROMANIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -654,7 +654,7 @@ class UD_CATALAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -682,7 +682,7 @@ class UD_POLISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -707,7 +707,7 @@ class UD_CZECH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -730,7 +730,7 @@ class UD_CZECH(UniversalDependenciesCorpus):
             f"{ud_path}/cs_pdt-ud-train-v.conllu",
             Path("datasets") / dataset_name / "original",
         )
-        data_path = Path(flair.cache_root) / "datasets" / dataset_name
+        data_path = flair.cache_root / "datasets" / dataset_name
 
         train_filenames = [
             "cs_pdt-ud-train-c.conllu",
@@ -760,7 +760,7 @@ class UD_SLOVAK(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -785,7 +785,7 @@ class UD_SWEDISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -814,7 +814,7 @@ class UD_DANISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -839,7 +839,7 @@ class UD_NORWEGIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -868,7 +868,7 @@ class UD_FINNISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -893,7 +893,7 @@ class UD_SLOVENIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -918,7 +918,7 @@ class UD_CROATIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -943,7 +943,7 @@ class UD_SERBIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -968,7 +968,7 @@ class UD_BULGARIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -993,7 +993,7 @@ class UD_ARABIC(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1019,7 +1019,7 @@ class UD_HEBREW(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1043,7 +1043,7 @@ class UD_TURKISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1070,7 +1070,7 @@ class UD_PERSIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1099,7 +1099,7 @@ class UD_RUSSIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1128,7 +1128,7 @@ class UD_HINDI(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1155,7 +1155,7 @@ class UD_INDONESIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1180,7 +1180,7 @@ class UD_JAPANESE(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1205,7 +1205,7 @@ class UD_CHINESE(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1230,7 +1230,7 @@ class UD_KOREAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1259,7 +1259,7 @@ class UD_BASQUE(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1284,7 +1284,7 @@ class UD_CHINESE_KYOTO(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1311,7 +1311,7 @@ class UD_GREEK(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1338,7 +1338,7 @@ class UD_NAIJA(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1365,7 +1365,7 @@ class UD_LIVVI(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1387,7 +1387,7 @@ class UD_BURYAT(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1413,7 +1413,7 @@ class UD_NORTH_SAMI(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1439,7 +1439,7 @@ class UD_MARATHI(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1466,7 +1466,7 @@ class UD_MALTESE(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
         web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Maltese-MUDT/master"
         cached_path(
@@ -1493,7 +1493,7 @@ class UD_AFRIKAANS(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
         web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Afrikaans-AfriBooms/master"
         cached_path(
@@ -1520,7 +1520,7 @@ class UD_GOTHIC(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1547,7 +1547,7 @@ class UD_OLD_FRENCH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1574,7 +1574,7 @@ class UD_WOLOF(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
         web_path = "https://raw.githubusercontent.com/UniversalDependencies/UD_Wolof-WTB/master"
         cached_path(
@@ -1601,7 +1601,7 @@ class UD_BELARUSIAN(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1628,7 +1628,7 @@ class UD_COPTIC(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary
@@ -1654,7 +1654,7 @@ class UD_IRISH(UniversalDependenciesCorpus):
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.cache_root) / "datasets"
+            base_path = flair.cache_root / "datasets"
         data_folder = base_path / dataset_name
 
         # download data if necessary

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1683,7 +1683,7 @@ class BPEmbSerializable(BPEmb):
         self.__dict__ = state
 
         # write out the binary sentence piece model into the expected directory
-        self.cache_dir: Path = Path(flair.cache_root) / "embeddings"
+        self.cache_dir: Path = flair.cache_root / "embeddings"
         if "spm_model_binary" in self.__dict__:
             # if the model was saved as binary and it is not found on disk, write to appropriate path
             if not os.path.exists(self.cache_dir / state["lang"]):
@@ -1716,7 +1716,7 @@ class BytePairEmbeddings(TokenEmbeddings):
         self.instance_parameters = self.get_instance_parameters(locals=locals())
 
         if not cache_dir:
-            cache_dir = Path(flair.cache_root) / "embeddings"
+            cache_dir = flair.cache_root / "embeddings"
         if language:
             self.name: str = f"bpe-{language}-{syllables}-{dim}"
         else:

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -82,7 +82,7 @@ def cached_path(url_or_filename: str, cache_dir: Union[str, Path]) -> Path:
     """
     if type(cache_dir) is str:
         cache_dir = Path(cache_dir)
-    dataset_cache = Path(flair.cache_root) / cache_dir
+    dataset_cache = flair.cache_root / cache_dir
 
     parsed = urlparse(url_or_filename)
 

--- a/flair/inference_utils.py
+++ b/flair/inference_utils.py
@@ -106,7 +106,7 @@ class WordEmbeddingsStore:
         """
         get the filename of the store
         """
-        cache_dir = Path(flair.cache_root)
+        cache_dir = flair.cache_root
         embedding_filename = re.findall("/(embeddings/.*)", embedding.name)[0]
         store_path = cache_dir / (embedding_filename + "." + backend)
         return store_path

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1167,32 +1167,32 @@ class SequenceTagger(flair.nn.Model):
 
         # special handling for the taggers by the @redewiegergabe project (TODO: move to model hub)
         elif model_name == "de-historic-indirect":
-            model_file = Path(flair.cache_root) / cache_dir / 'indirect' / 'final-model.pt'
+            model_file = flair.cache_root / cache_dir / 'indirect' / 'final-model.pt'
             if not model_file.exists():
                 cached_path('http://www.redewiedergabe.de/models/indirect.zip', cache_dir=cache_dir)
-                unzip_file(Path(flair.cache_root) / cache_dir / 'indirect.zip', Path(flair.cache_root) / cache_dir)
-            model_path = str(Path(flair.cache_root) / cache_dir / 'indirect' / 'final-model.pt')
+                unzip_file(flair.cache_root / cache_dir / 'indirect.zip', flair.cache_root / cache_dir)
+            model_path = str(flair.cache_root / cache_dir / 'indirect' / 'final-model.pt')
 
         elif model_name == "de-historic-direct":
-            model_file = Path(flair.cache_root) / cache_dir / 'direct' / 'final-model.pt'
+            model_file = flair.cache_root / cache_dir / 'direct' / 'final-model.pt'
             if not model_file.exists():
                 cached_path('http://www.redewiedergabe.de/models/direct.zip', cache_dir=cache_dir)
-                unzip_file(Path(flair.cache_root) / cache_dir / 'direct.zip', Path(flair.cache_root) / cache_dir)
-            model_path = str(Path(flair.cache_root) / cache_dir / 'direct' / 'final-model.pt')
+                unzip_file(flair.cache_root / cache_dir / 'direct.zip', flair.cache_root / cache_dir)
+            model_path = str(flair.cache_root / cache_dir / 'direct' / 'final-model.pt')
 
         elif model_name == "de-historic-reported":
-            model_file = Path(flair.cache_root) / cache_dir / 'reported' / 'final-model.pt'
+            model_file = flair.cache_root / cache_dir / 'reported' / 'final-model.pt'
             if not model_file.exists():
                 cached_path('http://www.redewiedergabe.de/models/reported.zip', cache_dir=cache_dir)
-                unzip_file(Path(flair.cache_root) / cache_dir / 'reported.zip', Path(flair.cache_root) / cache_dir)
-            model_path = str(Path(flair.cache_root) / cache_dir / 'reported' / 'final-model.pt')
+                unzip_file(flair.cache_root / cache_dir / 'reported.zip', flair.cache_root / cache_dir)
+            model_path = str(flair.cache_root / cache_dir / 'reported' / 'final-model.pt')
 
         elif model_name == "de-historic-free-indirect":
-            model_file = Path(flair.cache_root) / cache_dir / 'freeIndirect' / 'final-model.pt'
+            model_file = flair.cache_root / cache_dir / 'freeIndirect' / 'final-model.pt'
             if not model_file.exists():
                 cached_path('http://www.redewiedergabe.de/models/freeIndirect.zip', cache_dir=cache_dir)
-                unzip_file(Path(flair.cache_root) / cache_dir / 'freeIndirect.zip', Path(flair.cache_root) / cache_dir)
-            model_path = str(Path(flair.cache_root) / cache_dir / 'freeIndirect' / 'final-model.pt')
+                unzip_file(flair.cache_root / cache_dir / 'freeIndirect.zip', flair.cache_root / cache_dir)
+            model_path = str(flair.cache_root / cache_dir / 'freeIndirect' / 'final-model.pt')
 
         # for all other cases (not local file or special download location), use HF model hub
         else:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -166,4 +166,4 @@ def test_download_load_data(tasks_base_path):
     assert len(corpus.test) == 2077
 
     # clean up data directory
-    shutil.rmtree(Path(flair.cache_root) / "datasets" / "ud_english")
+    shutil.rmtree(flair.cache_root / "datasets" / "ud_english")

--- a/tests/test_datasets_biomedical.py
+++ b/tests/test_datasets_biomedical.py
@@ -382,7 +382,7 @@ def test_sanity_not_too_many_entities(CorpusType: Type[ColumnCorpus]):
 @pytest.mark.skip(msg="We skip this test because it's only relevant for development purposes")
 def test_sanity_no_misaligned_entities(CorpusType: Type[HunerDataset]):
     dataset_name = CorpusType.__class__.__name__.lower()
-    base_path = Path(flair.cache_root) / "datasets"
+    base_path = flair.cache_root / "datasets"
     data_folder = base_path / dataset_name
 
     from flair.tokenization import SciSpacyTokenizer


### PR DESCRIPTION
This PR solves the bug #2207 and also removes all Path construction and being replaced by one in the modules init file.

This PR introduces a huge diff, but without logic changes.  So should be easily reviewable. 