### PR TITLE
Major refactoring of Model classes (Step 2)

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -29,11 +29,17 @@ class Dictionary:
         # init dictionaries
         self.item2idx: Dict[str, int] = {}
         self.idx2item: List[str] = []
-        self.multi_label: bool = False
 
         # in order to deal with unknown tokens, add <unk>
         if add_unk:
             self.add_item("<unk>")
+
+    def remove_item(self, item: str):
+
+        item = item.encode("utf-8")
+        if item in self.item2idx:
+            self.idx2item.remove(item)
+            del self.item2idx[item]
 
     def add_item(self, item: str) -> int:
         """
@@ -140,9 +146,13 @@ class Label:
     """
 
     def __init__(self, value: str, score: float = 1.0):
+        self._value = value
+        self._score = score
+        super().__init__()
+
+    def set_value(self, value: str, score: float = 1.0):
         self.value = value
         self.score = score
-        super().__init__()
 
     @property
     def value(self):
@@ -163,10 +173,7 @@ class Label:
 
     @score.setter
     def score(self, score):
-        if 0.0 <= score <= 1.0:
-            self._score = score
-        else:
-            self._score = 1.0
+        self._score = score
 
     def to_dict(self):
         return {"value": self.value, "confidence": self.score}
@@ -176,6 +183,9 @@ class Label:
 
     def __repr__(self):
         return f"{self._value} ({round(self._score, 4)})"
+
+    def __eq__(self, other):
+        return self.value == other.value and self.score == other.score
 
     @property
     def identifier(self):
@@ -196,6 +206,9 @@ class SpanLabel(Label):
     def __len__(self):
         return len(self.span)
 
+    def __eq__(self, other):
+        return self.value == other.value and self.score == other.score and self.span.id_text == other.span.id_text
+
     @property
     def identifier(self):
         return f"{self.span.id_text}"
@@ -215,6 +228,12 @@ class RelationLabel(Label):
 
     def __len__(self):
         return len(self.head) + len(self.tail)
+
+    def __eq__(self, other):
+        return self.value == other.value \
+               and self.score == other.score \
+               and self.head.id_text == other.head.id_text \
+               and self.tail.id_text == other.tail.id_text
 
     @property
     def identifier(self):
@@ -255,6 +274,9 @@ class DataPoint:
         return self
 
     def add_complex_label(self, typename: str, label: Label):
+
+        if typename in self.annotation_layers and label in self.annotation_layers[typename]:
+            return self
 
         if typename not in self.annotation_layers:
             self.annotation_layers[typename] = [label]
@@ -308,6 +330,9 @@ class DataPair(DataPoint):
 
     def to_plain_string(self):
         return f"DataPair: First {self.first}  ||  Second {self.second}"
+
+    def to_original_text(self):
+        return f"{self.first.to_original_text()} || {self.second.to_original_text()}"
 
     def __len__(self):
         return len(self.first) + len(self.second)
@@ -1368,7 +1393,7 @@ class Corpus:
             len(self.test) if self.test else 0,
         )
 
-    def make_label_dictionary(self, label_type: str = None) -> Dictionary:
+    def make_label_dictionary(self, label_type: str) -> Dictionary:
         """
         Creates a dictionary of all labels assigned to the sentences in the corpus.
         :return: dictionary of labels
@@ -1382,12 +1407,15 @@ class Corpus:
         loader = DataLoader(data, batch_size=1)
 
         log.info("Computing label dictionary. Progress:")
+
+        all_label_types = Counter()
         for batch in Tqdm.tqdm(iter(loader)):
 
             for sentence in batch:
 
                 # check if sentence itself has labels
-                labels = sentence.get_labels(label_type) if label_type is not None else sentence.labels
+                labels = sentence.get_labels(label_type)
+                all_label_types.update(sentence.annotation_layers.keys())
 
                 for label in labels:
                     label_dictionary.add_item(label.value)
@@ -1395,15 +1423,23 @@ class Corpus:
                 # check for labels of words
                 if isinstance(sentence, Sentence):
                     for token in sentence.tokens:
+                        all_label_types.update(token.annotation_layers.keys())
                         for label in token.get_labels(label_type):
-                            # print(label)
                             label_dictionary.add_item(label.value)
 
                 if not label_dictionary.multi_label:
                     if len(labels) > 1:
                         label_dictionary.multi_label = True
 
-        log.info(label_dictionary.idx2item)
+        if len(label_dictionary.idx2item) == 0:
+            log.error(
+                f"Corpus contains only the labels: {', '.join([f'{label[0]} (#{label[1]})' for label in all_label_types.most_common()])}")
+            log.error(f"You specified as label_type='{label_type}' which is not in this dataset!")
+
+            raise Exception
+
+        log.info(f"Corpus contains the labels: {', '.join([label[0] + f' (#{label[1]})' for label in all_label_types.most_common()])}")
+        log.info(f"Dictionary for label '{label_type}' contains: {label_dictionary.idx2item}")
 
         return label_dictionary
 

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -1425,7 +1425,7 @@ class GO_EMOTIONS(ClassificationCorpus):
                             txt_file.write(f"{label_string}{text}\n")
 
         super(GO_EMOTIONS, self).__init__(
-            data_folder, label_type='sentiment', tokenizer=tokenizer,
+            data_folder, label_type='emotion', tokenizer=tokenizer,
             memory_mode=memory_mode, label_name_map=label_name_map, **corpusargs,
         )
 

--- a/flair/datasets/text_text.py
+++ b/flair/datasets/text_text.py
@@ -2,7 +2,6 @@ import logging
 import os
 from pathlib import Path
 from typing import List, Union
-from flair.datasets.base import find_train_dev_test_files
 
 import flair
 from flair.data import (
@@ -11,6 +10,7 @@ from flair.data import (
     FlairDataset,
     DataPair,
 )
+from flair.datasets.base import find_train_dev_test_files
 from flair.file_utils import cached_path, unpack_file, unzip_file
 
 log = logging.getLogger("flair")
@@ -435,6 +435,7 @@ class DataPairDataset(FlairDataset):
 class GLUE_RTE(DataPairCorpus):
     def __init__(
             self,
+            label_type="entailment",
             base_path: Union[str, Path] = None,
             max_tokens_per_doc=-1,
             max_chars_per_doc=-1,
@@ -480,13 +481,13 @@ class GLUE_RTE(DataPairCorpus):
 
         super(GLUE_RTE, self).__init__(
             data_folder / "RTE",
+            label_type=label_type,
             columns=[1, 2, 3],
             skip_first_line=True,
             use_tokenizer=use_tokenizer,
             max_tokens_per_doc=max_tokens_per_doc,
             max_chars_per_doc=max_chars_per_doc,
             in_memory=in_memory,
-            label_type='textual_entailment',
             sample_missing_splits=sample_missing_splits
 
         )

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -1,8 +1,9 @@
-from abc import abstractmethod
 import logging
+from abc import abstractmethod
 from typing import List, Union
 
 import torch
+from sklearn.feature_extraction.text import TfidfVectorizer
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 from transformers import AutoTokenizer, AutoConfig, AutoModel, CONFIG_MAPPING, PreTrainedTokenizer
 
@@ -11,8 +12,6 @@ from flair.data import Sentence
 from flair.embeddings.base import Embeddings, ScalarMix
 from flair.embeddings.token import TokenEmbeddings, StackedEmbeddings, FlairEmbeddings
 from flair.nn import LockedDropout, WordDropout
-
-from sklearn.feature_extraction.text import TfidfVectorizer
 
 log = logging.getLogger("flair")
 
@@ -36,7 +35,6 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
             self,
             model: str = "bert-base-uncased",
             fine_tune: bool = True,
-            batch_size: int = 1,
             layers: str = "-1",
             layer_mean: bool = False,
             pooling: str = "cls",
@@ -90,7 +88,6 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
         self.layer_mean = layer_mean
         self.fine_tune = fine_tune
         self.static_embeddings = not self.fine_tune
-        self.batch_size = batch_size
         self.pooling = pooling
 
         # check whether CLS is at beginning or end
@@ -106,18 +103,6 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
         """Add embeddings to all words in a list of sentences."""
-
-        # using list comprehension
-        sentence_batches = [sentences[i * self.batch_size:(i + 1) * self.batch_size]
-                            for i in range((len(sentences) + self.batch_size - 1) // self.batch_size)]
-
-        for batch in sentence_batches:
-            self._add_embeddings_to_sentences(batch)
-
-        return sentences
-
-    def _add_embeddings_to_sentences(self, sentences: List[Sentence]):
-        """Extract sentence embedding from CLS token or similar and add to Sentence object."""
 
         # gradients are enabled if fine-tuning is enabled
         gradient_context = torch.enable_grad() if (self.fine_tune and self.training) else torch.no_grad()
@@ -197,6 +182,8 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
                 # set the extracted embedding for the token
                 sentence.set_embedding(self.name, torch.cat(embeddings_all_layers))
 
+        return sentences
+
     @property
     @abstractmethod
     def embedding_length(self) -> int:
@@ -222,7 +209,6 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
 
             "base_model_name": self.base_model_name,
             "fine_tune": self.fine_tune,
-            "batch_size": self.batch_size,
             "layer_indexes": self.layer_indexes,
             "layer_mean": self.layer_mean,
             "pooling": self.pooling,
@@ -252,13 +238,13 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
             embedding = TransformerDocumentEmbeddings(
                 model=self.__dict__['base_model_name'],
                 fine_tune=self.__dict__['fine_tune'],
-                batch_size=self.__dict__['batch_size'],
                 layers=layers,
                 layer_mean=self.__dict__['layer_mean'],
 
                 config=loaded_config,
                 state_dict=d["model_state_dict"],
-                pooling=self.__dict__['pooling'] if 'pooling' in self.__dict__ else 'cls', # for backward compatibility with previous models
+                pooling=self.__dict__['pooling'] if 'pooling' in self.__dict__ else 'cls',
+                # for backward compatibility with previous models
             )
 
             # I have no idea why this is necessary, but otherwise it doesn't work
@@ -363,9 +349,9 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
 
 class DocumentTFIDFEmbeddings(DocumentEmbeddings):
     def __init__(
-        self,
-        train_dataset,
-        **vectorizer_params,
+            self,
+            train_dataset,
+            **vectorizer_params,
     ):
         """The constructor for DocumentTFIDFEmbeddings.
         :param train_dataset: the train dataset which will be used to construct vectorizer
@@ -376,7 +362,7 @@ class DocumentTFIDFEmbeddings(DocumentEmbeddings):
         import numpy as np
         self.vectorizer = TfidfVectorizer(dtype=np.float32, **vectorizer_params)
         self.vectorizer.fit([s.to_original_text() for s in train_dataset])
-        
+
         self.__embedding_length: int = len(self.vectorizer.vocabulary_)
 
         self.to(flair.device)
@@ -396,10 +382,10 @@ class DocumentTFIDFEmbeddings(DocumentEmbeddings):
 
         raw_sentences = [s.to_original_text() for s in sentences]
         tfidf_vectors = torch.from_numpy(self.vectorizer.transform(raw_sentences).A)
-    
+
         for sentence_id, sentence in enumerate(sentences):
             sentence.set_embedding(self.name, tfidf_vectors[sentence_id])
-        
+
     def _add_embeddings_internal(self, sentences: List[Sentence]):
         pass
 
@@ -665,6 +651,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         else:
             self.__dict__ = d
 
+
 class DocumentLMEmbeddings(DocumentEmbeddings):
     def __init__(self, flair_embeddings: List[FlairEmbeddings]):
         super().__init__()
@@ -814,7 +801,8 @@ class DocumentCNNEmbeddings(DocumentEmbeddings):
         self.__embedding_length: int = sum([kernel_num for kernel_num, kernel_size in self.kernels])
         self.convs = torch.nn.ModuleList(
             [
-                torch.nn.Conv1d(self.embeddings_dimension, kernel_num, kernel_size) for kernel_num, kernel_size in self.kernels
+                torch.nn.Conv1d(self.embeddings_dimension, kernel_num, kernel_size) for kernel_num, kernel_size in
+                self.kernels
             ]
         )
         self.pool = torch.nn.AdaptiveMaxPool1d(1)

--- a/flair/models/__init__.py
+++ b/flair/models/__init__.py
@@ -3,3 +3,5 @@ from .language_model import LanguageModel
 from .text_classification_model import TextClassifier
 from .pairwise_classification_model import TextPairClassifier
 from .relation_extractor_model import RelationExtractor
+from .tars_model import TARSClassifier
+from .tars_model import TARSTagger

--- a/flair/models/__init__.py
+++ b/flair/models/__init__.py
@@ -1,5 +1,5 @@
 from .sequence_tagger_model import SequenceTagger, MultiTagger
 from .language_model import LanguageModel
 from .text_classification_model import TextClassifier
-from .text_classification_model import TextPairClassifier
+from .pairwise_classification_model import TextPairClassifier
 from .relation_extractor_model import RelationExtractor

--- a/flair/models/diagnosis/distance_prediction_model.py
+++ b/flair/models/diagnosis/distance_prediction_model.py
@@ -101,6 +101,9 @@ class DistancePredictor(flair.nn.Model):
         # auto-spawn on GPU if available
         self.to(flair.device)
 
+    def label_type(self):
+        return "distance"
+
     # all input should be tensors
     def weighted_mse_loss(self, predictions, target):
 

--- a/flair/models/pairwise_classification_model.py
+++ b/flair/models/pairwise_classification_model.py
@@ -1,0 +1,152 @@
+from typing import Union, List
+
+import torch
+
+import flair.embeddings
+import flair.nn
+from flair.data import Label, DataPoint, Sentence, DataPair
+
+
+class TextPairClassifier(flair.nn.DefaultClassifier):
+    """
+    Text Pair Classification Model for tasks such as Recognizing Textual Entailment, build upon TextClassifier.
+    The model takes document embeddings and puts resulting text representation(s) into a linear layer to get the
+    actual class label. We provide two ways to embed the DataPairs: Either by embedding both DataPoints
+    and concatenating the resulting vectors ("embed_separately=True") or by concatenating the DataPoints and embedding
+    the resulting vector ("embed_separately=False").
+    """
+
+    def __init__(
+            self,
+            document_embeddings: flair.embeddings.DocumentEmbeddings,
+            label_type: str,
+            embed_separately: bool = False,
+            **classifierargs,
+    ):
+        """
+        Initializes a TextClassifier
+        :param document_embeddings: embeddings used to embed each data point
+        :param label_dictionary: dictionary of labels you want to predict
+        :param multi_label: auto-detected by default, but you can set this to True to force multi-label prediction
+        or False to force single-label prediction
+        :param multi_label_threshold: If multi-label you can set the threshold to make predictions
+        :param loss_weights: Dictionary of weights for labels for the loss function
+        (if any label's weight is unspecified it will default to 1.0)
+        """
+        super().__init__(**classifierargs)
+
+        self.document_embeddings: flair.embeddings.DocumentEmbeddings = document_embeddings
+
+        self._label_type = label_type
+
+        self.embed_separately = embed_separately
+
+        # if embed_separately == True the linear layer needs twice the length of the embeddings as input size
+        # since we concatenate the embeddings of the two DataPoints in the DataPairs
+        if self.embed_separately:
+            self.decoder = torch.nn.Linear(
+                2 * self.document_embeddings.embedding_length, len(self.label_dictionary)
+            ).to(flair.device)
+
+            torch.nn.init.xavier_uniform_(self.decoder.weight)
+
+        else:
+            # representation for both sentences
+            self.decoder = torch.nn.Linear(self.document_embeddings.embedding_length, len(self.label_dictionary))
+
+            # set separator to concatenate two sentences
+            self.sep = ' '
+            if isinstance(self.document_embeddings, flair.embeddings.document.TransformerDocumentEmbeddings):
+                if self.document_embeddings.tokenizer.sep_token:
+                    self.sep = ' ' + str(self.document_embeddings.tokenizer.sep_token) + ' '
+                else:
+                    self.sep = ' [SEP] '
+
+        torch.nn.init.xavier_uniform_(self.decoder.weight)
+
+        # auto-spawn on GPU if available
+        self.to(flair.device)
+
+    @property
+    def label_type(self):
+        return self._label_type
+
+    def forward_pass(self,
+                     datapairs: Union[List[DataPoint], DataPoint],
+                     return_label_candidates: bool = False,
+                     ):
+
+        if isinstance(datapairs, DataPair):
+            datapairs = [datapairs]
+
+        embedding_names = self.document_embeddings.get_names()
+
+        if self.embed_separately:  # embed both sentences seperately, concatenate the resulting vectors
+            first_elements = [pair.first for pair in datapairs]
+            second_elements = [pair.second for pair in datapairs]
+
+            self.document_embeddings.embed(first_elements)
+            self.document_embeddings.embed(second_elements)
+
+            text_embedding_list = [
+                torch.cat([a.get_embedding(embedding_names), b.get_embedding(embedding_names)], 0).unsqueeze(0)
+                for (a, b) in zip(first_elements, second_elements)
+            ]
+
+        else:  # concatenate the sentences and embed together
+            concatenated_sentences = [
+                Sentence(
+                    pair.first.to_tokenized_string() + self.sep + pair.second.to_tokenized_string(),
+                    use_tokenizer=False
+                )
+                for pair in datapairs]
+
+            self.document_embeddings.embed(concatenated_sentences)
+
+            text_embedding_list = [
+                sentence.get_embedding(embedding_names).unsqueeze(0) for sentence in concatenated_sentences
+            ]
+
+        text_embedding_tensor = torch.cat(text_embedding_list, 0).to(flair.device)
+
+        # linear layer
+        scores = self.decoder(text_embedding_tensor)
+
+        labels = []
+        for pair in datapairs:
+            labels.append([label.value for label in pair.get_labels(self.label_type)])
+
+        # minimal return is scores and labels
+        return_tuple = (scores, labels)
+
+        if return_label_candidates:
+            label_candidates = [Label(value=None) for pair in datapairs]
+            return_tuple += (datapairs, label_candidates)
+
+        return return_tuple
+
+    def _get_state_dict(self):
+        model_state = {
+            "state_dict": self.state_dict(),
+            "document_embeddings": self.document_embeddings,
+            "label_dictionary": self.label_dictionary,
+            "label_type": self.label_type,
+            "multi_label": self.multi_label,
+            "loss_weights": self.loss_weights,
+            "embed_separately": self.embed_separately,
+        }
+        return model_state
+
+    @staticmethod
+    def _init_model_with_state_dict(state):
+
+        model = TextPairClassifier(
+            document_embeddings=state["document_embeddings"],
+            label_dictionary=state["label_dictionary"],
+            label_type=state["label_type"],
+            multi_label=state["multi_label"],
+            loss_weights=state["loss_weights"],
+            embed_separately=state["embed_separately"],
+        )
+        model.load_state_dict(state["state_dict"])
+        return model

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -1,32 +1,27 @@
 import logging
-from typing import List, Union, Dict, Optional
+from typing import List, Union
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-from tqdm import tqdm
-import flair.nn
+
 import flair.embeddings
-from flair.data import Dictionary, Sentence, DataPoint, RelationLabel, Span
-from flair.datasets import SentenceDataset, DataLoader
-from flair.training_utils import store_embeddings
+import flair.nn
+from flair.data import DataPoint, RelationLabel, Span
 
 log = logging.getLogger("flair")
 
 
-class RelationExtractor(flair.nn.Classifier):
+class RelationExtractor(flair.nn.DefaultClassifier):
 
     def __init__(
             self,
             token_embeddings: flair.embeddings.TokenEmbeddings,
-            label_dictionary: Dictionary,
             label_type: str = None,
             span_label_type: str = None,
-            beta: float = 1.0,
-            loss_weights: Dict[str, float] = None,
             use_gold_spans: bool = False,
             pooling_operation: str = "first_last",
             dropout_value: float = 0.0,
+            **classifierargs,
     ):
         """
         Initializes a RelationClassifier
@@ -36,34 +31,17 @@ class RelationExtractor(flair.nn.Classifier):
         :param loss_weights: Dictionary of weights for labels for the loss function
         (if any label's weight is unspecified it will default to 1.0)
         """
-
-        super(RelationExtractor, self).__init__()
+        super(RelationExtractor, self).__init__(**classifierargs)
 
         self.token_embeddings: flair.embeddings.TokenEmbeddings = token_embeddings
-        self.label_dictionary: Dictionary = label_dictionary
-        self.label_dictionary.add_item('O')
         self._label_type = label_type
         self.span_label_type = span_label_type
 
-        self.beta = beta
         self.use_gold_spans = use_gold_spans
         self.pooling_operation = pooling_operation
 
         self.dropout_value = dropout_value
-
         self.dropout = torch.nn.Dropout(dropout_value)
-
-        self.weight_dict = loss_weights
-        # Initialize the weight tensor
-        if loss_weights is not None:
-            n_classes = len(self.label_dictionary)
-            weight_list = [1.0 for i in range(n_classes)]
-            for i, tag in enumerate(self.label_dictionary.get_items()):
-                if tag in loss_weights.keys():
-                    weight_list[i] = loss_weights[tag]
-            self.loss_weights = torch.FloatTensor(weight_list).to(flair.device)
-        else:
-            self.loss_weights = None
 
         relation_representation_length = 2 * token_embeddings.embedding_length
         if self.pooling_operation == 'first_last':
@@ -73,23 +51,20 @@ class RelationExtractor(flair.nn.Classifier):
 
         nn.init.xavier_uniform_(self.decoder.weight)
 
-        self.loss_function = nn.CrossEntropyLoss(weight=self.loss_weights)
-        # self.loss_function = flair.nn.FocalLoss(gamma=0.5, reduction='sum')
-        # self.loss_function = flair.nn.DiceLoss(reduction='sum', with_logits=True, ohem_ratio=0.1)
-
-        # auto-spawn on GPU if available
         self.to(flair.device)
 
-    def _internal_forward_scores_and_loss(self,
-                                          sentences: Union[List[DataPoint], DataPoint],
-                                          return_scores: bool = True,
-                                          return_loss: bool = True):
+    def forward_pass(self,
+                     sentences: Union[List[DataPoint], DataPoint],
+                     return_label_candidates: bool = False,
+                     ):
 
         self.token_embeddings.embed(sentences)
 
-        entity_pairs = []
+        # entity_pairs = []
+        empty_label_candidates = []
         relation_embeddings = []
-        indices = []
+        labels = []
+        sentences_to_label = []
 
         for sentence in sentences:
 
@@ -128,11 +103,15 @@ class RelationExtractor(flair.nn.Classifier):
                         # if no gold label exists, and all spans are used, label defaults to 'O' (no relation)
                         label = 'O'
 
-                    indices.append(self.label_dictionary.get_idx_for_item(label))
+                    labels.append([label])
 
                     relation_embeddings.append(torch.cat([embedding, embedding_2]))
 
-                    entity_pairs.append((span, span_2))
+                    # if predicting, also remember sentences and label candidates
+                    if return_label_candidates:
+                        candidate_label = RelationLabel(head=span, tail=span_2, value=None, score=None)
+                        empty_label_candidates.append(candidate_label)
+                        sentences_to_label.append(span[0].sentence)
 
         all_relations = torch.stack(relation_embeddings)
 
@@ -140,113 +119,13 @@ class RelationExtractor(flair.nn.Classifier):
 
         sentence_relation_scores = self.decoder(all_relations)
 
-        labels = torch.tensor(indices).to(flair.device)
+        # return either scores and gold labels (for loss calculation), or include label candidates for prediction
+        result_tuple = (sentence_relation_scores, labels)
 
-        if return_loss:
-            # print(sentence_relation_scores.size())
-            # print(labels.size())
-            # asd
-            loss = self.loss_function(sentence_relation_scores, labels)
-            # print(loss)
+        if return_label_candidates:
+            result_tuple += (sentences_to_label, empty_label_candidates)
 
-        if return_loss and not return_scores:
-            return loss, len(labels)
-
-        if return_scores and not return_loss:
-            return sentence_relation_scores, entity_pairs
-
-        if return_scores and return_loss:
-            return sentence_relation_scores, entity_pairs, loss,
-
-    def forward_loss(self, sentences: Union[List[DataPoint], DataPoint]) -> torch.tensor:
-        return self._internal_forward_scores_and_loss(sentences, return_scores=False, return_loss=True)
-
-    def predict(
-            self,
-            sentences: Union[List[Sentence], Sentence],
-            mini_batch_size: int = 32,
-            multi_class_prob: bool = False,
-            verbose: bool = False,
-            label_name: Optional[str] = None,
-            return_loss=False,
-            embedding_storage_mode="none",
-    ):
-        """
-        Predicts the class labels for the given sentences. The labels are directly added to the sentences.
-        :param sentences: list of sentences
-        :param mini_batch_size: mini batch size to use
-        :param multi_class_prob : return probability for all class for multiclass
-        :param verbose: set to True to display a progress bar
-        :param return_loss: set to True to return loss
-        :param label_name: set this to change the name of the label type that is predicted
-        :param embedding_storage_mode: default is 'none' which is always best. Only set to 'cpu' or 'gpu' if
-        you wish to not only predict, but also keep the generated embeddings in CPU or GPU memory respectively.
-        'gpu' to store embeddings in GPU memory.
-        """
-        if label_name is None:
-            label_name = self.label_type if self.label_type is not None else "label"
-
-        with torch.no_grad():
-            if not sentences:
-                return sentences
-
-            if isinstance(sentences, DataPoint):
-                sentences = [sentences]
-
-            # filter empty sentences
-            if isinstance(sentences[0], DataPoint):
-                sentences = [sentence for sentence in sentences if len(sentence) > 0]
-            if len(sentences) == 0:
-                return sentences
-
-            # reverse sort all sequences by their length
-            rev_order_len_index = sorted(range(len(sentences)), key=lambda k: len(sentences[k]), reverse=True)
-
-            reordered_sentences: List[Union[DataPoint, str]] = [sentences[index] for index in rev_order_len_index]
-
-            dataloader = DataLoader(dataset=SentenceDataset(reordered_sentences), batch_size=mini_batch_size)
-            # progress bar for verbosity
-            if verbose:
-                dataloader = tqdm(dataloader)
-
-            overall_loss = 0
-            batch_no = 0
-            for batch in dataloader:
-
-                batch_no += 1
-
-                if verbose:
-                    dataloader.set_description(f"Inferencing on batch {batch_no}")
-
-                # stop if all sentences are empty
-                if not batch:
-                    continue
-
-                scores_pairs_loss = self._internal_forward_scores_and_loss(batch,
-                                                                           return_scores=True,
-                                                                           return_loss=return_loss)
-                scores = scores_pairs_loss[0]
-                pairs = scores_pairs_loss[1]
-
-                if return_loss:
-                    overall_loss += scores_pairs_loss[2]
-
-                softmax = torch.nn.functional.softmax(scores, dim=-1)
-                conf, idx = torch.max(softmax, dim=-1)
-
-                for pair, c, i in zip(pairs, conf, idx):
-                    label = self.label_dictionary.get_item_for_index(i.item())
-
-                    sentence: Sentence = pair[0][0].sentence
-
-                    relation_label = RelationLabel(value=label, score=c.item(), head=pair[0], tail=pair[1])
-                    sentence.add_complex_label(label_name,
-                                               relation_label)
-
-                store_embeddings(batch, storage_mode=embedding_storage_mode)
-
-            if return_loss:
-                return overall_loss / batch_no
+        return result_tuple
 
     def _get_state_dict(self):
         model_state = {
@@ -255,7 +134,6 @@ class RelationExtractor(flair.nn.Classifier):
             "label_dictionary": self.label_dictionary,
             "label_type": self.label_type,
             "span_label_type": self.span_label_type,
-            "beta": self.beta,
             "loss_weights": self.loss_weights,
             "pooling_operation": self.pooling_operation,
             "dropout_value": self.dropout_value,
@@ -269,12 +147,10 @@ class RelationExtractor(flair.nn.Classifier):
             label_dictionary=state["label_dictionary"],
             label_type=state["label_type"],
             span_label_type=state["span_label_type"],
-            beta=state["beta"],
             loss_weights=state["loss_weights"],
             pooling_operation=state["pooling_operation"],
             dropout_value=state["dropout_value"],
         )
-
         model.load_state_dict(state["state_dict"])
         return model
 

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -51,7 +51,7 @@ class FewshotClassifier(flair.nn.Classifier):
 
     def _get_tars_formatted_sentences(self, sentences: List[Sentence]):
         label_text_pairs = []
-        all_labels = [label.decode("utf-8") for label in self.get_current_tag_dictionary().idx2item]
+        all_labels = [label.decode("utf-8") for label in self.get_current_label_dictionary().idx2item]
         # print(all_labels)
         for sentence in sentences:
             label_text_pairs_for_sentence = []
@@ -79,7 +79,7 @@ class FewshotClassifier(flair.nn.Classifier):
 
         # if there are no labels, return a random sample as negatives
         if len(labels) == 0:
-            tags = self.get_current_tag_dictionary().get_items()
+            tags = self.get_current_label_dictionary().get_items()
             import random
             sample = random.sample(tags, k=self.num_negative_labels_to_sample)
             # print(sample)
@@ -133,7 +133,7 @@ class FewshotClassifier(flair.nn.Classifier):
         """
 
         # get and embed all labels by making a Sentence object that contains only the label text
-        all_labels = [label.decode("utf-8") for label in self.get_current_tag_dictionary().idx2item]
+        all_labels = [label.decode("utf-8") for label in self.get_current_label_dictionary().idx2item]
         label_sentences = [Sentence(label) for label in all_labels]
 
         self.tars_embeddings.eval()  # TODO: check if this is necessary
@@ -162,10 +162,10 @@ class FewshotClassifier(flair.nn.Classifier):
                         similarity_matrix[row_index][column_index]
         self.label_nearest_map = negative_label_probabilities
 
-    def get_current_tag_dictionary(self):
+    def get_current_label_dictionary(self):
         return self._task_specific_attributes[self._current_task]['tag_dictionary']
 
-    def get_current_tag_type(self):
+    def get_current_label_type(self):
         return self._task_specific_attributes[self._current_task]['tag_type']
 
     def add_and_switch_to_new_task(self,
@@ -243,7 +243,7 @@ class FewshotClassifier(flair.nn.Classifier):
 
     @property
     def label_type(self):
-        return self.get_current_tag_type()
+        return self.get_current_label_type()
 
     def predict_zero_shot(self,
                           sentences: Union[List[Sentence], Sentence],
@@ -388,7 +388,7 @@ class TARSTagger(FewshotClassifier):
         tars_sentence = Sentence(label_text_pair, use_tokenizer=False)
 
         for token in sentence:
-            tag = token.get_tag(self.get_current_tag_type()).value
+            tag = token.get_tag(self.get_current_label_type()).value
 
             if tag == "O":
                 tars_tag = "O"
@@ -408,8 +408,8 @@ class TARSTagger(FewshotClassifier):
             "state_dict": self.state_dict(),
 
             "current_task": self._current_task,
-            "tag_type": self.get_current_tag_type(),
-            "tag_dictionary": self.get_current_tag_dictionary(),
+            "tag_type": self.get_current_label_type(),
+            "tag_dictionary": self.get_current_label_dictionary(),
             "tars_model": self.tars_model,
             "num_negative_labels_to_sample": self.num_negative_labels_to_sample,
             "prefix": self.prefix,
@@ -466,7 +466,7 @@ class TARSTagger(FewshotClassifier):
         'gpu' to store embeddings in GPU memory.
         """
         if label_name == None:
-            label_name = self.get_current_tag_type()
+            label_name = self.get_current_label_type()
 
         # with torch.no_grad():
         if not sentences:
@@ -524,7 +524,7 @@ class TARSTagger(FewshotClassifier):
                     for token in sentence:
                         token.remove_labels(label_name)
 
-                    all_labels = [label.decode("utf-8") for label in self.get_current_tag_dictionary().idx2item]
+                    all_labels = [label.decode("utf-8") for label in self.get_current_label_dictionary().idx2item]
 
                     all_detected = {}
                     for label in all_labels:
@@ -671,7 +671,7 @@ class TARSClassifier(FewshotClassifier):
         label_text_pair = f"{label} {self.separator} {original_text}" if self.prefix \
             else f"{original_text} {self.separator} {label}"
 
-        sentence_labels = [label.value for label in sentence.get_labels(self.get_current_tag_type())]
+        sentence_labels = [label.value for label in sentence.get_labels(self.get_current_label_type())]
 
         tars_label = "True" if label in sentence_labels else "False"
 
@@ -684,8 +684,8 @@ class TARSClassifier(FewshotClassifier):
             "state_dict": self.state_dict(),
 
             "current_task": self._current_task,
-            "label_type": self.get_current_tag_type(),
-            "label_dictionary": self.get_current_tag_dictionary(),
+            "label_type": self.get_current_label_type(),
+            "label_dictionary": self.get_current_label_dictionary(),
             "tars_model": self.tars_model,
             "num_negative_labels_to_sample": self.num_negative_labels_to_sample,
 
@@ -757,7 +757,7 @@ class TARSClassifier(FewshotClassifier):
         'gpu' to store embeddings in GPU memory.
         """
         if label_name == None:
-            label_name = self.get_current_tag_type()
+            label_name = self.get_current_label_type()
 
         # with torch.no_grad():
         if not sentences:
@@ -808,7 +808,7 @@ class TARSClassifier(FewshotClassifier):
                     # always remove tags first
                     sentence.remove_labels(label_name)
 
-                    all_labels = [label.decode("utf-8") for label in self.get_current_tag_dictionary().idx2item]
+                    all_labels = [label.decode("utf-8") for label in self.get_current_label_dictionary().idx2item]
 
                     all_detected = {}
                     for label in all_labels:

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -57,7 +57,6 @@ class FewshotClassifier(flair.nn.Classifier):
             label_text_pairs_for_sentence = []
             if self.training and self.num_negative_labels_to_sample is not None:
 
-                # positive_labels = {label.value for label in sentence.get_labels(self.label_type)}
                 positive_labels = list(OrderedDict.fromkeys(
                     [label.value for label in sentence.get_labels(self.label_type)]))
 
@@ -298,12 +297,9 @@ class FewshotClassifier(flair.nn.Classifier):
 
 class TARSTagger(FewshotClassifier):
     """
-    TARS Sequence Tagger Model
-    The model inherits TextClassifier class to provide usual interfaces such as evaluate,
-    predict etc. It can encapsulate multiple tasks inside it. The user has to mention
-    which task is intended to be used. In the backend, the model uses a BERT based binary
-    text classifier which given a <label, text> pair predicts the probability of two classes
-    "YES", and "NO". The input data is a usual Sentence object which is inflated
+    TARS model for sequence tagging. In the backend, the model uses a BERT based 5-class
+    sequence labeler which given a <label, text> pair predicts the probability for each word
+    to belong to one of the BIOES classes. The input data is a usual Sentence object which is inflated
     by the model internally before pushing it through the transformer stack of BERT.
     """
 
@@ -323,17 +319,12 @@ class TARSTagger(FewshotClassifier):
         Initializes a TextClassifier
         :param task_name: a string depicting the name of the task
         :param label_dictionary: dictionary of labels you want to predict
-        :param batch_size: batch size for forward pass while using BERT
-        :param document_embeddings: name of the pre-trained transformer model e.g.,
+        :param embeddings: name of the pre-trained transformer model e.g.,
         'bert-base-uncased' etc
-        :num_negative_labels_to_sample: number of negative labels to sample for each
+        :param num_negative_labels_to_sample: number of negative labels to sample for each
         positive labels against a sentence during training. Defaults to 2 negative
         labels for each positive label. The model would sample all the negative labels
         if None is passed. That slows down the training considerably.
-        :param multi_label: auto-detected by default, but you can set this to True
-        to force multi-label predictionor False to force single-label prediction
-        :param multi_label_threshold: If multi-label you can set the threshold to make predictions
-        :param beta: Parameter for F-beta score for evaluation and training annealing
         """
         super(TARSTagger, self).__init__()
 
@@ -593,12 +584,9 @@ class TARSTagger(FewshotClassifier):
 
 class TARSClassifier(FewshotClassifier):
     """
-    TARS Classifier Model
-    The model inherits TextClassifier class to provide usual interfaces such as evaluate,
-    predict etc. It can encapsulate multiple tasks inside it. The user has to mention
-    which task is intended to be used. In the backend, the model uses a BERT based binary
+    TARS model for text classification. In the backend, the model uses a BERT based binary
     text classifier which given a <label, text> pair predicts the probability of two classes
-    "YES", and "NO". The input data is a usual Sentence object which is inflated
+    "True", and "False". The input data is a usual Sentence object which is inflated
     by the model internally before pushing it through the transformer stack of BERT.
     """
 
@@ -618,10 +606,9 @@ class TARSClassifier(FewshotClassifier):
         Initializes a TextClassifier
         :param task_name: a string depicting the name of the task
         :param label_dictionary: dictionary of labels you want to predict
-        :param batch_size: batch size for forward pass while using BERT
-        :param document_embeddings: name of the pre-trained transformer model e.g.,
+        :param embeddings: name of the pre-trained transformer model e.g.,
         'bert-base-uncased' etc
-        :num_negative_labels_to_sample: number of negative labels to sample for each
+        :param num_negative_labels_to_sample: number of negative labels to sample for each
         positive labels against a sentence during training. Defaults to 2 negative
         labels for each positive label. The model would sample all the negative labels
         if None is passed. That slows down the training considerably.

--- a/flair/models/tars_tagger_model.py
+++ b/flair/models/tars_tagger_model.py
@@ -40,7 +40,6 @@ class FewshotClassifier(flair.nn.Classifier):
         sentences = self._get_tars_formatted_sentences(data_points)
 
         loss = self.tars_model.forward_loss(sentences)
-
         return loss
 
     @property
@@ -58,6 +57,7 @@ class FewshotClassifier(flair.nn.Classifier):
             label_text_pairs_for_sentence = []
             if self.training and self.num_negative_labels_to_sample is not None:
 
+                # positive_labels = {label.value for label in sentence.get_labels(self.label_type)}
                 positive_labels = list(OrderedDict.fromkeys(
                     [label.value for label in sentence.get_labels(self.label_type)]))
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -1,25 +1,19 @@
 import logging
 from pathlib import Path
-from typing import List, Union, Dict, Optional, Set
+from typing import List, Union
 
 import torch
 import torch.nn as nn
-from tqdm import tqdm
-import numpy as np
 
-from sklearn.metrics.pairwise import cosine_similarity
-from sklearn.preprocessing import minmax_scale
-import flair.nn
 import flair.embeddings
-from flair.data import Dictionary, Sentence, Label, DataPoint, DataPair
-from flair.datasets import SentenceDataset, DataLoader
+import flair.nn
+from flair.data import Label, DataPoint
 from flair.file_utils import cached_path
-from flair.training_utils import convert_labels_to_one_hot, store_embeddings
 
 log = logging.getLogger("flair")
 
 
-class TextClassifier(flair.nn.Classifier):
+class TextClassifier(flair.nn.DefaultClassifier):
     """
     Text Classification Model
     The model takes word embeddings, puts them into an RNN to obtain a text representation, and puts the
@@ -30,12 +24,8 @@ class TextClassifier(flair.nn.Classifier):
     def __init__(
             self,
             document_embeddings: flair.embeddings.DocumentEmbeddings,
-            label_dictionary: Dictionary,
             label_type: str,
-            multi_label: bool = None,
-            multi_label_threshold: float = 0.5,
-            beta: float = 1.0,
-            loss_weights: Dict[str, float] = None,
+            **classifierargs,
     ):
         """
         Initializes a TextClassifier
@@ -49,61 +39,46 @@ class TextClassifier(flair.nn.Classifier):
         (if any label's weight is unspecified it will default to 1.0)
         """
 
-        super(TextClassifier, self).__init__()
+        super(TextClassifier, self).__init__(**classifierargs)
 
         self.document_embeddings: flair.embeddings.DocumentEmbeddings = document_embeddings
-        self.label_dictionary: Dictionary = label_dictionary
+
         self._label_type = label_type
 
-        if multi_label is not None:
-            self.multi_label = multi_label
-        else:
-            self.multi_label = self.label_dictionary.multi_label
-
-        self.multi_label_threshold = multi_label_threshold
-
-        self.beta = beta
-
-        self.weight_dict = loss_weights
-        # Initialize the weight tensor
-        if loss_weights is not None:
-            n_classes = len(self.label_dictionary)
-            weight_list = [1. for i in range(n_classes)]
-            for i, tag in enumerate(self.label_dictionary.get_items()):
-                if tag in loss_weights.keys():
-                    weight_list[i] = loss_weights[tag]
-            self.loss_weights = torch.FloatTensor(weight_list).to(flair.device)
-        else:
-            self.loss_weights = None
-
-        self.decoder = nn.Linear(
-            self.document_embeddings.embedding_length, len(self.label_dictionary)
-        )
-
+        self.decoder = nn.Linear(self.document_embeddings.embedding_length, len(self.label_dictionary))
         nn.init.xavier_uniform_(self.decoder.weight)
-
-        if self.multi_label:
-            self.loss_function = nn.BCEWithLogitsLoss(weight=self.loss_weights)
-        else:
-            self.loss_function = nn.CrossEntropyLoss(weight=self.loss_weights)
 
         # auto-spawn on GPU if available
         self.to(flair.device)
 
-    def forward(self, sentences):
+    def forward_pass(self,
+                     sentences: Union[List[DataPoint], DataPoint],
+                     return_label_candidates: bool = False,
+                     ):
 
+        # embed sentences
         self.document_embeddings.embed(sentences)
 
+        # make tensor for all embedded sentences in batch
         embedding_names = self.document_embeddings.get_names()
-
-        text_embedding_list = [
-            sentence.get_embedding(embedding_names).unsqueeze(0) for sentence in sentences
-        ]
+        text_embedding_list = [sentence.get_embedding(embedding_names).unsqueeze(0) for sentence in sentences]
         text_embedding_tensor = torch.cat(text_embedding_list, 0).to(flair.device)
 
-        label_scores = self.decoder(text_embedding_tensor)
+        # send through decoder to get logits
+        scores = self.decoder(text_embedding_tensor)
 
-        return label_scores
+        labels = []
+        for sentence in sentences:
+            labels.append([label.value for label in sentence.get_labels(self.label_type)])
+
+        # minimal return is scores and labels
+        return_tuple = (scores, labels)
+
+        if return_label_candidates:
+            label_candidates = [Label(value=None) for sentence in sentences]
+            return_tuple += (sentences, label_candidates)
+
+        return return_tuple
 
     def _get_state_dict(self):
         model_state = {
@@ -112,14 +87,12 @@ class TextClassifier(flair.nn.Classifier):
             "label_dictionary": self.label_dictionary,
             "label_type": self.label_type,
             "multi_label": self.multi_label,
-            "beta": self.beta,
             "weight_dict": self.weight_dict,
         }
         return model_state
 
     @staticmethod
     def _init_model_with_state_dict(state):
-        beta = 1.0 if "beta" not in state.keys() else state["beta"]
         weights = None if "weight_dict" not in state.keys() else state["weight_dict"]
         label_type = None if "label_type" not in state.keys() else state["label_type"]
 
@@ -128,206 +101,10 @@ class TextClassifier(flair.nn.Classifier):
             label_dictionary=state["label_dictionary"],
             label_type=label_type,
             multi_label=state["multi_label"],
-            beta=beta,
             loss_weights=weights,
         )
-
         model.load_state_dict(state["state_dict"])
         return model
-
-    def forward_loss(
-            self, data_points: Union[List[Sentence], Sentence]
-    ) -> torch.tensor:
-
-        scores = self.forward(data_points)
-
-        return self._calculate_loss(scores, data_points)
-
-    def _calculate_loss(self, scores, data_points):
-
-        labels = self._labels_to_one_hot(data_points) if self.multi_label \
-            else self._labels_to_indices(data_points)
-
-        return self.loss_function(scores, labels)
-
-    def _forward_scores_and_loss(
-            self, data_points: Union[List[Sentence], Sentence], return_loss=False):
-        scores = self.forward(data_points)
-
-        loss = None
-        if return_loss:
-            loss = self._calculate_loss(scores, data_points)
-
-        return scores, loss
-
-    def predict(
-            self,
-            sentences: Union[List[Sentence], Sentence],
-            mini_batch_size: int = 32,
-            multi_class_prob: bool = False,
-            verbose: bool = False,
-            label_name: Optional[str] = None,
-            return_loss=False,
-            embedding_storage_mode="none",
-    ):
-        """
-        Predicts the class labels for the given sentences. The labels are directly added to the sentences.
-        :param sentences: list of sentences
-        :param mini_batch_size: mini batch size to use
-        :param multi_class_prob : return probability for all class for multiclass
-        :param verbose: set to True to display a progress bar
-        :param return_loss: set to True to return loss
-        :param label_name: set this to change the name of the label type that is predicted
-        :param embedding_storage_mode: default is 'none' which is always best. Only set to 'cpu' or 'gpu' if
-        you wish to not only predict, but also keep the generated embeddings in CPU or GPU memory respectively.
-        'gpu' to store embeddings in GPU memory.
-        """
-        if label_name == None:
-            label_name = self.label_type if self.label_type is not None else 'label'
-
-        with torch.no_grad():
-            if not sentences:
-                return sentences
-
-            if isinstance(sentences, DataPoint):
-                sentences = [sentences]
-
-            # filter empty sentences
-            if isinstance(sentences[0], DataPoint):
-                sentences = [sentence for sentence in sentences if len(sentence) > 0]
-            if len(sentences) == 0: return sentences
-
-            # reverse sort all sequences by their length
-            rev_order_len_index = sorted(
-                range(len(sentences)), key=lambda k: len(sentences[k]), reverse=True
-            )
-
-            reordered_sentences: List[Union[DataPoint, str]] = [
-                sentences[index] for index in rev_order_len_index
-            ]
-
-            dataloader = DataLoader(
-                dataset=SentenceDataset(reordered_sentences), batch_size=mini_batch_size
-            )
-            # progress bar for verbosity
-            if verbose:
-                dataloader = tqdm(dataloader)
-
-            overall_loss = 0
-            batch_no = 0
-            for batch in dataloader:
-
-                batch_no += 1
-
-                if verbose:
-                    dataloader.set_description(f"Inferencing on batch {batch_no}")
-
-                # stop if all sentences are empty
-                if not batch:
-                    continue
-
-                scores, loss = self._forward_scores_and_loss(batch, return_loss)
-
-                if return_loss:
-                    overall_loss += loss
-
-                predicted_labels = self._obtain_labels(scores, predict_prob=multi_class_prob)
-
-                for (sentence, labels) in zip(batch, predicted_labels):
-                    for label in labels:
-                        if self.multi_label or multi_class_prob:
-                            sentence.add_label(label_name, label.value, label.score)
-                        else:
-                            sentence.set_label(label_name, label.value, label.score)
-
-                # clearing token embeddings to save memory
-                store_embeddings(batch, storage_mode=embedding_storage_mode)
-
-            if return_loss:
-                return overall_loss / batch_no
-
-    @staticmethod
-    def _filter_empty_sentences(sentences: List[Sentence]) -> List[Sentence]:
-        filtered_sentences = [sentence for sentence in sentences if sentence.tokens]
-        if len(sentences) != len(filtered_sentences):
-            log.warning(
-                "Ignore {} sentence(s) with no tokens.".format(
-                    len(sentences) - len(filtered_sentences)
-                )
-            )
-        return filtered_sentences
-
-    def _obtain_labels(
-            self, scores: List[List[float]], predict_prob: bool = False
-    ) -> List[List[Label]]:
-        """
-        Predicts the labels of sentences.
-        :param scores: the prediction scores from the model
-        :return: list of predicted labels
-        """
-
-        if self.multi_label:
-            return [self._get_multi_label(s) for s in scores]
-
-        elif predict_prob:
-            return [self._predict_label_prob(s) for s in scores]
-
-        return [self._get_single_label(s) for s in scores]
-
-    def _get_multi_label(self, label_scores) -> List[Label]:
-        labels = []
-
-        sigmoid = torch.nn.Sigmoid()
-
-        results = list(map(lambda x: sigmoid(x), label_scores))
-        for idx, conf in enumerate(results):
-            if conf > self.multi_label_threshold:
-                label = self.label_dictionary.get_item_for_index(idx)
-                labels.append(Label(label, conf.item()))
-
-        return labels
-
-    def _get_single_label(self, label_scores) -> List[Label]:
-        softmax = torch.nn.functional.softmax(label_scores, dim=0)
-        conf, idx = torch.max(softmax, 0)
-        label = self.label_dictionary.get_item_for_index(idx.item())
-
-        return [Label(label, conf.item())]
-
-    def _predict_label_prob(self, label_scores) -> List[Label]:
-        softmax = torch.nn.functional.softmax(label_scores, dim=0)
-        label_probs = []
-        for idx, conf in enumerate(softmax):
-            label = self.label_dictionary.get_item_for_index(idx)
-            label_probs.append(Label(label, conf.item()))
-        return label_probs
-
-    def _labels_to_one_hot(self, sentences: List[Sentence]):
-
-        label_list = []
-        for sentence in sentences:
-            label_list.append([label.value for label in sentence.get_labels(self.label_type)])
-
-        one_hot = convert_labels_to_one_hot(label_list, self.label_dictionary)
-        one_hot = [torch.FloatTensor(l).unsqueeze(0) for l in one_hot]
-        one_hot = torch.cat(one_hot, 0).to(flair.device)
-        return one_hot
-
-    def _labels_to_indices(self, sentences: List[Sentence]):
-
-        indices = [
-            torch.LongTensor(
-                [
-                    self.label_dictionary.get_idx_for_item(label.value)
-                    for label in sentence.get_labels(self.label_type)
-                ]
-            )
-            for sentence in sentences
-        ]
-
-        vec = torch.cat(indices, 0).to(flair.device)
-
-        return vec
 
     @staticmethod
     def _fetch_model(model_name) -> str:
@@ -361,591 +138,6 @@ class TextClassifier(flair.nn.Classifier):
 
         return model_name
 
-    def __str__(self):
-        return super(flair.nn.Model, self).__str__().rstrip(')') + \
-               f'  (beta): {self.beta}\n' + \
-               f'  (weights): {self.weight_dict}\n' + \
-               f'  (weight_tensor) {self.loss_weights}\n)'
-
     @property
     def label_type(self):
         return self._label_type
-
-
-class TextPairClassifier(TextClassifier):
-    """
-    Text Pair Classification Model for tasks such as Recognizing Textual Entailment, build upon TextClassifier.
-    The model takes document embeddings and puts resulting text representation(s) into a linear layer to get the 
-    actual class label. We provide two ways to embed the DataPairs: Either by embedding both DataPoints
-    and concatenating the resulting vectors ("embed_separately=True") or by concatenating the DataPoints and embedding
-    the resulting vector ("embed_separately=False").
-    """
-
-    def __init__(
-            self,
-            document_embeddings: flair.embeddings.DocumentEmbeddings,
-            label_dictionary: Dictionary,
-            embed_separately: bool = False,
-            label_type: str = None,
-            multi_label: bool = None,
-            multi_label_threshold: float = 0.5,
-            beta: float = 1.0,
-            loss_weights: Dict[str, float] = None,
-    ):
-        """
-        :param document_embeddings: embeddings used to embed the Datapairs
-        :param label_dictionary: dictionary of labels you want to predict
-        :param label_type: name of the label
-        :param embed_separately: If True, the model embeds both data points separately, else cross-embedding
-        :param multi_label: auto-detected by default, but you can set this to True to force multi-label prediction
-        or False to force single-label prediction
-        :param multi_label_threshold: If multi-label you can set the threshold to make predictions
-        :param beta: Parameter for F-beta score for evaluation and training annealing
-        :param loss_weights: Dictionary of weights for labels for the loss function
-        (if any label's weight is unspecified it will default to 1.0)
-        """
-
-        self.bi_mode = embed_separately
-        # Initialize TextClassifier
-        super(TextPairClassifier, self).__init__(document_embeddings,
-                                                 label_dictionary,
-                                                 label_type=label_type,
-                                                 multi_label=multi_label,
-                                                 multi_label_threshold=multi_label_threshold,
-                                                 beta=beta,
-                                                 loss_weights=loss_weights)
-
-        # if bi_mode == True the linear layer needs twice the length of the embeddings as input size
-        # since we concatenate the embeddings of the two DataPoints in the DataPairs
-        if self.bi_mode:
-            self.decoder = nn.Linear(
-                2 * self.document_embeddings.embedding_length, len(self.label_dictionary)
-            ).to(flair.device)
-
-            nn.init.xavier_uniform_(self.decoder.weight)
-
-        # else, set separator to concatenate two sentences
-        else:
-            self.sep = ' '
-            if isinstance(self.document_embeddings, flair.embeddings.document.TransformerDocumentEmbeddings):
-                if self.document_embeddings.tokenizer.sep_token:
-                    self.sep = ' ' + str(self.document_embeddings.tokenizer.sep_token) + ' '
-                else:
-                    self.sep = ' [SEP] '
-
-    def _get_state_dict(self):
-        model_state = super()._get_state_dict()
-        model_state["bi_mode"] = self.bi_mode
-        return model_state
-
-    @staticmethod
-    def _init_model_with_state_dict(state):
-        beta = 1.0 if "beta" not in state.keys() else state["beta"]
-        weights = None if "weight_dict" not in state.keys() else state["weight_dict"]
-        label_type = None if "label_type" not in state.keys() else state["label_type"]
-        mode = True if "bi_mode" not in state.keys() else state["bi_mode"]
-
-        model = TextPairClassifier(
-            document_embeddings=state["document_embeddings"],
-            label_dictionary=state["label_dictionary"],
-            label_type=label_type,
-            multi_label=state["multi_label"],
-            beta=beta,
-            loss_weights=weights,
-            embed_separately=mode
-        )
-
-        model.load_state_dict(state["state_dict"])
-        return model
-
-    def forward(self, datapairs):
-
-        embedding_names = self.document_embeddings.get_names()
-
-        if isinstance(datapairs, DataPair):
-            datapairs = [datapairs]
-
-        if self.bi_mode:  # embed both sentences seperately, concatenate the resulting vectors
-            first_elements = [pair.first for pair in datapairs]
-            second_elements = [pair.second for pair in datapairs]
-
-            self.document_embeddings.embed(first_elements)
-
-            self.document_embeddings.embed(second_elements)
-
-            text_embedding_list = [
-                torch.cat([a.get_embedding(embedding_names), b.get_embedding(embedding_names)], 0).unsqueeze(0)
-                for (a, b) in zip(first_elements, second_elements)
-            ]
-
-        else:  # concatenate the sentences and embed together
-
-            concatenated_sentences = [
-                Sentence(
-                    pair.first.to_tokenized_string() + self.sep + pair.second.to_tokenized_string(),
-                    use_tokenizer=False
-                )
-                for pair in datapairs]
-
-            self.document_embeddings.embed(concatenated_sentences)
-
-            text_embedding_list = [
-                sentence.get_embedding(embedding_names).unsqueeze(0) for sentence in concatenated_sentences
-            ]
-
-        text_embedding_tensor = torch.cat(text_embedding_list, 0).to(flair.device)
-
-        # linear layer
-        label_scores = self.decoder(text_embedding_tensor)
-
-        return label_scores
-
-
-class TARSClassifier(TextClassifier):
-    """
-    TARS Classification Model
-    The model inherits TextClassifier class to provide usual interfaces such as evaluate,
-    predict etc. It can encapsulate multiple tasks inside it. The user has to mention
-    which task is intended to be used. In the backend, the model uses a BERT based binary
-    text classifier which given a <label, text> pair predicts the probability of two classes
-    "YES", and "NO". The input data is a usual Sentence object which is inflated
-    by the model internally before pushing it through the transformer stack of BERT.
-    """
-
-    static_label_yes = "YES"
-    static_label_no = "NO"
-    static_label_type = "tars_label"
-    static_adhoc_task_identifier = "adhoc_dummy"
-
-    def __init__(
-            self,
-            task_name: str,
-            label_dictionary: Dictionary,
-            batch_size: int = 16,
-            document_embeddings: str = 'bert-base-uncased',
-            num_negative_labels_to_sample: int = 2,
-            label_type: str = None,
-            multi_label: bool = None,
-            multi_label_threshold: float = 0.5,
-            beta: float = 1.0
-    ):
-        """
-        Initializes a TextClassifier
-        :param task_name: a string depicting the name of the task
-        :param label_dictionary: dictionary of labels you want to predict
-        :param batch_size: batch size for forward pass while using BERT
-        :param document_embeddings: name of the pre-trained transformer model e.g.,
-        'bert-base-uncased' etc
-        :num_negative_labels_to_sample: number of negative labels to sample for each 
-        positive labels against a sentence during training. Defaults to 2 negative 
-        labels for each positive label. The model would sample all the negative labels 
-        if None is passed. That slows down the training considerably.
-        :param multi_label: auto-detected by default, but you can set this to True
-        to force multi-label predictionor False to force single-label prediction
-        :param multi_label_threshold: If multi-label you can set the threshold to make predictions
-        :param beta: Parameter for F-beta score for evaluation and training annealing
-        """
-        from flair.embeddings.document import TransformerDocumentEmbeddings
-
-        if not isinstance(document_embeddings, TransformerDocumentEmbeddings):
-            document_embeddings = TransformerDocumentEmbeddings(model=document_embeddings,
-                                                                fine_tune=True,
-                                                                batch_size=batch_size)
-
-        super(TARSClassifier, self).__init__(document_embeddings,
-                                             label_dictionary,
-                                             label_type=label_type,
-                                             multi_label=multi_label,
-                                             multi_label_threshold=multi_label_threshold,
-                                             beta=beta)
-
-        # Drop unnecessary attributes from Parent class
-        self.document_embeddings = None
-        self.decoder = None
-        self.loss_function = None
-
-        # prepare binary label dictionary
-        tars_label_dictionary = Dictionary(add_unk=False)
-        tars_label_dictionary.add_item(self.static_label_no)
-        tars_label_dictionary.add_item(self.static_label_yes)
-
-        self.tars_model = TextClassifier(document_embeddings,
-                                         tars_label_dictionary,
-                                         label_type=self.static_label_type,
-                                         multi_label=False,
-                                         beta=1.0,
-                                         loss_weights=None)
-
-        self.num_negative_labels_to_sample = num_negative_labels_to_sample
-        self.label_nearest_map = None
-        self.cleaned_up_labels = {}
-        self.current_task = None
-
-        # Store task specific labels since TARS can handle multiple tasks
-        self.task_specific_attributes = {}
-        self.add_and_switch_to_new_task(task_name, label_dictionary, multi_label,
-                                        multi_label_threshold, label_type, beta)
-
-    def add_and_switch_to_new_task(self,
-                                   task_name,
-                                   label_dictionary: Union[List, Set, Dictionary, str],
-                                   multi_label: bool = True,
-                                   multi_label_threshold: float = 0.5,
-                                   label_type: str = None,
-                                   beta: float = 1.0
-                                   ):
-        """
-        Adds a new task to an existing TARS model. Sets necessary attributes and finally 'switches'
-        to the new task. Parameters are similar to the constructor except for model choice, batch
-        size and negative sampling. This method does not store the resultant model onto disk.
-        :param task_name: a string depicting the name of the task
-        :param label_dictionary: dictionary of the labels you want to predict
-        :param multi_label: auto-detect if a corpus label dictionary is provided. Defaults to True otherwise
-        :param multi_label_threshold: If multi-label you can set the threshold to make predictions
-        """
-        if task_name in self.task_specific_attributes:
-            log.warning("Task `%s` already exists in TARS model. Switching to it.", task_name)
-        else:
-
-            # make label dictionary if no Dictionary object is passed
-            if isinstance(label_dictionary, (list, set, str)):
-                label_dictionary = TARSClassifier._make_ad_hoc_label_dictionary(label_dictionary, multi_label)
-
-            self.task_specific_attributes[task_name] = {}
-            self.task_specific_attributes[task_name]['label_dictionary'] = label_dictionary
-            self.task_specific_attributes[task_name]['multi_label'] = label_dictionary.multi_label
-            self.task_specific_attributes[task_name]['multi_label_threshold'] = multi_label_threshold
-            self.task_specific_attributes[task_name]['label_type'] = label_type
-            self.task_specific_attributes[task_name]['beta'] = beta
-
-        self.switch_to_task(task_name)
-
-    def list_existing_tasks(self) -> Set[str]:
-        """
-        Lists existing tasks in the loaded TARS model on the console.
-        """
-        return set(self.task_specific_attributes.keys())
-
-    def _get_cleaned_up_label(self, label):
-        """
-        Does some basic clean up of the provided labels, stores them, looks them up.
-        """
-        if label not in self.cleaned_up_labels:
-            self.cleaned_up_labels[label] = label.replace("_", " ")
-        return self.cleaned_up_labels[label]
-
-    def _compute_label_similarity_for_current_epoch(self):
-        """
-        Compute the similarity between all labels for better sampling of negatives
-        """
-
-        # get and embed all labels by making a Sentence object that contains only the label text
-        all_labels = [label.decode("utf-8") for label in self.label_dictionary.idx2item]
-        label_sentences = [Sentence(self._get_cleaned_up_label(label)) for label in all_labels]
-        self.tars_model.document_embeddings.embed(label_sentences)
-
-        # get each label embedding and scale between 0 and 1
-        encodings_np = [sentence.get_embedding().cpu().detach().numpy() for \
-                        sentence in label_sentences]
-        normalized_encoding = minmax_scale(encodings_np)
-
-        # compute similarity matrix
-        similarity_matrix = cosine_similarity(normalized_encoding)
-
-        # the higher the similarity, the greater the chance that a label is
-        # sampled as negative example
-        negative_label_probabilities = {}
-        for row_index, label in enumerate(all_labels):
-            negative_label_probabilities[label] = {}
-            for column_index, other_label in enumerate(all_labels):
-                if label != other_label:
-                    negative_label_probabilities[label][other_label] = \
-                        similarity_matrix[row_index][column_index]
-        self.label_nearest_map = negative_label_probabilities
-
-    def train(self, mode=True):
-        """Populate label similarity map based on cosine similarity before running epoch
-
-        If the `num_negative_labels_to_sample` is set to an integer value then before starting
-        each epoch the model would create a similarity measure between the label names based
-        on cosine distances between their BERT encoded embeddings.
-        """
-        if mode and self.num_negative_labels_to_sample is not None:
-            self._compute_label_similarity_for_current_epoch()
-            super(TARSClassifier, self).train(mode)
-
-        super(TARSClassifier, self).train(mode)
-
-    def _get_nearest_labels_for(self, labels):
-        already_sampled_negative_labels = set()
-
-        for label in labels:
-            plausible_labels = []
-            plausible_label_probabilities = []
-            for plausible_label in self.label_nearest_map[label]:
-                if plausible_label in already_sampled_negative_labels or plausible_label in labels:
-                    continue
-                else:
-                    plausible_labels.append(plausible_label)
-                    plausible_label_probabilities.append(self.label_nearest_map[label][plausible_label])
-
-            # make sure the probabilities always sum up to 1
-            plausible_label_probabilities = np.array(plausible_label_probabilities, dtype='float64')
-            plausible_label_probabilities += 1e-08
-            plausible_label_probabilities /= np.sum(plausible_label_probabilities)
-
-            if len(plausible_labels) > 0:
-                num_samples = min(self.num_negative_labels_to_sample, len(plausible_labels))
-                sampled_negative_labels = np.random.choice(plausible_labels,
-                                                           num_samples,
-                                                           replace=False,
-                                                           p=plausible_label_probabilities)
-                already_sampled_negative_labels.update(sampled_negative_labels)
-
-        return already_sampled_negative_labels
-
-    def _get_tars_formatted_sentence(self, label, original_text, tars_label=None):
-        label_text_pair = " ".join([self._get_cleaned_up_label(label),
-                                    self.tars_model.document_embeddings.tokenizer.sep_token,
-                                    original_text])
-        label_text_pair_sentence = Sentence(label_text_pair, use_tokenizer=False)
-        if tars_label is not None:
-            if tars_label:
-                label_text_pair_sentence.add_label(self.tars_model.label_type,
-                                                   TARSClassifier.static_label_yes)
-            else:
-                label_text_pair_sentence.add_label(self.tars_model.label_type,
-                                                   TARSClassifier.static_label_no)
-        return label_text_pair_sentence
-
-    def _get_tars_formatted_sentences(self, sentences):
-        label_text_pairs = []
-        all_labels = [label.decode("utf-8") for label in self.label_dictionary.idx2item]
-        for sentence in sentences:
-            original_text = sentence.to_tokenized_string()
-            label_text_pairs_for_sentence = []
-            if self.training and self.num_negative_labels_to_sample is not None:
-                positive_labels = {label.value for label in sentence.get_labels()}
-                sampled_negative_labels = self._get_nearest_labels_for(positive_labels)
-                for label in positive_labels:
-                    label_text_pairs_for_sentence.append( \
-                        self._get_tars_formatted_sentence(label, original_text, True))
-                for label in sampled_negative_labels:
-                    label_text_pairs_for_sentence.append( \
-                        self._get_tars_formatted_sentence(label, original_text, False))
-            else:
-                positive_labels = {label.value for label in sentence.get_labels()}
-                for label in all_labels:
-                    tars_label = None if len(positive_labels) == 0 else label in positive_labels
-                    label_text_pairs_for_sentence.append( \
-                        self._get_tars_formatted_sentence(label, original_text, tars_label))
-            label_text_pairs.extend(label_text_pairs_for_sentence)
-        return label_text_pairs
-
-    def switch_to_task(self, task_name):
-        """
-        Switches to a task which was previously added.
-        """
-        if task_name not in self.task_specific_attributes:
-            log.error("Provided `%s` does not exist in the model. Consider calling "
-                      "`add_and_switch_to_new_task` first.", task_name)
-        else:
-            self.current_task = task_name
-            self.multi_label = self.task_specific_attributes[task_name]['multi_label']
-            self.multi_label_threshold = \
-                self.task_specific_attributes[task_name]['multi_label_threshold']
-            self.label_dictionary = self.task_specific_attributes[task_name]['label_dictionary']
-            self.task_name = task_name
-            self.beta = self.task_specific_attributes[task_name]['beta']
-
-    def _get_state_dict(self):
-        model_state = super(TARSClassifier, self)._get_state_dict()
-        model_state.update({
-            "current_task": self.current_task,
-            "task_specific_attributes": self.task_specific_attributes,
-            "tars_model": self.tars_model,
-            "num_negative_labels_to_sample": self.num_negative_labels_to_sample
-        })
-        return model_state
-
-    @staticmethod
-    def _init_model_with_state_dict(state):
-        task_name = state["current_task"]
-        print("init TARS")
-
-        # init new TARS classifier
-        model = TARSClassifier(
-            task_name,
-            label_dictionary=state["task_specific_attributes"][task_name]['label_dictionary'],
-            document_embeddings=state["tars_model"].document_embeddings,
-            num_negative_labels_to_sample=state["num_negative_labels_to_sample"],
-        )
-        # set all task information
-        model.task_specific_attributes = state["task_specific_attributes"]
-        # linear layers of internal classifier
-        model.load_state_dict(state["state_dict"])
-        return model
-
-    def forward_loss(
-            self, data_points: Union[List[Sentence], Sentence]
-    ) -> torch.tensor:
-        # Transform input data into TARS format
-        sentences = self._get_tars_formatted_sentences(data_points)
-
-        return self.tars_model.forward_loss(sentences)
-
-    def _transform_tars_scores(self, tars_scores):
-        # M: num_classes in task, N: num_samples
-        # reshape scores MN x 2 -> N x M x 2
-        # import torch
-        # a = torch.arange(30)
-        # b = torch.reshape(-1, 3, 2)
-        # c = b[:,:,1]
-        tars_scores = torch.nn.functional.softmax(tars_scores, dim=1)
-        scores = torch.reshape(tars_scores, (-1, len(self.label_dictionary.item2idx), 2))
-
-        # target shape N x M
-        target_scores = scores[:, :, 1]
-        return target_scores
-
-    def _forward_scores_and_loss(
-            self, data_points: Union[List[Sentence], Sentence], return_loss=False):
-        transformed_sentences = self._get_tars_formatted_sentences(data_points)
-        label_scores = self.tars_model.forward(transformed_sentences)
-        # Transform label_scores
-        transformed_scores = self._transform_tars_scores(label_scores)
-
-        loss = None
-        if return_loss:
-            loss = self.tars_model._calculate_loss(label_scores, transformed_sentences)
-
-        return transformed_scores, loss
-
-    def forward(self, sentences):
-        transformed_sentences = self._get_tars_formatted_sentences(sentences)
-        label_scores = self.tars_model.forward(transformed_sentences)
-
-        # Transform label_scores into current task's desired format
-        transformed_scores = self._transform_tars_scores(label_scores)
-
-        return transformed_scores
-
-    def _get_multi_label(self, label_scores) -> List[Label]:
-        labels = []
-
-        for idx, conf in enumerate(label_scores):
-            if conf > self.multi_label_threshold:
-                label = self.label_dictionary.get_item_for_index(idx)
-                labels.append(Label(label, conf.item()))
-
-        return labels
-
-    def _get_single_label(self, label_scores) -> List[Label]:
-        conf, idx = torch.max(label_scores, 0)
-        # TARS does not do a softmax, so confidence of the best predicted class might be very low.
-        # Therefore enforce a min confidence of 0.5 for a match.
-        label = self.label_dictionary.get_item_for_index(idx.item())
-        return [Label(label, conf.item())]
-
-    @staticmethod
-    def _make_ad_hoc_label_dictionary(candidate_label_set: Union[List[str], Set[str], str],
-                                      multi_label: bool = True) -> Dictionary:
-        """
-        Creates a dictionary given a set of candidate labels
-        :return: dictionary of labels
-        """
-        label_dictionary: Dictionary = Dictionary(add_unk=False)
-        label_dictionary.multi_label = multi_label
-
-        # make list if only one candidate label is passed
-        if isinstance(candidate_label_set, str):
-            candidate_label_set = {candidate_label_set}
-
-        # if list is passed, convert to set
-        if not isinstance(candidate_label_set, set):
-            candidate_label_set = set(candidate_label_set)
-
-        for label in candidate_label_set:
-            label_dictionary.add_item(label)
-
-        return label_dictionary
-
-    def _drop_task(self, task_name):
-        if task_name in self.task_specific_attributes:
-            if self.current_task == task_name:
-                log.error("`%s` is the current task."
-                          " Switch to some other task before dropping this.", task_name)
-            else:
-                self.task_specific_attributes.pop(task_name)
-        else:
-            log.warning("No task exists with the name `%s`.", task_name)
-
-    def predict_zero_shot(self,
-                          sentences: Union[List[Sentence], Sentence],
-                          candidate_label_set: Union[List[str], Set[str], str],
-                          multi_label: bool = True):
-        """
-        Method to make zero shot predictions from the TARS model
-        :param sentences: input sentence objects to classify
-        :param candidate_label_set: set of candidate labels
-        :param multi_label: indicates whether multi-label or single class prediction. Defaults to True.
-        """
-
-        # check if candidate_label_set is empty
-        if candidate_label_set is None or len(candidate_label_set) == 0:
-            log.warning("Provided candidate_label_set is empty")
-            return
-
-        label_dictionary = TARSClassifier._make_ad_hoc_label_dictionary(candidate_label_set, multi_label)
-
-        # note current task
-        existing_current_task = self.current_task
-
-        # create a temporary task
-        self.add_and_switch_to_new_task(TARSClassifier.static_adhoc_task_identifier,
-                                        label_dictionary, multi_label)
-
-        try:
-            # make zero shot predictions
-            self.predict(sentences)
-        except:
-            log.error("Something went wrong during prediction. Ensure you pass Sentence objects.")
-
-        finally:
-            # switch to the pre-existing task
-            self.switch_to_task(existing_current_task)
-
-            self._drop_task(TARSClassifier.static_adhoc_task_identifier)
-
-        return
-
-    def predict_all_tasks(self, sentences: Union[List[Sentence], Sentence]):
-
-        # remember current task
-        existing_current_task = self.current_task
-
-        # predict with each task model
-        for task in self.list_existing_tasks():
-            self.switch_to_task(task)
-            self.predict(sentences, label_name=task)
-
-        # switch to the pre-existing task
-        self.switch_to_task(existing_current_task)
-
-    @staticmethod
-    def _fetch_model(model_name) -> str:
-
-        model_map = {}
-        hu_path: str = "https://nlp.informatik.hu-berlin.de/resources/models"
-
-        model_map["tars-base"] = "/".join([hu_path, "tars-base", "tars-base-v8.pt"])
-
-        cache_dir = Path("models")
-        if model_name in model_map:
-            model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
-
-        return model_name
-
-    @property
-    def label_type(self):
-        return self.task_specific_attributes[self.task_name]['label_type']

--- a/flair/nn/__init__.py
+++ b/flair/nn/__init__.py
@@ -1,0 +1,2 @@
+from .dropout import LockedDropout, WordDropout
+from .model import Model, Classifier, DefaultClassifier

--- a/flair/nn/dropout.py
+++ b/flair/nn/dropout.py
@@ -1,0 +1,54 @@
+import torch
+
+
+class LockedDropout(torch.nn.Module):
+    """
+    Implementation of locked (or variational) dropout. Randomly drops out entire parameters in embedding space.
+    """
+
+    def __init__(self, dropout_rate=0.5, batch_first=True, inplace=False):
+        super(LockedDropout, self).__init__()
+        self.dropout_rate = dropout_rate
+        self.batch_first = batch_first
+        self.inplace = inplace
+
+    def forward(self, x):
+        if not self.training or not self.dropout_rate:
+            return x
+
+        if not self.batch_first:
+            m = x.data.new(1, x.size(1), x.size(2)).bernoulli_(1 - self.dropout_rate)
+        else:
+            m = x.data.new(x.size(0), 1, x.size(2)).bernoulli_(1 - self.dropout_rate)
+
+        mask = torch.autograd.Variable(m, requires_grad=False) / (1 - self.dropout_rate)
+        mask = mask.expand_as(x)
+        return mask * x
+
+    def extra_repr(self):
+        inplace_str = ", inplace" if self.inplace else ""
+        return "p={}{}".format(self.dropout_rate, inplace_str)
+
+
+class WordDropout(torch.nn.Module):
+    """
+    Implementation of word dropout. Randomly drops out entire words (or characters) in embedding space.
+    """
+
+    def __init__(self, dropout_rate=0.05, inplace=False):
+        super(WordDropout, self).__init__()
+        self.dropout_rate = dropout_rate
+        self.inplace = inplace
+
+    def forward(self, x):
+        if not self.training or not self.dropout_rate:
+            return x
+
+        m = x.data.new(x.size(0), x.size(1), 1).bernoulli_(1 - self.dropout_rate)
+
+        mask = torch.autograd.Variable(m, requires_grad=False)
+        return mask * x
+
+    def extra_repr(self):
+        inplace_str = ", inplace" if self.inplace else ""
+        return "p={}{}".format(self.dropout_rate, inplace_str)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -362,11 +362,12 @@ class DefaultClassifier(Classifier):
                                    for all_labels_for_point in labels], dtype=torch.float, device=flair.device)
 
         else:
+            zero_index = self.label_dictionary.get_idx_for_item('O')
             labels = torch.tensor([self.label_dictionary.get_idx_for_item(label[0]) if len(label) > 0
-                                   else self.label_dictionary.get_idx_for_item('O')
+                                   else zero_index
                                    for label in labels], dtype=torch.long, device=flair.device)
 
-        return self.loss_function(scores, labels)
+        return self.loss_function(scores, labels), len(labels)
 
     def predict(
             self,
@@ -437,7 +438,7 @@ class DefaultClassifier(Classifier):
                 scores, gold_labels, sentences, label_candidates = self.forward_pass(batch,
                                                                                      return_label_candidates=True)
                 if return_loss:
-                    overall_loss += self._calculate_loss(scores, gold_labels)
+                    overall_loss += self._calculate_loss(scores, gold_labels)[0]
                     label_count += len(label_candidates)
 
                 if self.multi_label:

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -450,6 +450,7 @@ class DefaultClassifier(Classifier):
                                 label_value = self.label_dictionary.get_item_for_index(idx)
                                 label.set_value(value=label_value, score=sigmoided[s_idx, idx].item())
                                 sentence.add_complex_label(label_name, copy.deepcopy(label))
+                        s_idx += 1
 
                 else:
                     softmax = torch.nn.functional.softmax(scores, dim=-1)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -459,12 +459,12 @@ class DefaultClassifier(Classifier):
                     overall_loss += self._calculate_loss(scores, gold_labels)[0]
                     label_count += len(label_candidates)
 
-                if self.multi_label:
+                if self.multi_label or multi_class_prob:
                     sigmoided = torch.sigmoid(scores)
                     s_idx = 0
                     for sentence, label in zip(sentences, label_candidates):
                         for idx in range(sigmoided.size(1)):
-                            if sigmoided[s_idx, idx] > self.multi_label_threshold:
+                            if sigmoided[s_idx, idx] > self.multi_label_threshold or multi_class_prob:
                                 label_value = self.label_dictionary.get_item_for_index(idx)
                                 label.set_value(value=label_value, score=sigmoided[s_idx, idx].item())
                                 sentence.add_complex_label(label_name, copy.deepcopy(label))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -570,7 +570,7 @@ def test_tagged_corpus_make_vocab_dictionary():
 def test_label_set_confidence():
     label = Label("class_1", 3.2)
 
-    assert 1.0 == label.score
+    assert 3.2 == label.score
     assert "class_1" == label.value
 
     label.score = 0.2

--- a/tests/test_tars.py
+++ b/tests/test_tars.py
@@ -14,28 +14,28 @@ def test_init_tars_and_switch(tasks_base_path):
                           label_type='class')
 
     # check if right number of classes
-    assert(len(tars.get_current_tag_dictionary()) == 2)
+    assert(len(tars.get_current_label_dictionary()) == 2)
 
     # switch to task with only one label
     tars.add_and_switch_to_new_task('1_CLASS', 'one class')
 
     # check if right number of classes
-    assert(len(tars.get_current_tag_dictionary()) == 1)
+    assert(len(tars.get_current_label_dictionary()) == 1)
 
     # switch to task with three labels provided as list
     tars.add_and_switch_to_new_task('3_CLASS', ['list 1', 'list 2', 'list 3'])
 
     # check if right number of classes
-    assert(len(tars.get_current_tag_dictionary()) == 3)
+    assert(len(tars.get_current_label_dictionary()) == 3)
 
     # switch to task with four labels provided as set
     tars.add_and_switch_to_new_task('4_CLASS', {'set 1', 'set 2', 'set 3', 'set 4'})
 
     # check if right number of classes
-    assert(len(tars.get_current_tag_dictionary()) == 4)
+    assert(len(tars.get_current_label_dictionary()) == 4)
 
     # switch to task with two labels provided as Dictionary
     tars.add_and_switch_to_new_task('2_CLASS_AGAIN', corpus.make_label_dictionary(label_type='class'))
 
     # check if right number of classes
-    assert(len(tars.get_current_tag_dictionary()) == 2)
+    assert(len(tars.get_current_label_dictionary()) == 2)

--- a/tests/test_tars.py
+++ b/tests/test_tars.py
@@ -1,6 +1,6 @@
 from flair.data import Corpus
 from flair.datasets import ClassificationCorpus
-from flair.models.text_classification_model import TARSClassifier
+from flair.models.tars_tagger_model import TARSClassifier
 
 
 def test_init_tars_and_switch(tasks_base_path):
@@ -9,31 +9,33 @@ def test_init_tars_and_switch(tasks_base_path):
     corpus = ClassificationCorpus(tasks_base_path / "imdb")
 
     # create a TARS classifier
-    tars = TARSClassifier(task_name='2_CLASS', label_dictionary=corpus.make_label_dictionary())
+    tars = TARSClassifier(task_name='2_CLASS',
+                          label_dictionary=corpus.make_label_dictionary(label_type='class'),
+                          label_type='class')
 
     # check if right number of classes
-    assert(len(tars.label_dictionary) == 2)
+    assert(len(tars.get_current_tag_dictionary()) == 2)
 
     # switch to task with only one label
     tars.add_and_switch_to_new_task('1_CLASS', 'one class')
 
     # check if right number of classes
-    assert(len(tars.label_dictionary) == 1)
+    assert(len(tars.get_current_tag_dictionary()) == 1)
 
     # switch to task with three labels provided as list
     tars.add_and_switch_to_new_task('3_CLASS', ['list 1', 'list 2', 'list 3'])
 
     # check if right number of classes
-    assert(len(tars.label_dictionary) == 3)
+    assert(len(tars.get_current_tag_dictionary()) == 3)
 
     # switch to task with four labels provided as set
     tars.add_and_switch_to_new_task('4_CLASS', {'set 1', 'set 2', 'set 3', 'set 4'})
 
     # check if right number of classes
-    assert(len(tars.label_dictionary) == 4)
+    assert(len(tars.get_current_tag_dictionary()) == 4)
 
     # switch to task with two labels provided as Dictionary
-    tars.add_and_switch_to_new_task('2_CLASS_AGAIN', corpus.make_label_dictionary())
+    tars.add_and_switch_to_new_task('2_CLASS_AGAIN', corpus.make_label_dictionary(label_type='class'))
 
     # check if right number of classes
-    assert(len(tars.label_dictionary) == 2)
+    assert(len(tars.get_current_tag_dictionary()) == 2)

--- a/tests/test_tars.py
+++ b/tests/test_tars.py
@@ -1,6 +1,6 @@
 from flair.data import Corpus
 from flair.datasets import ClassificationCorpus
-from flair.models.tars_tagger_model import TARSClassifier
+from flair.models import TARSClassifier
 
 
 def test_init_tars_and_switch(tasks_base_path):

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -259,33 +259,39 @@ def test_train_resume_classifier(results_base_path, tasks_base_path):
     del trainer
 
 
-def test_labels_to_indices(tasks_base_path):
-    corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "ag_news", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
-    model = TextClassifier(document_embeddings, label_dict, label_type="topic", multi_label=False)
-
-    result = model._labels_to_indices(corpus.train)
-
-    for i in range(len(corpus.train)):
-        expected = label_dict.get_idx_for_item(corpus.train[i].labels[0].value)
-        actual = result[i].item()
-
-        assert expected == actual
-
-
-def test_labels_to_one_hot(tasks_base_path):
-    corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "ag_news", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
-    model = TextClassifier(document_embeddings, label_dict, label_type="topic", multi_label=False)
-
-    result = model._labels_to_one_hot(corpus.train)
-
-    for i in range(len(corpus.train)):
-        expected = label_dict.get_idx_for_item(corpus.train[i].labels[0].value)
-        actual = result[i]
-
-        for idx in range(len(label_dict)):
-            if idx == expected:
-                assert actual[idx] == 1
-            else:
-                assert actual[idx] == 0
+# def test_labels_to_indices(tasks_base_path):
+#     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "ag_news", label_type="topic")
+#     label_dict = corpus.make_label_dictionary()
+#     model = TextClassifier(document_embeddings,
+#                            label_dictionary=label_dict,
+#                            label_type="topic",
+#                            multi_label=False)
+#
+#     result = model._labels_to_indices(corpus.train)
+#
+#     for i in range(len(corpus.train)):
+#         expected = label_dict.get_idx_for_item(corpus.train[i].labels[0].value)
+#         actual = result[i].item()
+#
+#         assert expected == actual
+#
+#
+# def test_labels_to_one_hot(tasks_base_path):
+#     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "ag_news", label_type="topic")
+#     label_dict = corpus.make_label_dictionary()
+#     model = TextClassifier(document_embeddings,
+#                            label_dictionary=label_dict,
+#                            label_type="topic",
+#                            multi_label=False)
+#
+#     result = model._labels_to_one_hot(corpus.train)
+#
+#     for i in range(len(corpus.train)):
+#         expected = label_dict.get_idx_for_item(corpus.train[i].labels[0].value)
+#         actual = result[i]
+#
+#         for idx in range(len(label_dict)):
+#             if idx == expected:
+#                 assert actual[idx] == 1
+#             else:
+#                 assert actual[idx] == 0

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -40,9 +40,12 @@ def test_load_use_classifier():
 @pytest.mark.integration
 def test_train_load_use_classifier(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
+    label_dict = corpus.make_label_dictionary(label_type="topic")
 
-    model: TextClassifier = TextClassifier(document_embeddings, label_dict, label_type="topic", multi_label=False)
+    model: TextClassifier = TextClassifier(document_embeddings=document_embeddings,
+                                           label_dictionary=label_dict,
+                                           label_type="topic",
+                                           multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -74,9 +77,12 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
 @pytest.mark.integration
 def test_train_load_use_classifier_with_sampler(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
+    label_dict = corpus.make_label_dictionary(label_type="topic")
 
-    model: TextClassifier = TextClassifier(document_embeddings, label_dict, label_type="topic", multi_label=False)
+    model: TextClassifier = TextClassifier(document_embeddings=document_embeddings,
+                                           label_dictionary=label_dict,
+                                           label_type="topic",
+                                           multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(
@@ -112,9 +118,12 @@ def test_train_load_use_classifier_with_sampler(results_base_path, tasks_base_pa
 @pytest.mark.integration
 def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
+    label_dict = corpus.make_label_dictionary(label_type="topic")
 
-    model: TextClassifier = TextClassifier(document_embeddings, label_dict, label_type="topic", multi_label=False)
+    model: TextClassifier = TextClassifier(document_embeddings=document_embeddings,
+                                           label_dictionary=label_dict,
+                                           label_type="topic",
+                                           multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -148,11 +157,12 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
 @pytest.mark.integration
 def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "multi_class", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
+    label_dict = corpus.make_label_dictionary(label_type="topic")
 
-    model: TextClassifier = TextClassifier(
-        document_embeddings, label_dict, label_type="topic", multi_label=True
-    )
+    model: TextClassifier = TextClassifier(document_embeddings=document_embeddings,
+                                           label_dictionary=label_dict,
+                                           label_type="topic",
+                                           multi_label=True)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(
@@ -205,13 +215,16 @@ def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_pat
 @pytest.mark.integration
 def test_train_load_use_classifier_flair(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
+    label_dict = corpus.make_label_dictionary(label_type="topic")
 
     flair_document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
         [flair_embeddings], 128, 1, False, 64, False, False
     )
 
-    model: TextClassifier = TextClassifier(flair_document_embeddings, label_dict, label_type="topic", multi_label=False)
+    model: TextClassifier = TextClassifier(document_embeddings=flair_document_embeddings,
+                                           label_dictionary=label_dict,
+                                           label_type="topic",
+                                           multi_label=False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -243,9 +256,12 @@ def test_train_load_use_classifier_flair(results_base_path, tasks_base_path):
 @pytest.mark.integration
 def test_train_resume_classifier(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb", label_type="topic")
-    label_dict = corpus.make_label_dictionary()
+    label_dict = corpus.make_label_dictionary(label_type="topic")
 
-    model = TextClassifier(document_embeddings, label_dict, multi_label=False, label_type="topic")
+    model = TextClassifier(document_embeddings=document_embeddings,
+                           label_dictionary=label_dict,
+                           multi_label=False,
+                           label_type="topic")
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)

--- a/tests/test_text_regressor.py
+++ b/tests/test_text_regressor.py
@@ -36,12 +36,12 @@ def test_labels_to_indices(tasks_base_path):
         assert expected == actual
 
 
-def test_trainer_evaluation(tasks_base_path):
-    corpus, model, trainer = init(tasks_base_path)
-
-    expected = model.evaluate(corpus.dev)
-
-    assert expected is not None
+# def test_trainer_evaluation(tasks_base_path):
+#     corpus, model, trainer = init(tasks_base_path)
+#
+#     expected = model.evaluate(corpus.dev)
+#
+#     assert expected is not None
 
 
 # def test_trainer_results(tasks_base_path):


### PR DESCRIPTION
As we are now adding many more types of models to Flair (see #2333) we are refactoring the logic of Flair model classes to remove many redundancies and make the code hopefully easier to read. 

This PR is the second step in this refactoring process and mainly adds the new `DefaultClassifier` base class to Flair. It contains all logic that is shared by models that do classification, so that these models use the same (1) evaluation code, (2) prediction code and (3) loss computation code. Any Flair model that inherits from `DefaultClassifier` now only has to implement the `forward_pass()` method - all the rest is then supplied by the parent class. 

With this refactoring, the `TextClassifier`, the `RelationExtractor`, the `TextPairClassifier` and the `SimpleSequenceTagger` now inherits from `DefaultClassifier`. Accordingly, much redundant code has disappeared. The `SequenceTagger` still inherits from  `Classifier`, but this will change as a major refactoring here is planned as well. 

In addition, the TARS classes (`TARSClassifier` and `TARSTagger`) were broadly refactored so thatt they inherit from the new base class `FewshotClassifier` and share most of the TARS logic through the super class. This removed many redundancies. The implementation of `TARSClassifier` is now slightly different from before as single-label predictions are no longer enforced.

In addition, many small changes were made: 
- The `batch_size` parameter in `TransformerDocumentEmbeddings` has been removed since it is very counterintuitive and caused speed losses if not used correctly. The default behavior is not to batch over all sentences in a given mini-batch.
- You can now remove entries from a `Dictionary` with the method `remove_item()`
- The sanity checks for setting scores on Labels have been removed
- Potentially breaking: the `make_label_dictionary()` method of the `Corpus` now requires you to specify a `label_type`. To make this change easier, it now prints a list of all available label types when a dictionary is computed
- The label_type in the `GO_EMOTIONS` dataset is renamed to 'emotion'
- The `TextPairClassifier` now resides in its own module
- The `flair.nn` module was split into a folder structure