### PR TITLE
refactor onehot embeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -1449,6 +1449,7 @@ class OneHotEmbeddings(TokenEmbeddings):
         self.field = field
         self.instance_parameters = self.get_instance_parameters(locals=locals())
         self.__embedding_length = embedding_length
+        self.vocab_dictionary = vocab_dictionary
 
         print(self.vocab_dictionary.idx2item)
         print(f"vocabulary size of {len(self.vocab_dictionary)}")


### PR DESCRIPTION
a few changes to the OneHotEmbeddings:

- allows creating OneHotEmbeddings by a Dictionary directly, in case you don't want to gather it from a corpus.
- still allows creating OneHotEmbeddings by a Corpus, using `OneHotEmbeddings.from_corpus(..)` 
- should fix https://github.com/flairNLP/flair/issues/2489 as the instance_parameters cover the Dictionary and not the Corpus -> it won't store the whole dataset and therefore reduces model size.
- allows usage of "stable embeddings" -> https://arxiv.org/abs/2110.02861 which seem to "reduce gradient variance that comes from the highly non-uniform distribution of input tokens"
- makes the `_add_embeddings_internal` method more beautiful, by removing nested loops (iterates over all tokens instead of all sentences and their tokens) and removing unneeded indexing/enumerations