### PR TITLE
Parameterize CoNLL-U (Plus) Fields for Token-Level Annotation

### DIFF
--- a/flair/datasets/conllu.py
+++ b/flair/datasets/conllu.py
@@ -26,10 +26,10 @@ DEFAULT_METADATA_PARSERS: Dict[str, conllu._MetadataParserType] = dict(
 
 
 def parse_relation_tuple_list(
-    key: str,
-    value: Optional[str] = None,
-    list_sep: str = "|",
-    value_sep: str = ";",
+        key: str,
+        value: Optional[str] = None,
+        list_sep: str = "|",
+        value_sep: str = ";",
 ) -> Optional[List[Tuple[int, int, int, int, str]]]:
     if value is None:
         return value
@@ -44,15 +44,15 @@ def parse_relation_tuple_list(
 
 class CoNLLUCorpus(Corpus):
     def __init__(
-        self,
-        data_folder: Union[str, Path],
-        train_file=None,
-        test_file=None,
-        dev_file=None,
-        in_memory: bool = True,
-        fields: Optional[Sequence[str]] = None,
-        field_parsers: Optional[Dict[str, conllu._FieldParserType]] = None,
-        metadata_parsers: Optional[Dict[str, conllu._MetadataParserType]] = None,
+            self,
+            data_folder: Union[str, Path],
+            train_file=None,
+            test_file=None,
+            dev_file=None,
+            in_memory: bool = True,
+            fields: Optional[Sequence[str]] = None,
+            field_parsers: Optional[Dict[str, conllu._FieldParserType]] = None,
+            metadata_parsers: Optional[Dict[str, conllu._MetadataParserType]] = None,
     ):
         """
         Instantiates a Corpus from CoNLL-U (Plus) column-formatted task data
@@ -108,12 +108,12 @@ class CoNLLUCorpus(Corpus):
 
 class CoNLLUDataset(FlairDataset):
     def __init__(
-        self,
-        path_to_conllu_file: Union[str, Path],
-        in_memory: bool = True,
-        fields: Optional[Sequence[str]] = None,
-        field_parsers: Optional[Dict[str, conllu._FieldParserType]] = None,
-        metadata_parsers: Optional[Dict[str, conllu._MetadataParserType]] = None,
+            self,
+            path_to_conllu_file: Union[str, Path],
+            in_memory: bool = True,
+            fields: Optional[Sequence[str]] = None,
+            field_parsers: Optional[Dict[str, conllu._FieldParserType]] = None,
+            metadata_parsers: Optional[Dict[str, conllu._MetadataParserType]] = None,
     ):
         """
         Instantiates a column dataset in CoNLL-U (Plus) format.
@@ -221,8 +221,8 @@ class CoNLLUDataset(FlairDataset):
             # relations: List[Relation] = []
             for head_start, head_end, tail_start, tail_end, label in token_list.metadata["relations"]:
                 # head and tail span indices are 1-indexed and end index is inclusive
-                head = Span(sentence.tokens[head_start - 1 : head_end])
-                tail = Span(sentence.tokens[tail_start - 1 : tail_end])
+                head = Span(sentence.tokens[head_start - 1: head_end])
+                tail = Span(sentence.tokens[tail_start - 1: tail_end])
 
                 sentence.add_complex_label("relation", RelationLabel(value=label, head=head, tail=tail))
 

--- a/tests/resources/tasks/conllu/train.conllu
+++ b/tests/resources/tasks/conllu/train.conllu
@@ -1,46 +1,46 @@
 # text = Larry Page and Sergey Brin founded Google.
 # relations = 7;7;1;2;founded_by|7;7;4;5;founded_by
-1	Larry	B-PER	_
-2	Page	I-PER	_
-3	and	O	_
-4	Sergey	B-PER	_
-5	Brin	I-PER	_
-6	founded	O	_
-7	Google	B-ORG	_
-8	.	O	SpaceAfter=No
+1	Larry	PROPN	B-PER	_
+2	Page	PROPN	I-PER	_
+3	and	CCONJ	O	_
+4	Sergey	PROPN	B-PER	_
+5	Brin	PROPN	I-PER	_
+6	founded	VERB	O	_
+7	Google	PROPN	B-ORG	_
+8	.	PUNCT	O	SpaceAfter=No
 
 # text = Microsoft was founded by Bill Gates.
 # relations = 1;1;5;6;founded_by
-1	Microsoft	B-ORG	_
-2	was	O	_
-3	founded	O	_
-4	by	O	_
-5	Bill	B-PER	_
-6	Gates	I-PER	_
-7	.	O	SpaceAfter=No
+1	Microsoft	PROPN	B-ORG	_
+2	was	AUX	O	_
+3	founded	VERB	O	_
+4	by	ADP	O	_
+5	Bill	PROPN	B-PER	_
+6	Gates	PROPN	I-PER	_
+7	.	PUNCT	O	SpaceAfter=No
 
 # text = Konrad Zuse was born in Berlin on 22 June 1910.
 # relations = 6;6;1;2;place_of_birth
-1	Konrad	B-PER	_
-2	Zuse	I-PER	_
-3	was	O	_
-4	born	O	_
-5	in	O	_
-6	Berlin	B-LOC	_
-7	on	O	_
-8	22	B-DATE	_
-9	June	I-DATE	_
-10	1910	I-DATE	_
-11	.	O	SpaceAfter=No
+1	Konrad	PROPN	B-PER	_
+2	Zuse	PROPN	I-PER	_
+3	was	AUX	O	_
+4	born	VERB	O	_
+5	in	ADP	O	_
+6	Berlin	PROPN	B-LOC	_
+7	on	ADP	O	_
+8	22	NUM	B-DATE	_
+9	June	PROPN	I-DATE	_
+10	1910	NUM	I-DATE	_
+11	.	PUNCT	O	SpaceAfter=No
 
 # text = Joseph Weizenbaum was born in Berlin, Germany.
 # relations = 6;6;1;2;place_of_birth
-1	Joseph	B-PER	_
-2	Weizenbaum	I-PER	_
-3	was	O	_
-4	born	O	_
-5	in	O	_
-6	Berlin	B-LOC	_
-7	,	O	_
-8	Germany	B-LOC	_
-9	.	O	SpaceAfter=No
+1	Joseph	PROPN	B-PER	_
+2	Weizenbaum	PROPN	I-PER	_
+3	was	AUX	O	_
+4	born	VERB	O	_
+5	in	ADP	O	_
+6	Berlin	PROPN	B-LOC	_
+7	,	PUNCT	O	_
+8	Germany	PROPN	B-LOC	_
+9	.	PUNCT	O	SpaceAfter=No

--- a/tests/resources/tasks/conllu/train.conllup
+++ b/tests/resources/tasks/conllu/train.conllup
@@ -1,47 +1,47 @@
-# global.columns = id form ner misc
+# global.columns = id form upos ner misc
 # text = Larry Page and Sergey Brin founded Google.
 # relations = 7;7;1;2;founded_by|7;7;4;5;founded_by
-1	Larry	B-PER	_
-2	Page	I-PER	_
-3	and	O	_
-4	Sergey	B-PER	_
-5	Brin	I-PER	_
-6	founded	O	_
-7	Google	B-ORG	_
-8	.	O	SpaceAfter=No
+1	Larry	PROPN	B-PER	_
+2	Page	PROPN	I-PER	_
+3	and	CCONJ	O	_
+4	Sergey	PROPN	B-PER	_
+5	Brin	PROPN	I-PER	_
+6	founded	VERB	O	_
+7	Google	PROPN	B-ORG	_
+8	.	PUNCT	O	SpaceAfter=No
 
 # text = Microsoft was founded by Bill Gates.
 # relations = 1;1;5;6;founded_by
-1	Microsoft	B-ORG	_
-2	was	O	_
-3	founded	O	_
-4	by	O	_
-5	Bill	B-PER	_
-6	Gates	I-PER	_
-7	.	O	SpaceAfter=No
+1	Microsoft	PROPN	B-ORG	_
+2	was	AUX	O	_
+3	founded	VERB	O	_
+4	by	ADP	O	_
+5	Bill	PROPN	B-PER	_
+6	Gates	PROPN	I-PER	_
+7	.	PUNCT	O	SpaceAfter=No
 
 # text = Konrad Zuse was born in Berlin on 22 June 1910.
 # relations = 6;6;1;2;place_of_birth
-1	Konrad	B-PER	_
-2	Zuse	I-PER	_
-3	was	O	_
-4	born	O	_
-5	in	O	_
-6	Berlin	B-LOC	_
-7	on	O	_
-8	22	B-DATE	_
-9	June	I-DATE	_
-10	1910	I-DATE	_
-11	.	O	SpaceAfter=No
+1	Konrad	PROPN	B-PER	_
+2	Zuse	PROPN	I-PER	_
+3	was	AUX	O	_
+4	born	VERB	O	_
+5	in	ADP	O	_
+6	Berlin	PROPN	B-LOC	_
+7	on	ADP	O	_
+8	22	NUM	B-DATE	_
+9	June	PROPN	I-DATE	_
+10	1910	NUM	I-DATE	_
+11	.	PUNCT	O	SpaceAfter=No
 
 # text = Joseph Weizenbaum was born in Berlin, Germany.
 # relations = 6;6;1;2;place_of_birth
-1	Joseph	B-PER	_
-2	Weizenbaum	I-PER	_
-3	was	O	_
-4	born	O	_
-5	in	O	_
-6	Berlin	B-LOC	_
-7	,	O	_
-8	Germany	B-LOC	_
-9	.	O	SpaceAfter=No
+1	Joseph	PROPN	B-PER	_
+2	Weizenbaum	PROPN	I-PER	_
+3	was	AUX	O	_
+4	born	VERB	O	_
+5	in	ADP	O	_
+6	Berlin	PROPN	B-LOC	_
+7	,	PUNCT	O	_
+8	Germany	PROPN	B-LOC	_
+9	.	PUNCT	O	SpaceAfter=No

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,7 +3,7 @@ import shutil
 import flair
 import flair.datasets
 from flair.data import MultiCorpus
-from flair.datasets.conllu import CoNLLUDataset, CoNLLUCorpus
+from flair.datasets.conllu import CoNLLUCorpus
 
 
 def test_load_imdb_data(tasks_base_path):
@@ -142,7 +142,6 @@ def test_load_no_dev_data_explicit(tasks_base_path):
 
 
 def test_multi_corpus(tasks_base_path):
-
     corpus_1 = flair.datasets.GERMEVAL_14(tasks_base_path)
 
     corpus_2 = flair.datasets.ColumnCorpus(tasks_base_path / "fashion", column_format={0: "text", 2: "ner"})
@@ -181,6 +180,17 @@ def _assert_conllu_dataset(dataset):
         "O",
     ]
 
+    assert [token.get_tag("upos").value for token in sent1.tokens] == [
+        "PROPN",
+        "PROPN",
+        "CCONJ",
+        "PROPN",
+        "PROPN",
+        "VERB",
+        "PROPN",
+        "PUNCT"
+    ]
+
     assert [token.whitespace_after for token in sent1.tokens] == [
         True,
         True,
@@ -192,8 +202,11 @@ def _assert_conllu_dataset(dataset):
         False,
     ]
 
-    spans1 = sent1.get_spans("ner")
-    assert len(spans1) == 3
+    ner_spans1 = sent1.get_spans("ner")
+    assert len(ner_spans1) == 3
+
+    upos_spans1 = sent1.get_spans("upos")
+    assert len(upos_spans1) == 8
 
     rels1 = sent1.get_labels("relation")
     assert len(rels1) == 2
@@ -202,8 +215,12 @@ def _assert_conllu_dataset(dataset):
     assert [token.idx for token in rels1[1].tail] == [4, 5]
 
     sent3 = dataset[2]
-    spans3 = sent3.get_labels("ner")
-    assert len(spans3) == 3
+
+    ner_labels3 = sent3.get_labels("ner")
+    assert len(ner_labels3) == 3
+
+    upos_labels3 = sent3.get_labels("upos")
+    assert len(upos_labels3) == 11
 
     rels3 = sent3.get_labels("relation")
     assert len(rels3) == 1
@@ -215,10 +232,11 @@ def _assert_conllu_dataset(dataset):
 def test_load_conllu_corpus(tasks_base_path):
     corpus = CoNLLUCorpus(
         tasks_base_path / "conllu",
-        fields=["id", "form", "ner", "misc"],
+        fields=["id", "form", "upos", "ner", "misc"],
         train_file="train.conllu",
         dev_file="train.conllu",
         test_file="train.conllu",
+        token_annotation_fields=["upos", "ner"],
         in_memory=False,
     )
 
@@ -232,10 +250,11 @@ def test_load_conllu_corpus(tasks_base_path):
 def test_load_conllu_corpus_in_memory(tasks_base_path):
     corpus = CoNLLUCorpus(
         tasks_base_path / "conllu",
-        fields=["id", "form", "ner", "misc"],
+        fields=["id", "form", "upos", "ner", "misc"],
         train_file="train.conllu",
         dev_file="train.conllu",
         test_file="train.conllu",
+        token_annotation_fields=["upos", "ner"],
         in_memory=True,
     )
 
@@ -252,6 +271,7 @@ def test_load_conllu_plus_corpus(tasks_base_path):
         train_file="train.conllup",
         dev_file="train.conllup",
         test_file="train.conllup",
+        token_annotation_fields=["upos", "ner"],
         in_memory=False,
     )
 
@@ -268,6 +288,7 @@ def test_load_conllu_corpus_plus_in_memory(tasks_base_path):
         train_file="train.conllup",
         dev_file="train.conllup",
         test_file="train.conllup",
+        token_annotation_fields=["upos", "ner"],
         in_memory=True,
     )
 


### PR DESCRIPTION
This PR enhances the `CoNLLUCorpus` and `CoNLLUDataset` to accept an optional `token_annotation_fields` parameter. It's used to explicitly specify the annotation fields of the CoNLL-U (Plus) file, which should be transcribed to token-level labels. Per default the LEMMA, UPOS and XPOS will be used. 

#### Example:

Consider the following CoNLL-U Plus snippet contained in a `train.conllup` file:

```
# global.columns = id form upos ner misc
# text = Larry Page and Sergey Brin founded Google.
# relations = 7;7;1;2;founded_by|7;7;4;5;founded_by
1	Larry	PROPN	B-PER	_
2	Page	PROPN	I-PER	_
3	and	CCONJ	O	_
4	Sergey	PROPN	B-PER	_
5	Brin	PROPN	I-PER	_
6	founded	VERB	O	_
7	Google	PROPN	B-ORG	_
8	.	PUNCT	O	SpaceAfter=No
```

We can now load a `CoNLLUDataset` annotated with NER and UPOS tags:

```python
from flair.datasets.conllu import CoNLLUDataset

dataset: CoNLLUDataset = CoNLLUDataset('train.conllup', token_annotation_fields=['upos', 'ner'])
```

Next, we print the sentence:

```python
print(dataset.sentences[0])

>>> Sentence: "Larry Page and Sergey Brin founded Google ."   [− Tokens: 8  − Token-Labels: "Larry <PROPN/B-PER> Page <PROPN/I-PER> and <CCONJ> Sergey <PROPN/B-PER> Brin <PROPN/I-PER> founded <VERB> Google <PROPN/B-ORG> . <PUNCT>"  − Sentence-Labels: {'relation': [founded_by from Google (7) -> Larry Page (1,2) (1.0), founded_by from Google (7) -> Sergey Brin (4,5) (1.0)]}]
```
