### PR TITLE
Fix error with whitespaces at the end of last token

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -477,7 +477,7 @@ class Span(DataPoint):
             plain += token.text
             if token.whitespace_after:
                 plain += " "
-        return plain.rstrip()
+        return plain
 
     def to_dict(self):
         return {
@@ -867,7 +867,7 @@ class Sentence(DataPoint):
             plain += token.text
             if token.whitespace_after:
                 plain += " "
-        return plain.rstrip()
+        return plain
 
     def convert_tag_scheme(self, tag_type: str = "ner", target_scheme: str = "iob"):
 


### PR DESCRIPTION
Test:
```
import torch

from flair.data import Token, Sentence
from flair.embeddings import FlairEmbeddings

ff = FlairEmbeddings('news-forward-fast', tokenized_lm=False)
s1 = Sentence()
s1.add_token(Token('1 '))
ff.embed(s1)
```