### PR TITLE
Adaptations for DrugProd Relation Extraction task

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -56,11 +56,12 @@ class Dictionary:
         :param item: string for which ID is requested
         :return: ID of string, otherwise 0
         """
-        item = item.encode("utf-8")
-        if item in self.item2idx.keys():
-            return self.item2idx[item]
+        item_encoded = item.encode("utf-8")
+        if item_encoded in self.item2idx.keys():
+            return self.item2idx[item_encoded]
         else:
-            return 0
+            log.error(f"The string '{item}' is not in dictionary! Dictionary contains only: {self.get_items()}")
+            raise IndexError
 
     def get_idx_for_items(self, items: List[str]) -> List[int]:
         """

--- a/flair/data.py
+++ b/flair/data.py
@@ -1,21 +1,18 @@
-import torch, flair
 import logging
 import re
-import ast
-
 from abc import abstractmethod, ABC
-
 from collections import Counter
 from collections import defaultdict
-
-from deprecated import deprecated
-from flair.file_utils import Tqdm
 from operator import itemgetter
+from typing import List, Dict, Union, Callable, Optional
 
+import flair
+import torch
+from deprecated import deprecated
 from torch.utils.data import Dataset
 from torch.utils.data.dataset import ConcatDataset, Subset
 
-from typing import List, Dict, Union, Callable, Optional
+from flair.file_utils import Tqdm
 
 log = logging.getLogger("flair")
 
@@ -1201,13 +1198,13 @@ class Corpus:
 
     def downsample(self, percentage: float = 0.1, downsample_train=True, downsample_dev=True, downsample_test=True):
 
-        if downsample_train:
+        if downsample_train and self._train:
             self._train = self._downsample_to_proportion(self.train, percentage)
 
-        if downsample_dev:
+        if downsample_dev and self._dev:
             self._dev = self._downsample_to_proportion(self.dev, percentage)
 
-        if downsample_test:
+        if downsample_test and self._test:
             self._test = self._downsample_to_proportion(self.test, percentage)
 
         return self
@@ -1443,7 +1440,8 @@ class Corpus:
 
             raise Exception
 
-        log.info(f"Corpus contains the labels: {', '.join([label[0] + f' (#{label[1]})' for label in all_label_types.most_common()])}")
+        log.info(
+            f"Corpus contains the labels: {', '.join([label[0] + f' (#{label[1]})' for label in all_label_types.most_common()])}")
         log.info(f"Dictionary for label '{label_type}' contains: {label_dictionary.idx2item}")
 
         return label_dictionary

--- a/flair/datasets/relation_extraction.py
+++ b/flair/datasets/relation_extraction.py
@@ -15,7 +15,7 @@ from flair.file_utils import cached_path
 from flair.datasets.conllu import CoNLLUCorpus
 from flair.tokenization import (
     SentenceSplitter,
-    SciSpacySentenceSplitter,
+    SciSpacySentenceSplitter, SegtokSentenceSplitter,
 )
 from flair.data import Sentence
 
@@ -467,17 +467,15 @@ class DrugProt(CoNLLUCorpus):
         self,
         base_path: Union[str, Path] = None,
         in_memory: bool = True,
-        sentence_splitter: SentenceSplitter = None,
+        sentence_splitter: SentenceSplitter = SegtokSentenceSplitter(),
     ):
         if type(base_path) == str:
             base_path: Path = Path(base_path)
 
-        self.sentence_splitter = (
-            sentence_splitter if sentence_splitter else SciSpacySentenceSplitter()
-        )
+        self.sentence_splitter = sentence_splitter
 
         # this dataset name
-        dataset_name = self.__class__.__name__.lower()
+        dataset_name = self.__class__.__name__.lower() + "_" + type(self.sentence_splitter).__name__
 
         # default dataset folder is the cache root
         if not base_path:
@@ -631,6 +629,13 @@ class DrugProt(CoNLLUCorpus):
 
                 token_dicts = []
                 for i, (token, tag_1, tag_2) in enumerate(zip(sent, tags_1, tags_2)):
+
+                    # hardcoded mapping TODO: perhaps find nicer solution
+                    tag_1 = tag_1.replace("GENE-N", "GENE")
+                    tag_1 = tag_1.replace("GENE-Y", "GENE")
+                    tag_2 = tag_2.replace("GENE-N", "GENE")
+                    tag_2 = tag_2.replace("GENE-Y", "GENE")
+
                     token_dicts.append({
                         "id": str(i + 1),
                         "form": token.text,

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -53,6 +53,9 @@ class RelationExtractor(flair.nn.DefaultClassifier):
         if self.pooling_operation == 'first_last':
             relation_representation_length *= 2
 
+        # entity pairs could also be no relation at all, add default value for this case to dictionary
+        self.label_dictionary.add_item('O')
+
         self.decoder = nn.Linear(relation_representation_length, len(self.label_dictionary))
 
         nn.init.xavier_uniform_(self.decoder.weight)

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -129,11 +129,16 @@ class RelationExtractor(flair.nn.DefaultClassifier):
                         empty_label_candidates.append(candidate_label)
                         sentences_to_label.append(span[0].sentence)
 
-        all_relations = torch.stack(relation_embeddings)
+        if len(labels) > 0:
 
-        all_relations = self.dropout(all_relations)
+            all_relations = torch.stack(relation_embeddings)
 
-        sentence_relation_scores = self.decoder(all_relations)
+            all_relations = self.dropout(all_relations)
+
+            sentence_relation_scores = self.decoder(all_relations)
+
+        else:
+            sentence_relation_scores = None
 
         # return either scores and gold labels (for loss calculation), or include label candidates for prediction
         result_tuple = (sentence_relation_scores, labels)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -163,9 +163,9 @@ class Classifier(Model):
 
                 if isinstance(loss_and_count, Tuple):
                     average_over += loss_and_count[1]
-                    eval_loss += loss_and_count[0]
+                    eval_loss += loss_and_count[0].item()
                 else:
-                    eval_loss += loss_and_count
+                    eval_loss += loss_and_count.item()
 
                 # get the gold labels
                 for datapoint in batch:
@@ -375,7 +375,7 @@ class DefaultClassifier(Classifier):
 
     def _calculate_loss(self, scores, labels):
 
-        if len(labels) == 0: return torch.tensor(0., requires_grad=True), 1
+        if len(labels) == 0: return torch.tensor(0., requires_grad=True, device=flair.device), 1
 
         if self.multi_label:
             labels = torch.tensor([[1 if l in all_labels_for_point else 0 for l in self.label_dictionary.get_items()]

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -471,6 +471,7 @@ class DefaultClassifier(Classifier):
                             for idx in range(sigmoided.size(1)):
                                 if sigmoided[s_idx, idx] > self.multi_label_threshold or multi_class_prob:
                                     label_value = self.label_dictionary.get_item_for_index(idx)
+                                    if label_value == 'O': continue
                                     label.set_value(value=label_value, score=sigmoided[s_idx, idx].item())
                                     sentence.add_complex_label(label_name, copy.deepcopy(label))
                             s_idx += 1
@@ -481,6 +482,7 @@ class DefaultClassifier(Classifier):
 
                         for sentence, label, c, i in zip(sentences, label_candidates, conf, idx):
                             label_value = self.label_dictionary.get_item_for_index(i.item())
+                            if label_value == 'O': continue
                             label.set_value(value=label_value, score=c.item())
 
                             sentence.add_complex_label(label_name, label)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -382,9 +382,8 @@ class DefaultClassifier(Classifier):
                                    for all_labels_for_point in labels], dtype=torch.float, device=flair.device)
 
         else:
-            zero_index = self.label_dictionary.get_idx_for_item('O')
             labels = torch.tensor([self.label_dictionary.get_idx_for_item(label[0]) if len(label) > 0
-                                   else zero_index
+                                   else self.label_dictionary.get_idx_for_item('O')
                                    for label in labels], dtype=torch.long, device=flair.device)
 
         return self.loss_function(scores, labels), len(labels)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -375,6 +375,8 @@ class DefaultClassifier(Classifier):
 
     def _calculate_loss(self, scores, labels):
 
+        if len(labels) == 0: return torch.tensor(0., requires_grad=True), 1
+
         if self.multi_label:
             labels = torch.tensor([[1 if l in all_labels_for_point else 0 for l in self.label_dictionary.get_items()]
                                    for all_labels_for_point in labels], dtype=torch.float, device=flair.device)
@@ -459,26 +461,29 @@ class DefaultClassifier(Classifier):
                     overall_loss += self._calculate_loss(scores, gold_labels)[0]
                     label_count += len(label_candidates)
 
-                if self.multi_label or multi_class_prob:
-                    sigmoided = torch.sigmoid(scores)
-                    s_idx = 0
-                    for sentence, label in zip(sentences, label_candidates):
-                        for idx in range(sigmoided.size(1)):
-                            if sigmoided[s_idx, idx] > self.multi_label_threshold or multi_class_prob:
-                                label_value = self.label_dictionary.get_item_for_index(idx)
-                                label.set_value(value=label_value, score=sigmoided[s_idx, idx].item())
-                                sentence.add_complex_label(label_name, copy.deepcopy(label))
-                        s_idx += 1
+                # if anything could possibly be predicted
+                if len(label_candidates) > 0:
 
-                else:
-                    softmax = torch.nn.functional.softmax(scores, dim=-1)
-                    conf, idx = torch.max(softmax, dim=-1)
+                    if self.multi_label or multi_class_prob:
+                        sigmoided = torch.sigmoid(scores)
+                        s_idx = 0
+                        for sentence, label in zip(sentences, label_candidates):
+                            for idx in range(sigmoided.size(1)):
+                                if sigmoided[s_idx, idx] > self.multi_label_threshold or multi_class_prob:
+                                    label_value = self.label_dictionary.get_item_for_index(idx)
+                                    label.set_value(value=label_value, score=sigmoided[s_idx, idx].item())
+                                    sentence.add_complex_label(label_name, copy.deepcopy(label))
+                            s_idx += 1
 
-                    for sentence, label, c, i in zip(sentences, label_candidates, conf, idx):
-                        label_value = self.label_dictionary.get_item_for_index(i.item())
-                        label.set_value(value=label_value, score=c.item())
+                    else:
+                        softmax = torch.nn.functional.softmax(scores, dim=-1)
+                        conf, idx = torch.max(softmax, dim=-1)
 
-                        sentence.add_complex_label(label_name, label)
+                        for sentence, label, c, i in zip(sentences, label_candidates, conf, idx):
+                            label_value = self.label_dictionary.get_item_for_index(i.item())
+                            label.set_value(value=label_value, score=c.item())
+
+                            sentence.add_complex_label(label_name, label)
 
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 


### PR DESCRIPTION
Some changes and bug fixes in the course of supporting DrugProd in Flair:

- The Dictionary object no longer gives a default return value if the key is not present, gives error instead
- The Corpus downsampling logic checks first if a split is present
- Sentence splitter in DrugProd is set to Sektok by default
- GENE-N and GENE-Y are mapped to GENE
- Fix errors that occur if the forward pass has no candidates to label
- Fix prediction of no label 