### PR TITLE
Reading algorithm for semantic roles for the Universal Propositions Bank dataset

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -594,6 +594,8 @@ class Sentence(DataPoint):
         # some sentences represent a document boundary (but most do not)
         self.is_document_boundary: bool = False
 
+        self.frames : List[Frame] = list()
+
     def get_token(self, token_id: int) -> Token:
         for token in self.tokens:
             if token.idx == token_id:
@@ -1443,3 +1445,16 @@ def randomly_split_into_two_datasets(dataset, length_of_first):
     second_dataset.sort()
 
     return [Subset(dataset, first_dataset), Subset(dataset, second_dataset)]
+
+class Frame(DataPoint):
+    def __init__(self, frame: Token, roles : List[Span]):
+        super().__init__()
+        self.frame = frame
+        self.roles = roles
+
+
+    def __len__(self):
+        return len(roles)
+
+    def __repr__(self):
+        return "Frame: "+str(self.frame)+"; Roles: "+str(self.roles)

--- a/flair/data.py
+++ b/flair/data.py
@@ -1452,6 +1452,10 @@ class Frame(DataPoint):
         self.frame = frame
         self.roles = roles
 
+    def to(self, device: str, pin_memory: bool = False):
+        self.frame.to(device, pin_memory)
+        for role in self.roles:
+            role.to(device, pin_memory)
 
     def __len__(self):
         return len(roles)

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -330,6 +330,30 @@ class ColumnDataset(FlairDataset):
                     token.whitespace_after = False
         return token
 
+    def dfs_tree(sub_root_id: int, verb_dict, tree_dict, ignore_other_frames = True) -> [int]:
+        """
+        Traverses a syntax tree from a given point sub_root_id to its leaves, stopping when frames are hit
+        Function is used for semantic role labeling
+        :param sub_root_id: ID of (sub)root-element (everything above ignored)
+        :param verb_dict: dictionary of frames (verbs) and its IDs
+        :param tree_dict: dictionary of IDs and the depending words
+        :param ignore_other_frames: set to true if algorithm should stop when hitting other frames
+        :return: list of IDs of words within a sentence which were traversed
+        """
+        list_of_word_ids = []
+
+        # Traversing all IDs of words dependent from the current one
+        for sub_id in tree_dict[sub_root_id]:
+            # It only continues if ID is not a frame itself or the frame-ignoring is deactivated
+            if sub_id not in verb_dict or not ignore_other_frames:
+                list_of_word_ids.append(sub_id)
+
+                # Continue recursion if there are more sub-ids
+                if sub_id in tree_dict:
+                    list_of_word_ids.extend(dfs_tree(sub_root_id=sub_id, verb_dict=verb_dict, tree_dict=tree_dict, ignore_other_frames=ignore_other_frames))
+
+        return list_of_word_ids
+    
     def __line_completes_sentence(self, line: str) -> bool:
         sentence_completed = line.isspace() or line == ''
         return sentence_completed

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -2835,7 +2835,7 @@ class UP_CHINESE(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 9: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 9: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -2886,7 +2886,7 @@ class UP_ENGLISH(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 10: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 10: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -2937,7 +2937,7 @@ class UP_FRENCH(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 9: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 9: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -2988,7 +2988,7 @@ class UP_FINNISH(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 9: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 9: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -3039,7 +3039,7 @@ class UP_GERMAN(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 9: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 9: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -3090,7 +3090,7 @@ class UP_ITALIAN(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 9: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 9: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -3141,7 +3141,7 @@ class UP_SPANISH(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 9: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 9: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()
@@ -3192,7 +3192,7 @@ class UP_SPANISH_ANCORA(ColumnCorpus):
             base_path: Path = Path(base_path)
 
         # column format
-        columns = {1: "text", 9: "frame"}
+        columns = {0: "id", 1: 'text', 6: "headid", 9: 'frame'}
 
         # this dataset name
         dataset_name = self.__class__.__name__.lower()

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -237,9 +237,9 @@ class ColumnDataset(FlairDataset):
             line = file.readline()
         return lines
 
-    #def dfs_tree(self, sub_root_id: int, verb_dict, tree_dict, ignore_other_frames = True) -> [int]:
-        """
-        Traverses a syntax tree from a given point sub_root_id to its leaves, stopping when frames are hit
+    def dfs_tree(self, sub_root_id: int, verb_dict, tree_dict, ignore_other_frames = True) -> [int]:
+        
+        """Traverses a syntax tree from a given point sub_root_id to its leaves, stopping when frames are hit
         Function is used for semantic role labeling
         :param sub_root_id: ID of (sub)root-element (everything above ignored)
         :param verb_dict: dictionary of frames (verbs) and its IDs
@@ -247,7 +247,7 @@ class ColumnDataset(FlairDataset):
         :param ignore_other_frames: set to true if algorithm should stop when hitting other frames
         :return: list of IDs of words within a sentence which were traversed
         """
-        """list_of_word_ids = []
+        list_of_word_ids = []
 
         # Traversing all IDs of words dependent from the current one
         for sub_id in tree_dict[sub_root_id]:
@@ -259,15 +259,14 @@ class ColumnDataset(FlairDataset):
                 if sub_id in tree_dict:
                     list_of_word_ids.extend(self.dfs_tree(sub_root_id=sub_id, verb_dict=verb_dict, tree_dict=tree_dict, ignore_other_frames=ignore_other_frames))
 
-        return list_of_word_ids"""
+        return list_of_word_ids
 
     def _convert_lines_to_sentence(self, lines):
 
         sentence: Sentence = Sentence()
 
-####################################################### BEGIN LUKAS ÄNDERUNGEN
         # If it is a semantic role labeler
-        """if self.is_srl:
+        if self.is_srl:
             # A couple of temporary variables needed
             frames = []     # Final frame objects
             frame_dict = {} # {'read.01': [('I', 'ARG0'), ...], ...}
@@ -276,7 +275,7 @@ class ColumnDataset(FlairDataset):
             tree_dict = {}  # {2: [1, 4, 22], 3: ...}
             id_text_dict = {}   # {1: "I", 2: "read", ...}
             role_dict = {}  #   {1: ['ARG0', '_', 'V'], 2: ...}
-            column_name_map_inv = {v: k for k, v in self.column_name_map.items()}"""
+            column_name_map_inv = {v: k for k, v in self.column_name_map.items()}
 
         for line in lines:
             # skip comments
@@ -301,7 +300,7 @@ class ColumnDataset(FlairDataset):
                 sentence.add_token(token)
             
                 # checks if its a srl problem
-                """if self.is_srl:
+                if self.is_srl:
                     # Split into small columns and parse the indices of the columns
                     columns = line.strip().split("\t")
                     column_frame = column_name_map_inv["frame"]
@@ -331,12 +330,12 @@ class ColumnDataset(FlairDataset):
                         id_text_dict[column_id] = column_text
 
                         # build id-roles dictionary
-                        role_dict[column_id] = columns[int(column_frame)+1 : ]"""
+                        role_dict[column_id] = columns[int(column_frame)+1 : ]
         
         # check if this sentence is a document boundary
         if sentence.to_original_text() == self.document_separator_token: sentence.is_document_boundary = True
         
-        """if self.is_srl:
+        if self.is_srl:
             # Traverses all semantic roles
             # k = id of word, v = list of semantic roles
             for k, v in role_dict.items():
@@ -380,23 +379,13 @@ class ColumnDataset(FlairDataset):
                             else:
                                 frame_dict[verb_list[idx]] = [(whole_string, sem_rol)]
 
-            print("Verb-dict:\t"+str(verb_dict)+"\n")
-            print("tree dict:\t"+str(tree_dict)+"\n")
-            print("id-text dict:\t"+str(id_text_dict)+"\n")
-            print("id-roles dict:\t"+str(role_dict)+"\n")
-            print("Frames:\t"+str(frame_dict)+"\n")"""
-
-            # TODO
-
             # Build frame object and append it to frame list for that sentence
-            #for frame, roles in temp_frame_dict.items():
-            #    frame_temp = Frame(frame, roles)
-            #    frames.append(frame_temp)
+            for frame, roles in frame_dict.items():
+                frame_temp = Frame(frame, roles)
+                frames.append(frame_temp)
 
             # Add frame list to sentence
-            #sentence.frames = frames
-
-####################################################### END LUKAS ÄNDERUNGEN
+            sentence.frames = frames
 
         if self.tag_to_bioes is not None:
             sentence.convert_tag_scheme(


### PR DESCRIPTION
The code contains the new algorithm which reads in the semantic roles, currently working for the seven UP-datasets in flair (can be extended). It also includes the new Frame-class which are the objects the semantic roles get read into.