### PR TITLE
GH-2292: add support for Spanish clinical Flair embeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -523,6 +523,9 @@ class FlairEmbeddings(TokenEmbeddings):
             # Tamil
             "ta-forward": f"{hu_path}/lm-ta-opus-large-forward-v0.1.pt",
             "ta-backward": f"{hu_path}/lm-ta-opus-large-backward-v0.1.pt",
+            # Spanish clinical
+            "es-clinical-forward": f"{hu_path}/es-clinical-forward.pt",
+            "es-clinical-backward": f"{hu_path}/es-clinical-backward.pt",
             # CLEF HIPE Shared task
             "de-impresso-hipe-v1-forward": f"{clef_hipe_path}/de-hipe-flair-v1-forward/best-lm.pt",
             "de-impresso-hipe-v1-backward": f"{clef_hipe_path}/de-hipe-flair-v1-backward/best-lm.pt",

--- a/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
+++ b/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
@@ -43,6 +43,7 @@ Currently, the following contextual string embeddings are provided (note: replac
 | 'de-historic-rw-X'  | German (historical) | Added by [@redewiedergabe](https://github.com/redewiedergabe): Historical German trained over 100 million tokens |
 | 'es-X'    | Spanish | Added by [@iamyihwa](https://github.com/zalandoresearch/flair/issues/80): Trained with Wikipedia |
 | 'es-X-fast'    | Spanish | Added by [@iamyihwa](https://github.com/zalandoresearch/flair/issues/80): Trained with Wikipediam CPU-friendly |
+| 'es-clinical-'    | Spanish (clinical) | Added by [@matirojasg](https://github.com/flairNLP/flair/issues/2292): Trained with Wikipedia |
 | 'eu-X'    | Basque | Added by [@stefan-it](https://github.com/zalandoresearch/flair/issues/614): Trained with Wikipedia/OPUS |
 | 'eu-v0-X'    | Basque | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): LM embeddings (earlier version) |
 | 'fa-X'     | Persian | Added by [@stefan-it](https://github.com/zalandoresearch/flair/issues/614): Trained with Wikipedia/OPUS |


### PR DESCRIPTION
This PR adds support for Flair embeddings trained over Spanish clinical text. Big thanks to @matirojasg for contributing these! 

Call like so: 

```python
forward_embeddings = FlairEmbeddings("es-clinical-forward")
backward_embeddings = FlairEmbeddings("es-clinical-backward")
```
