### PR TITLE
Add unit scaling to tqdm progress bar

### DIFF
--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -181,7 +181,7 @@ def download_file(url: str, cache_dir: Union[str, Path]):
     req = requests.get(url, stream=True)
     content_length = req.headers.get("Content-Length")
     total = int(content_length) if content_length is not None else None
-    progress = Tqdm.tqdm(unit="B", total=total)
+    progress = Tqdm.tqdm(unit="B", unit_scale=True, total=total)
     with open(temp_filename, "wb") as temp_file:
         for chunk in req.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks


### PR DESCRIPTION
## Proposed change:
Add unit scaling to the tqdm progress bar, which is used to track file downloading progress.

## Rationale:
It is quite uninformative to see a million-scale number in the progress bar when downloading large files. The scaled number is much more useful, as it is what we see on a daily basis when downloading files through the browser or checking connectivity speed in speedtest. Fortunately, tqdm itself is able to accurately scale numbers to their standard scaled variants: 12456098 B/s -> 12.4 MB/s. It can be enabled via `unit_scale` option in tqdm constructor.

Other popular libraries, that deal with downloading large files, are using unit_scale in their progress bars:
* Huggingface Transformers: [file_utils.py#L1516](https://github.com/huggingface/transformers/blob/3dd538c4d37248961d4cf99f4c07e8a5fe54984c/src/transformers/file_utils.py#L1516)
* AllenNLP: [file_utils.py#L542](https://github.com/allenai/allennlp/blob/527e43d909d9748fd7f98a1cbc6d11d945ebb63e/allennlp/common/file_utils.py#L542)