### PR TITLE
long sequence transformers of any kind

### DIFF
--- a/flair/embeddings/base.py
+++ b/flair/embeddings/base.py
@@ -21,6 +21,7 @@ from transformers import (
     TransfoXLModel,
     XLNetModel,
 )
+from transformers.tokenization_utils_base import TruncationStrategy, LARGE_INTEGER
 
 import flair
 from flair.data import DT, Sentence, Token
@@ -168,7 +169,6 @@ class ScalarMix(torch.nn.Module):
 
 
 class TransformerEmbedding(Embeddings[Sentence]):
-    NO_MAX_SEQ_LENGTH_MODELS = (XLNetModel, TransfoXLModel)
 
     def __init__(
         self,
@@ -217,7 +217,7 @@ class TransformerEmbedding(Embeddings[Sentence]):
 
         self.truncate = True
 
-        if isinstance(self.model, self.NO_MAX_SEQ_LENGTH_MODELS):
+        if self.tokenizer.model_max_length > LARGE_INTEGER:
             allow_long_sentences = False
             self.truncate = False
 


### PR DESCRIPTION
apparently the logic of the Transformers tokenizers is that if the sequence lenght exceeds a very large number, it counts as infinitive. 
this includes models like DebertaV3 but also XLNetModel.

For TransfoXLModel I couldn't test if this logic is valid, as I didn't find any model when searching for it in the HF modelhub