### PR TITLE
Docs site from existing tutorials/readme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: deploy-docs
+
+on:
+  push:
+    branches:
+      - master
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: bash resources/build_docs.sh && mkdocs gh-deploy --force
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Flair is:
 
 * **A powerful NLP library.** Flair allows you to apply our state-of-the-art natural language processing (NLP)
 models to your text, such as named entity recognition (NER), part-of-speech tagging (PoS), 
-  special support for [biomedical data](/resources/docs/HUNFLAIR.md),
+  special support for [biomedical data](resources/docs/HUNFLAIR.md),
  sense disambiguation and classification, with support for a rapidly growing number of languages.
 
 * **A text embedding library.** Flair has simple interfaces that allow you to use and combine different word and
@@ -101,21 +101,21 @@ Span [3]: "Berlin"   [− Labels: LOC (0.9992)]
 
 We provide a set of quick tutorials to get you started with the library:
 
-* [Tutorial 1: Basics](/resources/docs/TUTORIAL_1_BASICS.md)
-* [Tutorial 2: Tagging your Text](/resources/docs/TUTORIAL_2_TAGGING.md)
-* [Tutorial 3: Embedding Words](/resources/docs/TUTORIAL_3_WORD_EMBEDDING.md)
-* [Tutorial 4: List of All Word Embeddings](/resources/docs/TUTORIAL_4_ELMO_BERT_FLAIR_EMBEDDING.md)
-* [Tutorial 5: Embedding Documents](/resources/docs/TUTORIAL_5_DOCUMENT_EMBEDDINGS.md)
-* [Tutorial 6: Loading a Dataset](/resources/docs/TUTORIAL_6_CORPUS.md)
-* [Tutorial 7: Training a Model](/resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md)
-* [Tutorial 8: Training your own Flair Embeddings](/resources/docs/TUTORIAL_9_TRAINING_LM_EMBEDDINGS.md)
-* [Tutorial 9: Training a Zero Shot Text Classifier (TARS)](/resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md)
+* [Tutorial 1: Basics](resources/docs/TUTORIAL_1_BASICS.md)
+* [Tutorial 2: Tagging your Text](resources/docs/TUTORIAL_2_TAGGING.md)
+* [Tutorial 3: Embedding Words](resources/docs/TUTORIAL_3_WORD_EMBEDDING.md)
+* [Tutorial 4: List of All Word Embeddings](resources/docs/TUTORIAL_4_ELMO_BERT_FLAIR_EMBEDDING.md)
+* [Tutorial 5: Embedding Documents](resources/docs/TUTORIAL_5_DOCUMENT_EMBEDDINGS.md)
+* [Tutorial 6: Loading a Dataset](resources/docs/TUTORIAL_6_CORPUS.md)
+* [Tutorial 7: Training a Model](resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md)
+* [Tutorial 8: Training your own Flair Embeddings](resources/docs/TUTORIAL_9_TRAINING_LM_EMBEDDINGS.md)
+* [Tutorial 9: Training a Zero Shot Text Classifier (TARS)](resources/docs/TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md)
 
 The tutorials explain how the base NLP classes work, how you can load pre-trained models to tag your
 text, how you can embed your text with different word or document embeddings, and how you can train your own
 language models, sequence labeling models, and text classification models. Let us know if anything is unclear.
 
-There is also a dedicated landing page for our **[biomedical NER and datasets](/resources/docs/HUNFLAIR.md)** with
+There is also a dedicated landing page for our **[biomedical NER and datasets](resources/docs/HUNFLAIR.md)** with
 installation instructions and tutorials.
 
 There are also good third-party articles and posts that illustrate how to use Flair:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: Flair
+repo_name: flairNLP/flair
+docs_dir: resources/docs
+nav:
+  - Flair: README.md
+  - Tutorial:
+    - TUTORIAL_1_BASICS.md
+    - TUTORIAL_2_TAGGING.md
+    - TUTORIAL_3_WORD_EMBEDDING.md
+    - TUTORIAL_4_ELMO_BERT_FLAIR_EMBEDDING.md
+    - TUTORIAL_5_DOCUMENT_EMBEDDINGS.md
+    - TUTORIAL_6_CORPUS.md
+    - TUTORIAL_7_TRAINING_A_MODEL.md
+    - TUTORIAL_8_MODEL_OPTIMIZATION.md
+    - TUTORIAL_9_TRAINING_LM_EMBEDDINGS.md
+    - TUTORIAL_10_TRAINING_ZERO_SHOT_MODEL.md
+  - Embeddings:
+    - embeddings/BYTE_PAIR_EMBEDDINGS.md
+    - embeddings/CHARACTER_EMBEDDINGS.md
+    - embeddings/CLASSIC_WORD_EMBEDDINGS.md
+    - embeddings/DOCUMENT_POOL_EMBEDDINGS.md
+    - embeddings/DOCUMENT_RNN_EMBEDDINGS.md
+    - embeddings/ELMO_EMBEDDINGS.md
+    - embeddings/FASTTEXT_EMBEDDINGS.md
+    - embeddings/FLAIR_EMBEDDINGS.md
+    - embeddings/ONE_HOT_EMBEDDINGS.md
+    - embeddings/TRANSFORMER_EMBEDDINGS.md
+  - Hunflair:
+    - HUNFLAIR.md
+    - HUNFLAIR_CORPORA.md
+    - HUNFLAIR_EXPERIMENTS.md
+    - HUNFLAIR_TUTORIAL_1_TAGGING.md
+    - HUNFLAIR_TUTORIAL_2_TRAINING.md
+  - EXPERIMENTS.md
+  - Contributing: CONTRIBUTING.md
+  - CHANGELOG: CHANGELOG.md
+  - Code of Conduct: CODE_OF_CONDUCT.md
+  - License: https://github.com/flairNLP/flair/blob/8f9b2dc0ed199dcb0b8b8dc54478f81545ef6414/LICENSE
+
+theme:
+  name: material
+  palette:
+    primary: orange
+  favicon: flair_logo_2020.svg
+  logo: flair_logo_2020.svg
+  highlightjs: true
+  hljs_languages:
+  - python
+  - json
+
+markdown_extensions:
+  - toc:
+        permalink: '#'
+  - markdown.extensions.codehilite:
+        guess_lang: true
+  - admonition
+  - codehilite
+  - extra
+  - pymdownx.highlight
+  - pymdownx.superfences
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,6 @@ nav:
     - HUNFLAIR_TUTORIAL_2_TRAINING.md
   - EXPERIMENTS.md
   - Contributing: CONTRIBUTING.md
-  - CHANGELOG: CHANGELOG.md
   - Code of Conduct: CODE_OF_CONDUCT.md
   - License: https://github.com/flairNLP/flair/blob/8f9b2dc0ed199dcb0b8b8dc54478f81545ef6414/LICENSE
 

--- a/resources/build_docs.sh
+++ b/resources/build_docs.sh
@@ -1,0 +1,7 @@
+
+# Change the paths to be relative when copying the readme into the docs,
+# so the links are correct.
+sed  's/resources\/docs\///g' README.md > ./resources/docs/README.md
+cp CONTRIBUTING.md ./resources/docs/
+cp CODE_OF_CONDUCT.md ./resources/docs/
+


### PR DESCRIPTION
Adds some docs, and a github action to deploy them on github pages.

- Uses [Material Mkdocs](https://squidfunk.github.io/mkdocs-material/)
- Adds a yml file with the configuration, various things in this can be tweaked, like colours, file names etc.
- Adds a small bash script which copies some top level files into the docs directory before building it, so the README on the docs is the exact same as on the github repo (it also has to modify some paths in the readme from `resources/docs/` to `./` as the files have changed location)
- Adds a github action which builds and deploys the docs on every push to master

To run this locally:
```
pip install material-mkdocs
bash resources/build_docs.sh
mkdocs serve
```

This doesn't include API docs, which are a bit more involved if you want to autogenerate them. But it's definitely a start! 

The docs look like this:

![Screen Shot 2021-10-08 at 12 59 19 PM](https://user-images.githubusercontent.com/16001974/136553178-53441f15-7466-4e07-8b8a-cad959dd72cb.png)

