### PR TITLE
GH-1529 fix infinite loop in Span::to_original_text

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -509,7 +509,7 @@ class Span(DataPoint):
             return " ".join([t.text for t in self.tokens])
         str = ""
         for t in self.tokens:
-            while t.start_pos != pos:
+            while t.start_pos > pos:
                 str += " "
                 pos += 1
 


### PR DESCRIPTION
With https://github.com/flairNLP/flair/issues/1529 there was already a fix for a potential endless loop in the `Sentence` class. Now we also got trapped in the same situation, but within `Span` class this time.