### PR TITLE
Automatic "Model Cards" for Flair models, and default ability to resume training

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -254,14 +254,9 @@ class SequenceTagger(flair.nn.Classifier):
 
         rnn_type = "LSTM" if "rnn_type" not in state.keys() else state["rnn_type"]
         use_dropout = 0.0 if "use_dropout" not in state.keys() else state["use_dropout"]
-        use_word_dropout = (
-            0.0 if "use_word_dropout" not in state.keys() else state["use_word_dropout"]
-        )
-        use_locked_dropout = (
-            0.0
-            if "use_locked_dropout" not in state.keys()
-            else state["use_locked_dropout"]
-        )
+        use_word_dropout = 0.0 if "use_word_dropout" not in state.keys() else state["use_word_dropout"]
+        use_locked_dropout = 0.0 if "use_locked_dropout" not in state.keys() else state["use_locked_dropout"]
+
         train_initial_hidden_state = (
             False
             if "train_initial_hidden_state" not in state.keys()

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -93,19 +93,19 @@ class Model(torch.nn.Module):
 
                 if 'optimizer' in training_parameters:
                     optimizer = training_parameters['optimizer']
-                    self.model_card['optimizer_class'] = optimizer.__class__
                     training_parameters['optimizer_state_dict'] = optimizer.state_dict()
+                    training_parameters['optimizer'] = optimizer.__class__
 
                 if 'scheduler' in training_parameters:
                     scheduler = training_parameters['scheduler']
-                    self.model_card['scheduler_class'] = scheduler.__class__
                     training_parameters['scheduler_state_dict'] = scheduler.state_dict()
+                    training_parameters['scheduler'] = scheduler.__class__
 
             model_state['model_card'] = self.model_card
 
-            # delete optimizer and scheduler instance since this may cause serialization errors
-            del model_state['model_card']['training_parameters']['optimizer']
-            del model_state['model_card']['training_parameters']['scheduler']
+            # # delete optimizer and scheduler instance since this may cause serialization errors
+            # del model_state['model_card']['training_parameters']['optimizer']
+            # del model_state['model_card']['training_parameters']['scheduler']
 
         # save model
         torch.save(model_state, str(model_file), pickle_protocol=4)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -142,7 +142,7 @@ class Model(torch.nn.Module):
 
         return model
 
-    def print_training_parameters(self):
+    def print_model_card(self):
         if hasattr(self, 'model_card'):
             param_out = "\n------------------------------------\n"
             param_out += "--------- Flair Model Card ---------\n"

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -103,10 +103,6 @@ class Model(torch.nn.Module):
 
             model_state['model_card'] = self.model_card
 
-            # # delete optimizer and scheduler instance since this may cause serialization errors
-            # del model_state['model_card']['training_parameters']['optimizer']
-            # del model_state['model_card']['training_parameters']['scheduler']
-
         # save model
         torch.save(model_state, str(model_file), pickle_protocol=4)
 

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -776,10 +776,6 @@ class ModelTrainer:
         # recover all arguments that were used to train this model
         args_used_to_train_model = self.model.model_card['training_parameters']
 
-        # only pass the class of the optimizer, not the instance
-        args_used_to_train_model['optimizer'] = self.model.model_card['optimizer_class']
-        args_used_to_train_model['scheduler'] = self.model.model_card['scheduler_class']
-
         # you can overwrite params with your own
         for param in trainer_args:
             args_used_to_train_model[param] = trainer_args[param]

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -315,7 +315,7 @@ class AnnealOnPlateau(object):
 
     def load_state_dict(self, state_dict):
         self.__dict__.update(state_dict)
-        self._init_is_better(mode=self.mode, threshold=self.threshold, threshold_mode=self.threshold_mode)
+        self._init_is_better(mode=self.mode)
 
 
 def init_output_file(base_path: Union[str, Path], file_name: str) -> Path:

--- a/tests/test_sequence_tagger.py
+++ b/tests/test_sequence_tagger.py
@@ -345,6 +345,7 @@ def test_train_load_use_tagger_multicorpus(results_base_path, tasks_base_path):
 
 @pytest.mark.integration
 def test_train_resume_tagger(results_base_path, tasks_base_path):
+
     corpus_1 = flair.datasets.ColumnCorpus(
         data_folder=tasks_base_path / "fashion", column_format={0: "text", 3: "ner"}
     )
@@ -361,13 +362,16 @@ def test_train_resume_tagger(results_base_path, tasks_base_path):
         use_crf=False,
     )
 
+    # train model for 2 epochs
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
-    del trainer, model
-    trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
+    del model
 
-    trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
+    # load the checkpoint model and train until epoch 4
+    checkpoint_model = SequenceTagger.load(results_base_path / "checkpoint.pt")
+    trainer.resume(model=checkpoint_model,
+                   max_epochs=4)
 
     # clean up results directory
     shutil.rmtree(results_base_path)

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -263,51 +263,17 @@ def test_train_resume_classifier(results_base_path, tasks_base_path):
                            multi_label=False,
                            label_type="topic")
 
+    # train model for 2 epochs
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
-    del trainer, model
-    trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
+    del model
+
+    # load the checkpoint model and train until epoch 4
+    checkpoint_model = TextClassifier.load(results_base_path / "checkpoint.pt")
+    trainer.resume(model=checkpoint_model,
+                   max_epochs=4)
 
     # clean up results directory
     shutil.rmtree(results_base_path)
     del trainer
-
-
-# def test_labels_to_indices(tasks_base_path):
-#     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "ag_news", label_type="topic")
-#     label_dict = corpus.make_label_dictionary()
-#     model = TextClassifier(document_embeddings,
-#                            label_dictionary=label_dict,
-#                            label_type="topic",
-#                            multi_label=False)
-#
-#     result = model._labels_to_indices(corpus.train)
-#
-#     for i in range(len(corpus.train)):
-#         expected = label_dict.get_idx_for_item(corpus.train[i].labels[0].value)
-#         actual = result[i].item()
-#
-#         assert expected == actual
-#
-#
-# def test_labels_to_one_hot(tasks_base_path):
-#     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "ag_news", label_type="topic")
-#     label_dict = corpus.make_label_dictionary()
-#     model = TextClassifier(document_embeddings,
-#                            label_dictionary=label_dict,
-#                            label_type="topic",
-#                            multi_label=False)
-#
-#     result = model._labels_to_one_hot(corpus.train)
-#
-#     for i in range(len(corpus.train)):
-#         expected = label_dict.get_idx_for_item(corpus.train[i].labels[0].value)
-#         actual = result[i]
-#
-#         for idx in range(len(label_dict)):
-#             if idx == expected:
-#                 assert actual[idx] == 1
-#             else:
-#                 assert actual[idx] == 0


### PR DESCRIPTION
This PR modifies the ModelTrainer so that it automatically stores all training parameters as a "model card" in a Flair model. This allows you to: 
- print all parameters with which a model was trained
- resume training any Flair model since the optimizer and scheduler are now stored by default

**Model cards**

When you train any Flair model, a model card will now automatically be saved. The following example trains a small POS-tagger and prints the model card in the end: 

```python
# initialize corpus and make label dictionary for POS tags
corpus = UD_ENGLISH().downsample(0.01)
tag_type = "pos"
tag_dictionary = corpus.make_label_dictionary(tag_type)

# simple sequence tagger
tagger = SequenceTagger(hidden_size=256,
                        embeddings=WordEmbeddings("glove"),
                        tag_dictionary=tag_dictionary,
                        tag_type=tag_type)

# initialize model trainer and experiment path
trainer = ModelTrainer(tagger, corpus)
path = f'resources/taggers/model-card'

# train for a few epochs
trainer.train(path,
              max_epochs=20,
              )

# load best model and print "model card"
trained_model = SequenceTagger.load(path + '/best-model.pt')
trained_model.print_model_card()
```

This should print a model card like: 
~~~
------------------------------------
--------- Flair Model Card ---------
------------------------------------
- this Flair model was trained with:
-- Flair version 0.9
-- PyTorch version 1.7.1
-- Transformers version 4.8.1
------------------------------------
------- Training Parameters: -------
------------------------------------
-- base_path = resources/taggers/model-card
-- learning_rate = 0.1
-- mini_batch_size = 32
-- mini_batch_chunk_size = None
-- max_epochs = 20
-- train_with_dev = False
-- train_with_test = False
[... shortened ...]
------------------------------------
~~~


**Resume training**

Previously, we distinguished between checkpoints and model files. Now all models can function as checkpoints, meaning you can load them and continue training them. Say you want to load the model above (trained to epoch 20) and continue training it to epoch 25. Do it like this: 

```python
# resume training best model, but this time until epoch 25
trainer.resume(trained_model,
               base_path=path + '-resume',
               max_epochs=25,
               )
```