### PR TITLE
Proposal to allow users to push models to the 🤗 Hub

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1249,7 +1249,8 @@ class SequenceTagger(flair.nn.Model):
 
         return model_path
 
-    def push_to_hub(self,
+    def push_to_hub(
+        self,
         repo_name: str,
         organization: Optional[str] = None,
         private: bool = None,
@@ -1295,7 +1296,8 @@ class SequenceTagger(flair.nn.Model):
                 token,
                 path_or_fileobj=local_path,
                 path_in_repo=hf_model_name,
-                repo_id=repo_id)
+                repo_id=repo_id
+            )
             return repo_url
 
     def get_transition_matrix(self):

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1256,11 +1256,11 @@ class SequenceTagger(flair.nn.Model):
         commit_message: str = "Add new SequenceTagger model."):
         """
         Uploads the Sequence Tagger model to a HuggingFace Hub repository.
-        :param repo_name: Repository name for your model in the Hub.
-        :param organization:  Organization in which you want to push your model(you must be a member of this organization).
+        :param repo_name: Repository name for the model in the Hub.
+        :param organization:  Organization in which the model will be pushed (you must be a member of this organization).
         :param private: Whether the repository is private.
         :param commit_message: Message to commit while pushing.
-        :return: The url of the commit of your model in the given repository.
+        :return: The url of the commit of the model in the given repository.
         """
         # Lazy import
         from huggingface_hub import HfApi, HfFolder, Repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ sentencepiece==0.1.95
 konoha<5.0.0,>=4.0.0
 janome
 gdown==3.12.2
-huggingface-hub
+huggingface-hub>=0.0.10

--- a/test_flair.py
+++ b/test_flair.py
@@ -1,6 +1,0 @@
-from flair.models import SequenceTagger
-from flair.data import Sentence
-
-sentence = Sentence('I love Berlin .')
-tagger = SequenceTagger.load('flair/ner-english')
-print(tagger.push_to_hub('flair-ner-english3', commit_message="This is a new model"))

--- a/test_flair.py
+++ b/test_flair.py
@@ -1,0 +1,6 @@
+from flair.models import SequenceTagger
+from flair.data import Sentence
+
+sentence = Sentence('I love Berlin .')
+tagger = SequenceTagger.load('flair/ner-english')
+print(tagger.push_to_hub('flair-ner-english3', commit_message="This is a new model"))


### PR DESCRIPTION
**Hi Flair Team! I wanted to propose extending the 🤗 Hub integration by allowing your users to upload their models.**

Your users would benefit by being able to easily share their models and try them out with the Hub widgets. This PR is just a demo to show how it can be done. This allows users to simply share their model with a single line.

```
model = SequenceTagger.load(...)
model.push_to_hub('my-own-ner-english')
```

[Here is an example](https://huggingface.co/osanseviero/flair-ner-english) of a repo created with this method. I kept the changes minimal to showcase how this part of the integration could look like, but we would be happy to discuss further in Slack if you prefer.


As a follow-up, there are two things that could be nice

1. Allow trainer to push to Hub

```
trainer = ModelTrainer(tagger, corpus)
trainer.train('resources/taggers/example-pos',
              learning_rate=0.1,
              mini_batch_size=32,
              max_epochs=150,
              push_to_hub=True)
```

2. Automatically create the model card information from training, such as datasets, metrics, and more!

Let us know what you think :) I'm looking forward for a more complete integration with Flair, the library is awesome!

Cheers!
Omar & 🤗 team



