### PR TITLE
Small bug fixes in TARS and simple sequence tagger

### DIFF
--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -843,7 +843,7 @@ class TARSClassifier(FewshotClassifier):
 
                     # only use label with highest confidence if enforcing single-label predictions
                     if not multi_label:
-                        if len(sentence.get_labels()) > 0:
+                        if len(sentence.get_labels(label_name)) > 0:
 
                             # get all label scores and do an argmax to get the best label
                             label_scores = torch.tensor([label.score for label in sentence.get_labels(label_name)],

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -801,6 +801,7 @@ class ModelTrainer:
                   warmup_fraction: float = 0.1,
                   mini_batch_size: int = 4,
                   embeddings_storage_mode: str = 'none',
+                  use_final_model_for_eval: bool = True,
                   **trainer_args,
                   ):
 
@@ -813,6 +814,7 @@ class ModelTrainer:
             warmup_fraction=warmup_fraction,
             mini_batch_size=mini_batch_size,
             embeddings_storage_mode=embeddings_storage_mode,
+            use_final_model_for_eval=use_final_model_for_eval,
             **trainer_args,
         )
 


### PR DESCRIPTION
This PR fixes a few bugs: 
- a bug in TARS prediction if no label is predicted, but the sentence already has labels
- a bug in clearing previous labels in the predict() method of the DefaultClassifier
- loss summation in DefaultClassifier