### PR TITLE
default handling when Tokenizer's model_max_length is not set

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -67,6 +67,10 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings):
 
         # load tokenizer and transformer model
         self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(model, **kwargs)
+        if self.tokenizer.model_max_length > 1000000000:
+            self.tokenizer.model_max_length = 512
+            log.info("No model_max_length in Tokenizer's config.json - setting it to 512. "
+                     "Specify desired model_max_length by passing it as attribute to embedding instance.")
         if not 'config' in kwargs:
             config = AutoConfig.from_pretrained(model, output_hidden_states=True, **kwargs)
             self.model = AutoModel.from_pretrained(model, config=config)

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -933,6 +933,10 @@ class TransformerWordEmbeddings(TokenEmbeddings):
 
         # load tokenizer and transformer model
         self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(model, **kwargs)
+        if self.tokenizer.model_max_length > 1000000000:
+            self.tokenizer.model_max_length = 512
+            log.info("No model_max_length in Tokenizer's config.json - setting it to 512. "
+                     "Specify desired model_max_length by passing it as attribute to embedding instance.")
         if not 'config' in kwargs:
             config = AutoConfig.from_pretrained(model, output_hidden_states=True, **kwargs)
             self.model = AutoModel.from_pretrained(model, config=config)


### PR DESCRIPTION
fixes and closes gh-2210, gh-2305, gh-2476, gh-2500