### PR TITLE
Add Support For WandB Logger

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -125,6 +125,7 @@ class ModelTrainer:
             tensorboard_comment='',
             save_best_checkpoints=False,
             log_model_each_k_epochs: int = 0,
+            log_final_model: bool = False,
             use_swa: bool = False,
             use_final_model_for_eval: bool = False,
             **kwargs,
@@ -734,6 +735,10 @@ class ModelTrainer:
             # if we do not use dev data for model selection, save final model
             if save_final_model and not param_selection_mode:
                 self.model.save(base_path / "final-model.pt")
+            
+            if log_final_model or (log_model_each_k_epochs > 0 and not self.epoch % log_model_each_k_epochs):
+                if not Path(base_path / "final-model.pt").is_file():
+                    self.model.save(base_path / model_name)               
                 if self.wandb_logger.wandb_run:
                     self.wandb_logger.log_artifact(
                         name=f"model_{self.wandb_logger.wandb_run.id}",

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -18,7 +18,7 @@ except ImportError:
     amp = None
 
 import flair
-import flair.nn 
+import flair.nn
 from flair.data import MultiCorpus, Corpus
 from flair.datasets import DataLoader
 from flair.optim import ExpAnnealLR
@@ -717,16 +717,16 @@ class ModelTrainer:
                     model_name = "model_epoch_" + str(self.epoch) + ".pt"
                     if not Path(base_path / model_name).is_file():
                         self.model.save(base_path / model_name)
-                self.wandb_logger.log_artifact(
-                    name=f"model_{self.wandb_logger.wandb_run.id}",
-                    type="model",
-                    file_or_dir=base_path / model_name,
-                    aliases=[
-                        "latest",
-                        "best" if current_epoch_has_best_model_so_far else "",
-                        f"epoch-{self.epoch}",
-                    ],
-                )
+                    self.wandb_logger.log_artifact(
+                        name=f"model_{self.wandb_logger.wandb_run.id}",
+                        type="model",
+                        file_or_dir=base_path / model_name,
+                        aliases=[
+                            "latest",
+                            "best" if current_epoch_has_best_model_so_far else "",
+                            f"epoch-{self.epoch}",
+                        ],
+                    )
 
             if use_swa:
                 optimizer.swap_swa_sgd()

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -723,7 +723,7 @@ class ModelTrainer:
                     file_or_dir=base_path / model_name,
                     aliases=[
                         "latest",
-                        "best" if self.check_for_best_score(current_score) else "",
+                        "best" if current_epoch_has_best_model_so_far else "",
                         f"epoch-{self.epoch}",
                     ],
                 )

--- a/flair/wandb_logger.py
+++ b/flair/wandb_logger.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+try:
+    import wandb
+    from wandb import init, finish
+except ImportError:
+    wandb = None
+
+
+class WandbLogger:
+    def __init__(self, project, name=None, config={}, entity=None):
+        self.wandb_run = None
+        self.log_dict = {}
+        if wandb:
+            self.wandb_run = (
+                wandb.init(project=project, name=name, config=config, entity=entity)
+                if not wandb.run
+                else wandb.run
+            )
+
+    def log(self, log_dict, prefix=""):
+        if not isinstance(log_dict, dict):
+            return
+        for key, value in log_dict.items():
+            self.log_dict[f"{prefix}{key}"] = value
+
+    def log_artifact(self, name, type, file_or_dir, metadata={}, aliases=[]):
+        artifact = wandb.Artifact(name=name, type=type, metadata=metadata)
+        path_to_log = Path(file_or_dir)
+        if path_to_log.is_file():
+            artifact.add_file(file_or_dir)
+        if path_to_log.is_dir(): 
+            artifact.add_dir(file_or_dir)
+
+        wandb.log_artifact(artifact, aliases=aliases)
+
+    def flush(self):
+        self.wandb_run.log(self.log_dict)
+        self.log_dict = {}
+
+    def log_config(self, config_dict):
+        self.wandb_run.config.update(config_dict)
+
+    def finish(self):
+        self.wandb_run.finish()

--- a/flair/wandb_logger.py
+++ b/flair/wandb_logger.py
@@ -12,6 +12,7 @@ class WandbLogger:
         self.wandb_run = None
         self.log_dict = {}
         if wandb:
+            config['repo'] = 'https://github.com/flairNLP/flair.git'
             self.wandb_run = (
                 wandb.init(project=project, name=name, config=config, entity=entity)
                 if not wandb.run

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -1,51 +1,35 @@
 from flair.data import Corpus
-from flair.datasets import UD_ENGLISH
-from flair.embeddings import TokenEmbeddings, WordEmbeddings, StackedEmbeddings
-
-# 1. get the corpus
-corpus: Corpus = UD_ENGLISH().downsample(0.1)
-print(corpus)
-
-# 2. what tag do we want to predict?
-tag_type = 'pos'
-
-# 3. make the tag dictionary from the corpus
-tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
-print(tag_dictionary)
-
-# 4. initialize embeddings
-embedding_types = [
-
-    WordEmbeddings('glove'),
-
-    # comment in this line to use character embeddings
-    # CharacterEmbeddings(),
-
-    # comment in these lines to use flair embeddings
-    # FlairEmbeddings('news-forward'),
-    # FlairEmbeddings('news-backward'),
-]
-
-embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)
-
-# 5. initialize sequence tagger
-from flair.models import SequenceTagger
-
-tagger: SequenceTagger = SequenceTagger(hidden_size=256,
-                                        embeddings=embeddings,
-                                        tag_dictionary=tag_dictionary,
-                                        tag_type=tag_type,
-                                        use_crf=True)
-
-# 6. initialize trainer
+from flair.datasets import TREC_6
+from flair.embeddings import WordEmbeddings, FlairEmbeddings, DocumentRNNEmbeddings
+from flair.models import TextClassifier
 from flair.trainers import ModelTrainer
 
-trainer: ModelTrainer = ModelTrainer(tagger, corpus, project_name='Sequence_tagger', run_name='example_pos')
 
-# 7. start training
-trainer.train('resources/taggers/example-pos',
+# 1. get the corpus
+corpus: Corpus = TREC_6()
+
+# 2. create the label dictionary
+label_dict = corpus.make_label_dictionary()
+
+# 3. make a list of word embeddings
+word_embeddings = [WordEmbeddings('glove')]
+
+# 4. initialize document embedding by passing list of word embeddings
+# Can choose between many RNN types (GRU by default, to change use rnn_type parameter)
+document_embeddings = DocumentRNNEmbeddings(word_embeddings, hidden_size=256)
+
+# 5. create the text classifier
+classifier = TextClassifier(document_embeddings, label_dictionary=label_dict)
+
+# 6. initialize the text classifier trainer
+trainer = ModelTrainer(classifier, corpus, project_name='Text_classifier', run_name='exp1')
+
+# 7. start the training
+trainer.train('resources/taggers/trec',
               learning_rate=0.1,
               mini_batch_size=32,
-              max_epochs=150, 
-              log_model_each_k_epochs=1
+              anneal_factor=0.5,
+              patience=5,
+              max_epochs=150,
+              log_model_each_k_epochs=1,
               )

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -1,0 +1,51 @@
+from flair.data import Corpus
+from flair.datasets import UD_ENGLISH
+from flair.embeddings import TokenEmbeddings, WordEmbeddings, StackedEmbeddings
+
+# 1. get the corpus
+corpus: Corpus = UD_ENGLISH().downsample(0.1)
+print(corpus)
+
+# 2. what tag do we want to predict?
+tag_type = 'pos'
+
+# 3. make the tag dictionary from the corpus
+tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
+print(tag_dictionary)
+
+# 4. initialize embeddings
+embedding_types = [
+
+    WordEmbeddings('glove'),
+
+    # comment in this line to use character embeddings
+    # CharacterEmbeddings(),
+
+    # comment in these lines to use flair embeddings
+    # FlairEmbeddings('news-forward'),
+    # FlairEmbeddings('news-backward'),
+]
+
+embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)
+
+# 5. initialize sequence tagger
+from flair.models import SequenceTagger
+
+tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+                                        embeddings=embeddings,
+                                        tag_dictionary=tag_dictionary,
+                                        tag_type=tag_type,
+                                        use_crf=True)
+
+# 6. initialize trainer
+from flair.trainers import ModelTrainer
+
+trainer: ModelTrainer = ModelTrainer(tagger, corpus, project_name='Sequence_tagger', run_name='example_pos')
+
+# 7. start training
+trainer.train('resources/taggers/example-pos',
+              learning_rate=0.1,
+              mini_batch_size=32,
+              max_epochs=150, 
+              log_model_each_k_epochs=1
+              )

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -22,7 +22,7 @@ document_embeddings = DocumentRNNEmbeddings(word_embeddings, hidden_size=256)
 classifier = TextClassifier(document_embeddings, label_dictionary=label_dict)
 
 # 6. initialize the text classifier trainer
-trainer = ModelTrainer(classifier, corpus, project_name='Text_classifier', run_name='exp1')
+trainer = ModelTrainer(classifier, corpus, project_name='Text_classifier_new', run_name='exp1_log_epochs')
 
 # 7. start the training
 trainer.train('resources/taggers/trec',
@@ -30,6 +30,7 @@ trainer.train('resources/taggers/trec',
               mini_batch_size=32,
               anneal_factor=0.5,
               patience=5,
-              max_epochs=150,
-              log_model_each_k_epochs=1,
+              max_epochs=10,
+              #log_model_each_k_epochs=1,
+              log_final_model= True
               )


### PR DESCRIPTION
# This PR adds support for WandB logger. 
### To enable, install wandb using `pip install wandb`
## Following notable changes have been introduced:
* Instead of accepting project name and tensorboard log directory as separate variables, this accepts `project_name` and `run_name` and utilizes them to initialize both wandb run and tensorboard directory. ( `self.tensorboard_log_dir = Path(project_name) / run_name`)
* Trainer now accepts `log_model_each_k_epochs` to log models as W&B aritfacts. Assigns aliases-> `epoch`, `best` if the current model is best
* Automatically tracks all metrics
## To discuss:
###  Resume runs directly from artifacts: 
There are many ways we can do this as logging model checkpoints is already implemented. Simplest way would be to check if a checkpoint is a W&B link. For example,
```
checkpoint = 'https://wandb.ai/user/project/model_runid:latest'
trainer = ModelTrainer.load_checkpoint(checkpoint, corpus)
```
 But we can go a step further, and add another function that automatically resumes runs from run links like:
```
run_link = `hhtps://wandb.ai/user/project/runid`
trainer.resume_from_artifact(run_link )
```
### Log and version the datasets


cc @alanakbik 