### PR TITLE
Improve speed of TransformerWordEmbeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1100,9 +1100,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
             for original_sentence, expanded_sentence, context_offset in zip(original_sentences,
                                                                             sentences,
                                                                             context_offsets):
-                print(original_sentence)
-                print(expanded_sentence)
-                print(context_offset)
                 for token_idx, token in enumerate(original_sentence):
                     print(token_idx)
                     token.set_embedding(self.name, expanded_sentence[token_idx + context_offset].get_embedding(self.name))

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1346,12 +1346,12 @@ class TransformerWordEmbeddings_Fast(TransformerWordEmbeddings):
                     token.set_embedding(self.name, torch.zeros(self.embedding_length))
                 return
 
-            print(sentence)
-            print(subtokenized_sentence)
+            # print(sentence)
+            # print(subtokenized_sentence)
             # determine into how many subtokens each token is split
             token_subtoken_lengths = self.reconstruct_tokens_from_subtokens(sentence, subtokenized_sentence)
             all_token_subtoken_lengths.append(token_subtoken_lengths)
-            print(token_subtoken_lengths)
+            # print(token_subtoken_lengths)
 
             # encode inputs
             encoded_inputs = self.tokenizer.encode_plus(tokenized_string,
@@ -1373,7 +1373,7 @@ class TransformerWordEmbeddings_Fast(TransformerWordEmbeddings):
                 n_parts += 1
             sentence_parts_lengths.append(n_parts)
 
-        print(subtokenized_sentences)
+        # print(subtokenized_sentences)
 
         # find longest sentence in batch
         longest_sequence_in_batch: int = len(max(subtokenized_sentences, key=len))
@@ -1395,8 +1395,8 @@ class TransformerWordEmbeddings_Fast(TransformerWordEmbeddings):
             input_ids[s_id][:sequence_length] = sentence
             mask[s_id][:sequence_length] = torch.ones(sequence_length)
 
-        print(input_ids.size())
-        print(mask)
+        # print(input_ids.size())
+        # print(mask)
         # asd
 
         # put encoded batch through transformer model to get all hidden states of all encoder layers

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1149,8 +1149,10 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         left_context_split = left_context.split(" ")
         right_context_split = right_context.split(" ")
-        # if left_context_split == [""]: left_context_split = []
-        # if right_context_split == [""]: right_context_split = []
+
+        # empty contexts should not introduce whitespace tokens
+        if left_context_split == [""]: left_context_split = []
+        if right_context_split == [""]: right_context_split = []
 
         # make expanded sentence
         expanded_sentence = Sentence()

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1101,7 +1101,6 @@ class TransformerWordEmbeddings(TokenEmbeddings):
                                                                             sentences,
                                                                             context_offsets):
                 for token_idx, token in enumerate(original_sentence):
-                    print(token_idx)
                     token.set_embedding(self.name, expanded_sentence[token_idx + context_offset].get_embedding(self.name))
                 sentence = original_sentence
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -327,15 +327,6 @@ class SequenceTagger(flair.nn.Classifier):
             if isinstance(sentences, Sentence):
                 sentences = [sentences]
 
-            # set context if not set already
-            previous_sentence = None
-            for sentence in sentences:
-                if sentence.is_context_set(): continue
-                sentence._previous_sentence = previous_sentence
-                sentence._next_sentence = None
-                if previous_sentence: previous_sentence._next_sentence = sentence
-                previous_sentence = sentence
-
             # reverse sort all sequences by their length
             rev_order_len_index = sorted(
                 range(len(sentences)), key=lambda k: len(sentences[k]), reverse=True

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1068,7 +1068,7 @@ class MultiTagger:
             tagger.predict(
                 sentences=sentences,
                 mini_batch_size=mini_batch_size,
-                all_tag_prob=all_tag_prob,
+                # all_tag_prob=all_tag_prob,
                 verbose=verbose,
                 label_name=name,
                 return_loss=return_loss,

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -151,6 +151,8 @@ class Classifier(Model):
             sentence_id = 0
             for batch in data_loader:
 
+                print(batch)
+
                 # remove any previously predicted labels
                 for datapoint in batch:
                     datapoint.remove_labels('predicted')

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -151,8 +151,6 @@ class Classifier(Model):
             sentence_id = 0
             for batch in data_loader:
 
-                print(batch)
-
                 # remove any previously predicted labels
                 for datapoint in batch:
                     datapoint.remove_labels('predicted')


### PR DESCRIPTION
The `TransformerWordEmbeddings` is currently a bottleneck on Flair's speed. This PR changes the implementation such that mini-batching is used in the class. 

Depending on the mini-batch size used this PR results in significant speed ups for model training - in my experiments I've seen speed-ups between x2 and 6x (the higher the mini batch size, the greater the speed up).