### PR TITLE
Fix typo.

### DIFF
--- a/resources/docs/TUTORIAL_1_BASICS.md
+++ b/resources/docs/TUTORIAL_1_BASICS.md
@@ -220,7 +220,7 @@ sentence = Sentence('France is the current world cup winner.')
 sentence.add_label('topic', 'sports')
 sentence.add_label('topic', 'soccer')
 
-# this sentence has a "language" labels
+# this sentence has a "language" label
 sentence.add_label('language', 'English')
 
 print(sentence)


### PR DESCRIPTION
The word "label" should be in singular, not plural, as there is only one language label.