### PR TITLE
Added text classification datasets from Glue benchmark 

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -79,6 +79,7 @@ from .document_classification import CSVClassificationDataset
 from .document_classification import AMAZON_REVIEWS
 from .document_classification import COMMUNICATIVE_FUNCTIONS
 from .document_classification import GERMEVAL_2018_OFFENSIVE_LANGUAGE
+from .document_classification import GLUE_COLA
 from .document_classification import GO_EMOTIONS
 from .document_classification import IMDB
 from .document_classification import NEWSGROUPS

--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -161,7 +161,12 @@ from .text_text import ParallelTextDataset
 from .text_text import OpusParallelCorpus
 from .text_text import DataPairDataset
 from .text_text import DataPairCorpus
+from .text_text import GLUE_MNLI
+from .text_text import GLUE_MRPC
 from .text_text import GLUE_RTE
+from .text_text import GLUE_QNLI
+from .text_text import GLUE_QQP
+from .text_text import GLUE_WNLI
 from .text_text import SUPERGLUE_RTE
 
 # Expose all text-image datasets

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -1257,13 +1257,17 @@ class SENTEVAL_SST_BINARY(ClassificationCorpus):
             cached_path('https://raw.githubusercontent.com/PrincetonML/SIF/master/data/sentiment-dev',
                         Path("datasets") / dataset_name / 'raw')
 
-            # create train.txt file by iterating over pos and neg file
-            with open(data_folder / "train.txt", "a") as out_file, open(
-                    data_folder / 'raw' / "sentiment-train") as in_file:
-                for line in in_file:
-                    fields = line.split('\t')
-                    label = 'POSITIVE' if fields[1].rstrip() == '1' else 'NEGATIVE'
-                    out_file.write(f"__label__{label} {fields[0]}\n")
+            original_filenames = ["sentiment-train", "sentiment-dev", "sentiment-test"]
+            new_filenames = ["train.txt", "dev.txt", "test.txt"]
+
+            # create train dev and test files in fasttext format
+            for new_filename, original_filename in zip(new_filenames, original_filenames):
+                with open(data_folder / new_filename, "a") as out_file, open(
+                        data_folder / 'raw' / original_filename) as in_file:
+                    for line in in_file:
+                        fields = line.split('\t')
+                        label = 'POSITIVE' if fields[1].rstrip() == '1' else 'NEGATIVE'
+                        out_file.write(f"__label__{label} {fields[0]}\n")
 
         super(SENTEVAL_SST_BINARY, self).__init__(
             data_folder,

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -15,7 +15,7 @@ from flair.data import (
 )
 from flair.tokenization import SegtokTokenizer, SpaceTokenizer
 from flair.datasets.base import find_train_dev_test_files
-from flair.file_utils import cached_path, unzip_file
+from flair.file_utils import cached_path, unzip_file, unpack_file
 
 import logging
 log = logging.getLogger("flair")
@@ -41,6 +41,7 @@ class ClassificationCorpus(Corpus):
             label_name_map: Dict[str, str] = None,
             skip_labels: List[str] = None,
             allow_examples_without_labels=False,
+            sample_missing_splits: bool = True,
             encoding: str = 'utf-8',
     ):
         """
@@ -113,7 +114,7 @@ class ClassificationCorpus(Corpus):
         ) if dev_file is not None else None
 
         super(ClassificationCorpus, self).__init__(
-            train, dev, test, name=str(data_folder)
+            train, dev, test, name=str(data_folder), sample_missing_splits=sample_missing_splits
         )
 
         log.info(f"Initialized corpus {self.name} (label type name is '{label_type}')")
@@ -1330,6 +1331,107 @@ class SENTEVAL_SST_GRANULAR(ClassificationCorpus):
             memory_mode=memory_mode,
             **corpusargs,
         )
+
+
+class GLUE_COLA(ClassificationCorpus):
+    """
+    Corpus of Linguistic Acceptability from GLUE benchmark (https://gluebenchmark.com/tasks).
+    The task is to predict whether an English sentence is grammatically correct.
+    Additionaly to the Corpus we have eval_dataset containing the unlabeled test data for Glue evaluation.
+    """
+
+    def __init__(self,
+                label_type="acceptability",
+                base_path: Union[str, Path] = None,
+                tokenizer: Tokenizer = SegtokTokenizer(),
+                **corpusargs):
+        """
+        Instantiates CoLA dataset
+        :param base_path: Provide this only if you store the COLA corpus in a specific folder.
+        :param tokenizer: Custom tokenizer to use (default is SegtokTokenizer)
+        :param corpusargs: Other args for ClassificationCorpus.
+        """
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        dataset_name = "glue"
+
+        # if no base_path provided take cache root
+        if not base_path:
+            base_path = flair.cache_root / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        cola_path = "https://dl.fbaipublicfiles.com/glue/data/CoLA.zip"
+
+        data_file = data_folder / "CoLA/train.txt"
+
+        # if data is not downloaded yet, download it
+        if not data_file.is_file():
+            # get the zip file
+            zipped_data_path = cached_path(cola_path, Path("datasets") / dataset_name)
+
+            unpack_file(zipped_data_path, data_folder, mode="zip", keep=False)
+
+            # move original .tsv files to another folder
+            Path(data_folder / "CoLA/train.tsv").rename(data_folder / "CoLA/original/train.tsv")
+            Path(data_folder / "CoLA/dev.tsv").rename(data_folder / "CoLA/original/dev.tsv")
+            Path(data_folder / "CoLA/test.tsv").rename(data_folder / "CoLA/original/test.tsv")
+
+            label_map = {0: 'not_grammatical', 1: 'grammatical'}
+
+            # create train and dev splits in fasttext format
+            for split in ["train", "dev"]:
+                with open(data_folder / "CoLA" / (split + ".txt"), "a") as out_file, open(
+                        data_folder / "CoLA" / "original" / (split + ".tsv")) as in_file:
+                    for line in in_file:
+                        fields = line.rstrip().split('\t')
+                        label = int(fields[1])
+                        sentence = fields[3]
+                        out_file.write(f"__label__{label_map[label]} {sentence}\n")
+
+            # create eval_dataset file with no labels
+            with open(data_folder / "CoLA" / "eval_dataset.txt", "a") as out_file, open(
+                    data_folder / "CoLA" / "original" / "test.tsv",) as in_file:
+                for line in in_file:
+                    fields = line.rstrip().split('\t')
+                    sentence = fields[1]
+                    out_file.write(f"{sentence}\n")
+
+        super(GLUE_COLA, self).__init__(
+            data_folder / "CoLA",
+            label_type=label_type,
+            tokenizer=tokenizer,
+            **corpusargs,
+        )
+
+        self.eval_dataset = ClassificationDataset(
+            data_folder / "CoLA/eval_dataset.txt",
+            label_type=label_type,
+            allow_examples_without_labels=True,
+            tokenizer=tokenizer,
+            memory_mode="full",
+        )
+
+    """
+    This function creates a tsv file with predictions of the eval_dataset (after calling 
+    classifier.predict(corpus.eval_dataset, label_name='acceptability')). The resulting file 
+    is called CoLA.tsv and is in the format required for submission to the Glue Benchmark.
+    """
+
+    def tsv_from_eval_dataset(self, folder_path: Union[str, Path]):
+
+        if type(folder_path) == str:
+            folder_path = Path(folder_path)
+        folder_path = folder_path / 'CoLA.tsv'
+
+        with open(folder_path, mode='w') as tsv_file:
+            tsv_file.write("index\tprediction\n")
+            for index, datapoint in enumerate(self.eval_dataset):
+                reverse_label_map = {'grammatical': 1, 'not_grammatical': 0}
+                predicted_label = reverse_label_map[datapoint.get_labels('acceptability')[0].value]
+                tsv_file.write(str(index) + '\t' + predicted_label + '\n')
 
 
 class GO_EMOTIONS(ClassificationCorpus):

--- a/flair/datasets/text_text.py
+++ b/flair/datasets/text_text.py
@@ -590,10 +590,10 @@ class GLUE_MNLI(DataPairCorpus):
                       str(data_folder / "MNLI/eval_dataset_mismatched.tsv"))
 
         matched_suffix = "matched" if evaluate_on_matched else "mismatched"
-        
-        dev_dataset = "MNLI/dev_" + matched_suffix + ".tsv"
-        eval_dataset = "MNLI/eval_dataset_" + matched_suffix + ".tsv"
-        
+
+        dev_dataset = "dev_" + matched_suffix + ".tsv"
+        eval_dataset = "eval_dataset_" + matched_suffix + ".tsv"
+
         self.evaluate_on_matched = evaluate_on_matched
 
         super(GLUE_MNLI, self).__init__(
@@ -611,7 +611,7 @@ class GLUE_MNLI(DataPairCorpus):
         )
 
         self.eval_dataset = DataPairDataset(
-            data_folder / eval_dataset,
+            data_folder / "MNLI" / eval_dataset,
             columns=[8, 9, 11],
             use_tokenizer=use_tokenizer,
             max_tokens_per_doc=max_tokens_per_doc,

--- a/flair/datasets/text_text.py
+++ b/flair/datasets/text_text.py
@@ -520,6 +520,476 @@ class GLUE_RTE(DataPairCorpus):
                 tsv_file.write(str(index) + '\t' + datapoint.get_labels('textual_entailment')[0].value + '\n')
 
 
+class GLUE_MNLI(DataPairCorpus):
+    def __init__(
+            self,
+            label_type="entailment",
+            evaluate_on_matched: bool = True,
+            base_path: Union[str, Path] = None,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            use_tokenizer=True,
+            in_memory: bool = True,
+            sample_missing_splits: bool = True
+    ):
+        """
+        Creates a DataPairCorpus for the Multi-Genre Natural Language Inference Corpus (MNLI)
+        from GLUE benchmark (https://gluebenchmark.com/tasks). Entailment annotations are: 
+        entailment, contradiction, neutral. This corpus includes two dev sets mathced/mismatched 
+        and two unlabeled test sets: eval_dataset_matched, eval_dataset_mismatched.
+        """
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        dataset_name = "glue"
+
+        # if no base_path provided take cache root
+        if not base_path:
+            base_path = flair.cache_root / "datasets"
+        data_folder = base_path / dataset_name
+
+        data_file = data_folder / "MNLI/train.tsv"
+
+        # if data is not downloaded yet, download it
+        if not data_file.is_file():
+            # get the zip file
+            zipped_data_path = cached_path(
+                "https://dl.fbaipublicfiles.com/glue/data/MNLI.zip",
+                Path("datasets") / dataset_name
+            )
+
+            unpack_file(
+                zipped_data_path,
+                data_folder,
+                mode="zip",
+                keep=False
+            )
+
+            # reorder dev datasets to have same columns as in train set: 8, 9, and 11
+            # dev sets include 5 different annotations but we will only keep the gold label
+            for dev_filename in ["dev_matched.tsv", "dev_mismatched.tsv"]:
+
+                temp_file = str("temp_" + dev_filename)
+                os.rename(str(data_folder / "MNLI" / dev_filename),
+                          str(data_folder / "MNLI" / temp_file))
+
+                with open(data_folder / "MNLI" / dev_filename, "a") as out_file, open(
+                    data_folder / "MNLI" / temp_file) as in_file:
+                    for line in in_file:
+                        fields = line.split('\t')
+                        reordered_columns = '\t'.join(fields[column_id] for column_id in range(11))
+                        reordered_columns += '\t' + fields[15]
+                        out_file.write(reordered_columns)
+                os.remove(str(data_folder / "MNLI" / temp_file))
+
+            # rename test file to eval_dataset, since it has no labels
+            os.rename(str(data_folder / "MNLI/test_matched.tsv"),
+                      str(data_folder / "MNLI/eval_dataset_matched.tsv"))
+            os.rename(str(data_folder / "MNLI/test_mismatched.tsv"),
+                      str(data_folder / "MNLI/eval_dataset_mismatched.tsv"))
+
+        matched_suffix = "matched" if evaluate_on_matched else "mismatched"
+        
+        dev_dataset = "MNLI/dev_" + matched_suffix + ".tsv"
+        eval_dataset = "MNLI/eval_dataset_" + matched_suffix + ".tsv"
+        
+        self.evaluate_on_matched = evaluate_on_matched
+
+        super(GLUE_MNLI, self).__init__(
+            data_folder / "MNLI",
+            train_file=data_file,
+            dev_file=dev_dataset,
+            label_type=label_type,
+            columns=[8, 9, 11],
+            skip_first_line=True,
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            sample_missing_splits=sample_missing_splits
+        )
+
+        self.eval_dataset = DataPairDataset(
+            data_folder / eval_dataset,
+            columns=[8, 9, 11],
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            skip_first_line=True,
+            label=False
+        )
+
+    """
+    This function creates a tsv file of the predictions of the eval_dataset (after calling 
+    classifier.predict(corpus.eval_dataset, label_name='textual_entailment')). The resulting file 
+    is called MNLI-m.tsv or MNLI-mm.tsv and is in the format required for the Glue Benchmark.
+    """
+
+    def tsv_from_eval_dataset(self, folder_path: Union[str, Path]):
+
+        if type(folder_path) == str:
+            folder_path = Path(folder_path)
+        glue_eval_tsv = "MNLI-m.tsv" if self.evaluate_on_matched else "MNLI-mm.tsv"
+        folder_path = folder_path / glue_eval_tsv
+
+        with open(folder_path, mode='w') as tsv_file:
+            tsv_file.write("index\tprediction\n")
+            for index, datapoint in enumerate(self.eval_dataset):
+                label = datapoint.get_labels('textual_entailment')[0].value
+                tsv_file.write(str(index) + '\t' + label + '\n')
+
+
+class GLUE_MRPC(DataPairCorpus):
+    def __init__(
+            self,
+            label_type="paraphrase",
+            base_path: Union[str, Path] = None,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            use_tokenizer=True,
+            in_memory: bool = True,
+            sample_missing_splits: bool = True
+    ):
+        """
+        Creates a DataPairCorpus for the Microsoft Research Paraphrase Corpus (MRPC) 
+        from Glue benchmark (https://gluebenchmark.com/tasks). MRPC includes annotated 
+        train and test sets. Dev set is sampled each time when creating this corpus.
+        """
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        dataset_name = "glue"
+
+        # if no base_path provided take cache root
+        if not base_path:
+            base_path = flair.cache_root / "datasets"
+        data_folder = base_path / dataset_name
+
+        data_file = data_folder / "MRPC/train.tsv"
+
+        mrpc_path = "https://dl.fbaipublicfiles.com/senteval/senteval_data/"
+
+        original_filenames = ["msr_paraphrase_train.txt", "msr_paraphrase_test.txt"]
+
+        # if data is not downloaded yet, download it
+        if not data_file.is_file():
+            for original_filename in original_filenames:
+                # get test and dev sets
+                cached_path(f"{mrpc_path}{original_filename}",
+                            Path("datasets") / dataset_name / "MRPC")
+
+            os.rename(str(data_folder / "MRPC/msr_paraphrase_train.txt"),
+                      str(data_folder / "MRPC/train.tsv"))
+            os.rename(str(data_folder / "MRPC/msr_paraphrase_test.txt"),
+                      str(data_folder / "MRPC/test.tsv"))
+
+        super(GLUE_MRPC, self).__init__(
+            data_folder / "MRPC",
+            label_type=label_type,
+            columns=[3, 4, 0],
+            skip_first_line=True,
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            sample_missing_splits=sample_missing_splits
+        )
+
+    """
+    This function creates a tsv file of the predictions of the eval_dataset (after calling
+    classifier.predict(corpus.test, label_name='paraphrase')). The dataset that is used
+    for evaluation is the same as the test set. The resulting file is called MRPC.tsv
+    and is in the format required for submission to the Glue Benchmark.
+    """
+
+    def tsv_from_eval_dataset(self, folder_path: Union[str, Path]):
+
+        if type(folder_path) == str:
+            folder_path = Path(folder_path)
+        folder_path = folder_path / 'MRPC.tsv'
+
+        with open(folder_path, mode='w') as tsv_file:
+            tsv_file.write("index\tprediction\n")
+            for index, datapoint in enumerate(self.test):
+                label = datapoint.get_labels('paraphrase')[0].value
+                tsv_file.write(str(index) + '\t' + label + '\n')
+
+
+class GLUE_QNLI(DataPairCorpus):
+    def __init__(
+            self,
+            label_type="entailment",
+            base_path: Union[str, Path] = None,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            use_tokenizer=True,
+            in_memory: bool = True,
+            sample_missing_splits: bool = True
+    ):
+        """
+        Creates a DataPairCorpus for the Question-answering Natural Language Inference dataset 
+        (QNLI) from GLUE benchmark (https://gluebenchmark.com/tasks).
+        Additionaly to the Corpus we have a eval_dataset containing the test file of the Glue data. 
+        This file contains unlabeled test data to evaluate models on the Glue QNLI task.
+        """
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        dataset_name = "glue"
+
+        # if no base_path provided take cache root
+        if not base_path:
+            base_path = flair.cache_root / "datasets"
+        data_folder = base_path / dataset_name
+
+        data_file = data_folder / "QNLI/train.tsv"
+
+        # if data is not downloaded yet, download it
+        if not data_file.is_file():
+            # get the zip file
+            zipped_data_path = cached_path(
+                "https://dl.fbaipublicfiles.com/glue/data/QNLIv2.zip",
+                Path("datasets") / dataset_name
+            )
+
+            unpack_file(
+                zipped_data_path,
+                data_folder,
+                mode="zip",
+                keep=False
+            )
+
+            # rename test file to eval_dataset, since it has no labels
+            os.rename(str(data_folder / "QNLI/test.tsv"),
+                      str(data_folder / "QNLI/eval_dataset.tsv"))
+
+        super(GLUE_QNLI, self).__init__(
+            data_folder / "QNLI",
+            label_type=label_type,
+            columns=[1, 2, 3],
+            skip_first_line=True,
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            sample_missing_splits=sample_missing_splits
+        )
+
+        self.eval_dataset = DataPairDataset(
+            data_folder / "QNLI/eval_dataset.tsv",
+            columns=[1, 2, 3],
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            skip_first_line=True,
+            label=False
+        )
+
+    """    
+    This function creates a tsv file of the predictions of the eval_dataset (after calling
+    classifier.predict(corpus.eval_dataset, label_name='textual_entailment')). The resulting
+    file is called QNLI.tsv and is in the format required for submission to the Glue Benchmark.
+    """
+
+    def tsv_from_eval_dataset(self, folder_path: Union[str, Path]):
+
+        if type(folder_path) == str:
+            folder_path = Path(folder_path)
+        folder_path = folder_path / 'QNLI.tsv'
+
+        with open(folder_path, mode='w') as tsv_file:
+            tsv_file.write("index\tprediction\n")
+            for index, datapoint in enumerate(self.eval_dataset):
+                label = datapoint.get_labels('textual_entailment')[0].value
+                tsv_file.write(str(index) + '\t' + label + '\n')
+
+
+class GLUE_QQP(DataPairCorpus):
+    def __init__(
+            self,
+            label_type="paraphrase",
+            base_path: Union[str, Path] = None,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            use_tokenizer=True,
+            in_memory: bool = True,
+            sample_missing_splits: bool = True
+    ):
+        """
+        Creates a Quora Question Pairs (QQP) Corpus from the Glue benchmark (https://gluebenchmark.com/tasks).
+        The task is to determine whether a pair of questions are semantically equivalent.
+        Additionaly to the Corpus we have a eval_dataset containing the test file of the Glue data. 
+        This file contains unlabeled test data to evaluate models on the Glue QQP task.
+        """
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        dataset_name = "glue"
+
+        # if no base_path provided take cache root
+        if not base_path:
+            base_path = flair.cache_root / "datasets"
+        data_folder = base_path / dataset_name
+
+        data_file = data_folder / "QQP/train.tsv"
+
+        # if data is not downloaded yet, download it
+        if not data_file.is_file():
+            # get the zip file
+            zipped_data_path = cached_path(
+                "https://dl.fbaipublicfiles.com/glue/data/QQP-clean.zip",
+                Path("datasets") / dataset_name
+            )
+
+            unpack_file(
+                zipped_data_path,
+                data_folder,
+                mode="zip",
+                keep=False
+            )
+
+            # rename test file to eval_dataset, since it has no labels
+            os.rename(str(data_folder / "QQP/test.tsv"),
+                      str(data_folder / "QQP/eval_dataset.tsv"))
+
+        super(GLUE_QQP, self).__init__(
+            data_folder / "QQP",
+            label_type=label_type,
+            columns=[3, 4, 5],
+            skip_first_line=True,
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            sample_missing_splits=sample_missing_splits
+        )
+
+        self.eval_dataset = DataPairDataset(
+            data_folder / "QQP/eval_dataset.tsv",
+            columns=[1, 2, 0],
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            skip_first_line=True,
+            label=False
+        )
+
+    """
+    This function creates a tsv file of the predictions of the eval_dataset (after calling 
+    classifier.predict(corpus.eval_dataset, label_name='paraphrase')). The resulting file
+    is called QQP.tsv and is in the format required for submission to the Glue Benchmark.
+    """
+
+    def tsv_from_eval_dataset(self, folder_path: Union[str, Path]):
+
+        if type(folder_path) == str:
+            folder_path = Path(folder_path)
+        folder_path = folder_path / 'QQP.tsv'
+
+        with open(folder_path, mode='w') as tsv_file:
+            tsv_file.write("index\tprediction\n")
+            for index, datapoint in enumerate(self.eval_dataset):
+                label = datapoint.get_labels('paraphrase')[0].value
+                tsv_file.write(str(index) + '\t' + label + '\n')
+
+
+class GLUE_WNLI(DataPairCorpus):
+    def __init__(
+            self,
+            label_type="entailment",
+            base_path: Union[str, Path] = None,
+            max_tokens_per_doc=-1,
+            max_chars_per_doc=-1,
+            use_tokenizer=True,
+            in_memory: bool = True,
+            sample_missing_splits: bool = True
+    ):
+        """
+        Creates a Winograd Schema Challenge Corpus formated as Natural Language Inference task (WNLI).
+        The task is to predict if the sentence with the pronoun substituted is entailed by the original sentence.
+        Additionaly to the Corpus we have a eval_dataset containing the test file of the Glue data.
+        This file contains unlabeled test data to evaluate models on the Glue WNLI task.
+        """
+
+        if type(base_path) == str:
+            base_path: Path = Path(base_path)
+
+        dataset_name = "glue"
+
+        # if no base_path provided take cache root
+        if not base_path:
+            base_path = flair.cache_root / "datasets"
+        data_folder = base_path / dataset_name
+
+        data_file = data_folder / "WNLI/train.tsv"
+
+        # if data is not downloaded yet, download it
+        if not data_file.is_file():
+            # get the zip file
+            zipped_data_path = cached_path(
+                "https://dl.fbaipublicfiles.com/glue/data/WNLI.zip",
+                Path("datasets") / dataset_name
+            )
+
+            unpack_file(
+                zipped_data_path,
+                data_folder,
+                mode="zip",
+                keep=False
+            )
+
+            # rename test file to eval_dataset, since it has no labels
+            os.rename(str(data_folder / "WNLI/test.tsv"),
+                      str(data_folder / "WNLI/eval_dataset.tsv"))
+
+        super(GLUE_WNLI, self).__init__(
+            data_folder / "WNLI",
+            label_type=label_type,
+            columns=[1, 2, 3],
+            skip_first_line=True,
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            sample_missing_splits=sample_missing_splits
+        )
+
+        self.eval_dataset = DataPairDataset(
+            data_folder / "WNLI/eval_dataset.tsv",
+            columns=[1, 2, 3],
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+            skip_first_line=True,
+            label=False
+        )
+
+    """
+    This function creates a tsv file of the predictions of the eval_dataset (after calling
+    classifier.predict(corpus.eval_dataset, label_name='textual_entailment')). The resulting file
+    is called WNLI.tsv and is in the format required for submission to the Glue Benchmark.
+    """
+
+    def tsv_from_eval_dataset(self, folder_path: Union[str, Path]):
+
+        if type(folder_path) == str:
+            folder_path = Path(folder_path)
+        folder_path = folder_path / 'WNLI.tsv'
+
+        with open(folder_path, mode='w') as tsv_file:
+            tsv_file.write("index\tprediction\n")
+            for index, datapoint in enumerate(self.eval_dataset):
+                tsv_file.write(str(index) + '\t' + datapoint.get_labels('entailment')[0].value + '\n')
+
+
 class SUPERGLUE_RTE(DataPairCorpus):
     def __init__(
             self,

--- a/resources/docs/TUTORIAL_6_CORPUS.md
+++ b/resources/docs/TUTORIAL_6_CORPUS.md
@@ -302,9 +302,16 @@ for the purpose of training multilingual frame detection systems.
 #### Recognizing Textual Entailment
 | ID(s) | Languages | Description |
 | -------------    | ------------- |------------- |
+| 'GLUE_MNLI' | English | The Multi-Genre Natural Language Inference Corpus from the GLUE benchmark |
 | 'GLUE_RTE' | English | The RTE task from the GLUE benchmark |
+| 'GLUE_QNLI' | English | The Stanford Question Answering Dataset formated as NLI task from the GLUE benchmark |
+| 'GLUE_WNLI' | English | The Winograd Schema Challenge formated as NLI task from the GLUE benchmark |
 | 'SUPERGLUE_RTE' | English | The RTE task from the SuperGLUE benchmark |
 
+#### Paraphrase Identification
+| 'GLUE_MRPC' | English | The MRPC task from GLUE benchmark |
+| 'GLUE_QQP' | English | The Quora Question Pairs where the task is to tell whether a pair of questions are seman-
+tically equivalent |
 
 #### Experimental: Similarity Learning
 | ID(s) | Languages | Description |

--- a/resources/docs/TUTORIAL_6_CORPUS.md
+++ b/resources/docs/TUTORIAL_6_CORPUS.md
@@ -309,9 +309,10 @@ for the purpose of training multilingual frame detection systems.
 | 'SUPERGLUE_RTE' | English | The RTE task from the SuperGLUE benchmark |
 
 #### Paraphrase Identification
+| ID(s) | Languages | Description |
+| -------------    | ------------- |------------- |
 | 'GLUE_MRPC' | English | The MRPC task from GLUE benchmark |
-| 'GLUE_QQP' | English | The Quora Question Pairs where the task is to tell whether a pair of questions are seman-
-tically equivalent |
+| 'GLUE_QQP' | English | The Quora Question Pairs dataset where the task is to determine whether a pair of questions are semantically equivalent |
 
 #### Experimental: Similarity Learning
 | ID(s) | Languages | Description |

--- a/resources/docs/TUTORIAL_6_CORPUS.md
+++ b/resources/docs/TUTORIAL_6_CORPUS.md
@@ -276,6 +276,7 @@ for the purpose of training multilingual frame detection systems.
 | 'AMAZON_REVIEWS' | English |  [Amazon product reviews](https://nijianmo.github.io/amazon/index.html/) dataset with sentiment annotation |
 | 'COMMUNICATIVE_FUNCTIONS' | English |  [Communicative functions](https://github.com/Alab-NII/FECFevalDataset) of sentences in scholarly papers |
 | 'GERMEVAL_2018_OFFENSIVE_LANGUAGE' | German | Offensive language detection for German |
+| 'GLUE_COLA' | English | The Corpus of Linguistic Acceptability from GLUE benchmark |
 | 'GO_EMOTIONS' | English | [GoEmotions dataset](https://github.com/google-research/google-research/tree/master/goemotions) Reddit comments labeled with 27 emotions |
 | 'IMDB' | English |  [IMDB](http://ai.stanford.edu/~amaas/data/sentiment/) dataset of movie reviews with sentiment annotation  |
 | 'NEWSGROUPS' | English | The popular [20 newsgroups](http://qwone.com/~jason/20Newsgroups/) classification dataset |


### PR DESCRIPTION
Following datasets from GLUE were added:

- Text classification: CoLA and SST2 (which already exists as SENTEVAL_SST_BINARY so I just checked that train/dev/test splits are kept in original form and not sampled)
- Text-pair classification: MNLI, QNLI, QQP, MRPC, WNLI

The only missing dataset is Semantic Textual Similarity STS-B, which is a text-pair regression task and would probably require a TextPairRegressor model.