### PR TITLE
allow finetuning of word-embeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -244,9 +244,8 @@ class WordEmbeddings(TokenEmbeddings):
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
 
-        for i, sentence in enumerate(sentences):
-
-            for token, token_idx in zip(sentence.tokens, range(len(sentence.tokens))):
+        for sentence in sentences:
+            for token in sentence.tokens:
 
                 if "field" not in self.__dict__ or self.field is None:
                     word = token.text

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -271,7 +271,7 @@ class WordEmbeddings(TokenEmbeddings):
                 word = token.get_tag(self.field).value
             word_indices.append(self.get_cached_token_index(word))
 
-        embeddings = self.embedding(torch.tensor(word_indices, dtype=torch.int, device=self.device))
+        embeddings = self.embedding(torch.tensor(word_indices, dtype=torch.long, device=self.device))
         if self.stable:
             embeddings = self.layer_norm(embeddings)
 

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -133,7 +133,7 @@ class WordEmbeddings(TokenEmbeddings):
         self.instance_parameters = self.get_instance_parameters(locals=locals())
 
         if fine_tune and force_cpu and flair.device.type != "cpu":
-            raise Exception("Cannot train WordEmbeddings on cpu if the model is trained on gpu")
+            raise ValueError("Cannot train WordEmbeddings on cpu if the model is trained on gpu, set force_cpu=False")
 
         hu_path: str = "https://flair.informatik.hu-berlin.de/resources/embeddings/token"
 

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -307,12 +307,17 @@ class WordEmbeddings(TokenEmbeddings):
 
     def _apply(self, fn):
         if fn.__name__ == "convert" and self.force_cpu:
+            # this is required to force the module on the cpu,
+            # if a parent module is put to gpu, the _apply is called to each sub_module
+            # self.to(..) actually sets the device properly
             if not hasattr(self, "device"):
                 self.to(flair.device)
             return
         super(WordEmbeddings, self)._apply(fn)
 
     def __getattribute__(self, item):
+        # this ignores the get_cached_vec method when loading older versions
+        # it is needed for compatibility reasons
         if "get_cached_vec" == item:
             return None
         return super().__getattribute__(item)


### PR DESCRIPTION
This PR reworks the `WordEmbeddings` to add a few features:

- embeddings are stored as a torch Embedding instead of a gensim keyedvector. That way it will never come to version issues, if gensim doesn't ensure backwards compatibility (happened to me a few times over the last 2 years)
- embeddings can be put on gpu, if wanted. For that, `WordEmbeddings('<name>', force_cpu=False)` can be used
- embeddings can be fine-tuned. For that, `FordEmbeddings('<name>', fine_tune=True)` can be used.
- the lru_cache will store indices per word instead of vector lookups. This is because the lookups shouldn't take long if calculating all indices at once (especially if using gpu). However, the regex operations and multiple lookups will remain cached.
- lru_cache is increased, as it takes (<embedding_length> - 1)* 4 bytes less per lookup.
- allows usage of "stable embeddings" → https://arxiv.org/abs/2110.02861 which seem to "reduce gradient variance that comes from the highly non-uniform distribution of input tokens"
