### PR TITLE
Add banned sentences parameter in SequenceTagger 

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -36,6 +36,7 @@ class ColumnCorpus(Corpus):
             skip_first_line: bool = False,
             in_memory: bool = True,
             label_name_map: Dict[str, str] = None,
+            banned_sentences: List[str] = None,
             autofind_splits: bool = True,
             **corpusargs,
     ):
@@ -53,8 +54,9 @@ class ColumnCorpus(Corpus):
         :param document_separator_token: If provided, sentences that function as document boundaries are so marked
         :param skip_first_line: set to True if your dataset has a header line
         :param in_memory: If set to True, the dataset is kept in memory as Sentence objects, otherwise does disk reads
-        :return: a Corpus with annotated train, dev and test data
         :param label_name_map: Optionally map tag names to different schema.
+        :param banned_sentences: Optionally remove sentences from the corpus. Works only if `in_memory` is true
+        :return: a Corpus with annotated train, dev and test data
         """
 
         # find train, dev and test files if not specified
@@ -69,6 +71,7 @@ class ColumnCorpus(Corpus):
             encoding=encoding,
             comment_symbol=comment_symbol,
             column_delimiter=column_delimiter,
+            banned_sentences=banned_sentences,
             in_memory=in_memory,
             document_separator_token=document_separator_token,
             skip_first_line=skip_first_line,
@@ -83,6 +86,7 @@ class ColumnCorpus(Corpus):
             encoding=encoding,
             comment_symbol=comment_symbol,
             column_delimiter=column_delimiter,
+            banned_sentences=banned_sentences,
             in_memory=in_memory,
             document_separator_token=document_separator_token,
             skip_first_line=skip_first_line,
@@ -96,6 +100,7 @@ class ColumnCorpus(Corpus):
             tag_to_bioes,
             encoding=encoding,
             comment_symbol=comment_symbol,
+            banned_sentences=banned_sentences,
             column_delimiter=column_delimiter,
             in_memory=in_memory,
             document_separator_token=document_separator_token,
@@ -117,6 +122,7 @@ class ColumnDataset(FlairDataset):
             tag_to_bioes: str = None,
             column_delimiter: str = r"\s+",
             comment_symbol: str = None,
+            banned_sentences: List[str] = None,
             in_memory: bool = True,
             document_separator_token: str = None,
             encoding: str = "utf-8",
@@ -135,6 +141,8 @@ class ColumnDataset(FlairDataset):
         :param document_separator_token: If provided, sentences that function as document boundaries are so marked
         :param skip_first_line: set to True if your dataset has a header line
         :param label_name_map: Optionally map tag names to different schema.
+        :param banned_sentences: Optionally remove sentences from the corpus. Works only if `in_memory` is true
+        :return: a dataset with annotated data
         """
         if type(path_to_column_file) is str:
             path_to_column_file = Path(path_to_column_file)
@@ -146,6 +154,7 @@ class ColumnDataset(FlairDataset):
         self.comment_symbol = comment_symbol
         self.document_separator_token = document_separator_token
         self.label_name_map = label_name_map
+        self.banned_sentences = banned_sentences
 
         # store either Sentence objects in memory, or only file offsets
         self.in_memory = in_memory
@@ -198,6 +207,9 @@ class ColumnDataset(FlairDataset):
                 while True:
                     sentence = self._convert_lines_to_sentence(self._read_next_sentence(file))
                     if not sentence: break
+                    if self.banned_sentences is not None and any(
+                        [d in sentence.to_plain_string() for d in self.banned_sentences]):
+                        continue
                     sentence._previous_sentence = previous_sentence
                     sentence._next_sentence = None
 

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -998,7 +998,11 @@ class STACKOVERFLOW_NER(ColumnCorpus):
                           "Library_Class": "Class",
                           "Organization": "Website",
                           "Library_Variable": "Variable",
-                          "Variable_Name": "Variable"
+                          "Variable_Name": "Variable",
+                          "Error_Name": "O",
+                          "Keyboard_IP": "O",
+                          "Value": "O",
+                          "Output_Block": "O"
                           }
 
         # this dataset name
@@ -1013,7 +1017,7 @@ class STACKOVERFLOW_NER(ColumnCorpus):
         STACKOVERFLOW_NER_path = "https://raw.githubusercontent.com/jeniyat/StackOverflowNER/master/resources/annotated_ner_data/StackOverflow/"
 
         # data validation
-        disallowed_list = ["code omitted for annotation",
+        banned_sentences = ["code omitted for annotation",
                            "omitted for annotation",
                            "CODE_BLOCK :",
                            "OP_BLOCK :",
@@ -1026,49 +1030,26 @@ class STACKOVERFLOW_NER(ColumnCorpus):
         for file in files:
             questions = 0
             answers = 0
-            sentences = 0
-            max_length = 0
-            words = []
-            lines_sentence = []
 
             cached_path(f"{STACKOVERFLOW_NER_path}{file}.txt", Path("datasets") / dataset_name)
-            write_file = open(data_folder/ (file + "_clean.txt"), mode="w+")
             for line in open(data_folder/ (file + ".txt"), mode="r", encoding="utf-8"):
                 if line.startswith("Question_ID"):
                     questions += 1
 
                 if line.startswith("Answer_to_Question_ID"):
                     answers += 1
-
-                line_values = line.strip().split()
-                if len(line_values) < 2:
-                    text = " ".join(w for w in words)
-                    allowed = all([d not in text for d in disallowed_list])
-                    if allowed and len(text) > 0:
-                        sentences += 1
-                        max_length = max(len(words), max_length)
-                        for l in lines_sentence:
-                            write_file.write(l)
-                    write_file.write("\n")
-                    words = []
-                    lines_sentence = []
-                    continue
-                words.append(line_values[0])
-                lines_sentence.append(line)
-            log.info(f"File {file} processed:")
-            log.info(f"The longest sentences has {max_length} words.")
-            log.info(f"Questions: {questions} and Answers: {answers}")
-            log.info(f"Processed sentences: {sentences}.")
+            log.info(f"File {file} has {questions} questions and {answers} answers.")
 
 
         super(STACKOVERFLOW_NER, self).__init__(
             data_folder,
             columns,
-            train_file="train_clean.txt",
-            test_file="test_clean.txt",
-            dev_file="dev_clean.txt",
+            train_file="train.txt",
+            test_file="test.txt",
+            dev_file="dev.txt",
             tag_to_bioes=tag_to_bioes,
             encoding="utf-8",
+            banned_sentences=banned_sentences,
             in_memory=in_memory,
             label_name_map=entity_mapping,
             **corpusargs


### PR DESCRIPTION
It contains:
- Add banned sentences parameter as mentioned in #2229
- Use the new parameter to load the `STACKOVERFLOW_NER` corpus.
- Ignore tags that were excluded in the paper using `label_name_map`. There was an error when mapping to `O` tag, which was fixed with #2254.

Using the `comment_symbol` was not feasible as it applies at a line level. The new one has to be applied once there is a full sentence.

