### PR TITLE
Refactor embedding logic for data points

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -14,9 +14,6 @@ if torch.cuda.is_available():
 else:
     device = torch.device("cpu")
 
-# global variable: embedding_storage_mode
-embedding_storage_mode = "default"
-
 
 from . import (  # noqa: E402 import after setting device
     data,
@@ -58,7 +55,6 @@ __all__ = [
     "__version__",
     "logger",
     "set_seed",
-    "embedding_storage_mode",
     "data",
     "models",
     "nn",

--- a/flair/data.py
+++ b/flair/data.py
@@ -297,10 +297,10 @@ class RelationLabel(Label):
 
     def __eq__(self, other):
         return (
-                self.value == other.value
-                and self.score == other.score
-                and self.head.id_text == other.head.id_text
-                and self.tail.id_text == other.tail.id_text
+            self.value == other.value
+            and self.score == other.score
+            and self.head.id_text == other.head.id_text
+            and self.tail.id_text == other.tail.id_text
         )
 
     @property
@@ -415,12 +415,12 @@ class Token(DataPoint):
     """
 
     def __init__(
-            self,
-            text: str,
-            idx: int = None,
-            head_id: int = None,
-            whitespace_after: bool = True,
-            start_position: int = None,
+        self,
+        text: str,
+        idx: int = None,
+        head_id: int = None,
+        whitespace_after: bool = True,
+        start_position: int = None,
     ):
         super().__init__()
 
@@ -602,11 +602,11 @@ class Sentence(DataPoint):
     """
 
     def __init__(
-            self,
-            text: Union[str, List[str]] = [],
-            use_tokenizer: Union[bool, Tokenizer, Callable] = True,
-            language_code: str = None,
-            start_position: int = None,
+        self,
+        text: Union[str, List[str]] = [],
+        use_tokenizer: Union[bool, Tokenizer, Callable] = True,
+        language_code: str = None,
+        start_position: int = None,
     ):
         """
         Class to hold all meta related to a text (tokens, predictions, language code, ...)
@@ -634,11 +634,13 @@ class Sentence(DataPoint):
 
         elif callable(use_tokenizer):
             from flair.tokenization import TokenizerWrapper
+
             tokenizer = TokenizerWrapper(use_tokenizer)
 
         elif type(use_tokenizer) == bool:
 
             from flair.tokenization import SegtokTokenizer, SpaceTokenizer
+
             tokenizer = SegtokTokenizer() if use_tokenizer else SpaceTokenizer()
 
         else:
@@ -669,7 +671,7 @@ class Sentence(DataPoint):
         self._position_in_dataset: Optional[typing.Tuple[Dataset, int]] = None
 
     def get_span(self, from_id: int, to_id: int) -> Span:
-        return self.tokens[from_id:to_id + 1]
+        return self.tokens[from_id : to_id + 1]
 
     def get_token(self, token_id: int) -> Optional[Token]:
         for token in self.tokens:
@@ -1118,12 +1120,12 @@ class FlairDataset(Dataset):
 
 class Corpus:
     def __init__(
-            self,
-            train: Dataset = None,
-            dev: Dataset = None,
-            test: Dataset = None,
-            name: str = "corpus",
-            sample_missing_splits: Union[bool, str] = True,
+        self,
+        train: Dataset = None,
+        dev: Dataset = None,
+        test: Dataset = None,
+        name: str = "corpus",
+        sample_missing_splits: Union[bool, str] = True,
     ):
         # set name
         self.name: str = name
@@ -1162,11 +1164,11 @@ class Corpus:
         return self._test
 
     def downsample(
-            self,
-            percentage: float = 0.1,
-            downsample_train=True,
-            downsample_dev=True,
-            downsample_test=True,
+        self,
+        percentage: float = 0.1,
+        downsample_train=True,
+        downsample_dev=True,
+        downsample_test=True,
     ):
 
         if downsample_train and self._train is not None:

--- a/flair/data.py
+++ b/flair/data.py
@@ -297,10 +297,10 @@ class RelationLabel(Label):
 
     def __eq__(self, other):
         return (
-            self.value == other.value
-            and self.score == other.score
-            and self.head.id_text == other.head.id_text
-            and self.tail.id_text == other.tail.id_text
+                self.value == other.value
+                and self.score == other.score
+                and self.head.id_text == other.head.id_text
+                and self.tail.id_text == other.tail.id_text
         )
 
     @property
@@ -325,9 +325,33 @@ class DataPoint:
     def embedding(self):
         pass
 
-    @abstractmethod
+    def set_embedding(self, name: str, vector: torch.Tensor):
+        self._embeddings[name] = vector
+
+    def get_embedding(self, names: Optional[List[str]] = None) -> torch.Tensor:
+        embeddings = self.get_each_embedding(names)
+
+        if embeddings:
+            return torch.cat(embeddings, dim=0)
+
+        return torch.tensor([], device=flair.device)
+
+    def get_each_embedding(self, embedding_names: Optional[List[str]] = None) -> List[torch.Tensor]:
+        embeddings = []
+        for embed_name in sorted(self._embeddings.keys()):
+            if embedding_names and embed_name not in embedding_names:
+                continue
+            embed = self._embeddings[embed_name].to(flair.device)
+            embeddings.append(embed)
+        return embeddings
+
     def to(self, device: str, pin_memory: bool = False):
-        pass
+        for name, vector in self._embeddings.items():
+            if str(vector.device) != str(device):
+                if pin_memory:
+                    self._embeddings[name] = vector.to(device, non_blocking=True).pin_memory()
+                else:
+                    self._embeddings[name] = vector.to(device, non_blocking=True)
 
     def clear_embeddings(self, embedding_names: List[str] = None):
         if embedding_names is None:
@@ -379,25 +403,6 @@ class DataPoint:
             all_labels.extend(self.annotation_layers[key])
         return all_labels
 
-    def get_embedding(self, names: Optional[List[str]] = None) -> torch.Tensor:
-        embeddings = self.get_each_embedding(names)
-
-        if embeddings:
-            return torch.cat(embeddings, dim=0)
-
-        return torch.tensor([], device=flair.device)
-
-    def get_each_embedding(self, embedding_names: Optional[List[str]] = None) -> List[torch.Tensor]:
-        embeddings = []
-        for embed_name in sorted(self._embeddings.keys()):
-            if embedding_names and embed_name not in embedding_names:
-                continue
-            embed = self._embeddings[embed_name].to(flair.device)
-            if (flair.embedding_storage_mode == "cpu") and embed.device != flair.device:
-                embed = embed.to(flair.device)
-            embeddings.append(embed)
-        return embeddings
-
 
 DT = typing.TypeVar("DT", bound=DataPoint)
 DT2 = typing.TypeVar("DT2", bound=DataPoint)
@@ -410,12 +415,12 @@ class Token(DataPoint):
     """
 
     def __init__(
-        self,
-        text: str,
-        idx: int = None,
-        head_id: int = None,
-        whitespace_after: bool = True,
-        start_position: int = None,
+            self,
+            text: str,
+            idx: int = None,
+            head_id: int = None,
+            whitespace_after: bool = True,
+            start_position: int = None,
     ):
         super().__init__()
 
@@ -452,22 +457,6 @@ class Token(DataPoint):
 
     def get_head(self):
         return self.sentence.get_token(self.head_id)
-
-    def set_embedding(self, name: str, vector: torch.Tensor):
-        device = flair.device
-        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
-            device = next(iter(self._embeddings.values())).device
-        if device != vector.device:
-            vector = vector.to(device)
-        self._embeddings[name] = vector
-
-    def to(self, device: str, pin_memory: bool = False):
-        for name, vector in self._embeddings.items():
-            if str(vector.device) != str(device):
-                if pin_memory:
-                    self._embeddings[name] = vector.to(device, non_blocking=True).pin_memory()
-                else:
-                    self._embeddings[name] = vector.to(device, non_blocking=True)
 
     @property
     def start_position(self) -> Optional[int]:
@@ -613,11 +602,11 @@ class Sentence(DataPoint):
     """
 
     def __init__(
-        self,
-        text: Union[str, List[str]] = [],
-        use_tokenizer: Union[bool, Tokenizer, Callable] = True,
-        language_code: str = None,
-        start_position: int = None,
+            self,
+            text: Union[str, List[str]] = [],
+            use_tokenizer: Union[bool, Tokenizer, Callable] = True,
+            language_code: str = None,
+            start_position: int = None,
     ):
         """
         Class to hold all meta related to a text (tokens, predictions, language code, ...)
@@ -634,23 +623,24 @@ class Sentence(DataPoint):
 
         self.tokens: List[Token] = []
 
-        self._embeddings: Dict = {}
-
         self.language_code: Optional[str] = language_code
 
         self.start_pos = start_position
         self.end_pos = start_position + len(text) if start_position is not None else None
 
+        # the tokenizer used for this sentence
         if isinstance(use_tokenizer, Tokenizer):
             tokenizer = use_tokenizer
+
         elif callable(use_tokenizer):
             from flair.tokenization import TokenizerWrapper
-
             tokenizer = TokenizerWrapper(use_tokenizer)
-        elif type(use_tokenizer) == bool:
-            from flair.tokenization import SegtokTokenizer, SpaceTokenizer
 
+        elif type(use_tokenizer) == bool:
+
+            from flair.tokenization import SegtokTokenizer, SpaceTokenizer
             tokenizer = SegtokTokenizer() if use_tokenizer else SpaceTokenizer()
+
         else:
             raise AssertionError(
                 "Unexpected type of parameter 'use_tokenizer'. "
@@ -673,10 +663,13 @@ class Sentence(DataPoint):
         # some sentences represent a document boundary (but most do not)
         self.is_document_boundary: bool = False
 
+        # internal variables to denote position inside dataset
         self._previous_sentence: Optional[Sentence] = None
         self._next_sentence: Optional[Sentence] = None
-
         self._position_in_dataset: Optional[typing.Tuple[Dataset, int]] = None
+
+    def get_span(self, from_id: int, to_id: int) -> Span:
+        return self.tokens[from_id:to_id + 1]
 
     def get_token(self, token_id: int) -> Optional[Token]:
         for token in self.tokens:
@@ -781,25 +774,12 @@ class Sentence(DataPoint):
     def embedding(self):
         return self.get_embedding()
 
-    def set_embedding(self, name: str, vector: torch.Tensor):
-        device = flair.device
-        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
-            device = next(iter(self._embeddings.values())).device
-        if device != vector.device:
-            vector = vector.to(device)
-        self._embeddings[name] = vector
-
     def to(self, device: str, pin_memory: bool = False):
 
         # move sentence embeddings to device
-        for name, vector in self._embeddings.items():
-            if str(vector.device) != str(device):
-                if pin_memory:
-                    self._embeddings[name] = vector.to(device, non_blocking=True).pin_memory()
-                else:
-                    self._embeddings[name] = vector.to(device, non_blocking=True)
+        super().to(device=device, pin_memory=pin_memory)
 
-        # move token embeddings to device
+        # also move token embeddings to device
         for token in self:
             token.to(device, pin_memory)
 
@@ -1124,27 +1104,10 @@ class Image(DataPoint):
         return self.get_embedding()
 
     def __str__(self):
-
         image_repr = self.data.size() if self.data else ""
         image_url = self.imageURL if self.imageURL else ""
 
         return f"Image: {image_repr} {image_url}"
-
-    def set_embedding(self, name: str, vector: torch.Tensor):
-        device = flair.device
-        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
-            device = next(iter(self._embeddings.values())).device
-        if device != vector.device:
-            vector = vector.to(device)
-        self._embeddings[name] = vector
-
-    def to(self, device: str, pin_memory: bool = False):
-        for name, vector in self._embeddings.items():
-            if str(vector.device) != str(device):
-                if pin_memory:
-                    self._embeddings[name] = vector.to(device, non_blocking=True).pin_memory()
-                else:
-                    self._embeddings[name] = vector.to(device, non_blocking=True)
 
 
 class FlairDataset(Dataset):
@@ -1155,12 +1118,12 @@ class FlairDataset(Dataset):
 
 class Corpus:
     def __init__(
-        self,
-        train: Dataset = None,
-        dev: Dataset = None,
-        test: Dataset = None,
-        name: str = "corpus",
-        sample_missing_splits: Union[bool, str] = True,
+            self,
+            train: Dataset = None,
+            dev: Dataset = None,
+            test: Dataset = None,
+            name: str = "corpus",
+            sample_missing_splits: Union[bool, str] = True,
     ):
         # set name
         self.name: str = name
@@ -1199,11 +1162,11 @@ class Corpus:
         return self._test
 
     def downsample(
-        self,
-        percentage: float = 0.1,
-        downsample_train=True,
-        downsample_dev=True,
-        downsample_test=True,
+            self,
+            percentage: float = 0.1,
+            downsample_train=True,
+            downsample_dev=True,
+            downsample_test=True,
     ):
 
         if downsample_train and self._train is not None:

--- a/flair/embeddings/base.py
+++ b/flair/embeddings/base.py
@@ -21,7 +21,7 @@ from transformers import (
     TransfoXLModel,
     XLNetModel,
 )
-from transformers.tokenization_utils_base import TruncationStrategy, LARGE_INTEGER
+from transformers.tokenization_utils_base import LARGE_INTEGER, TruncationStrategy
 
 import flair
 from flair.data import DT, Sentence, Token
@@ -169,7 +169,6 @@ class ScalarMix(torch.nn.Module):
 
 
 class TransformerEmbedding(Embeddings[Sentence]):
-
     def __init__(
         self,
         model: str = "bert-base-uncased",

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union
+from typing import List, Union, Optional
 
 import torch
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -61,7 +61,7 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings, TransformerEmbedding):
 class DocumentPoolEmbeddings(DocumentEmbeddings):
     def __init__(
         self,
-        embeddings: List[TokenEmbeddings],
+        embeddings: Union[TokenEmbeddings, List[TokenEmbeddings]],
         fine_tune_mode: str = "none",
         pooling: str = "mean",
     ):

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 import torch
 from sklearn.feature_extraction.text import TfidfVectorizer

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -73,6 +73,9 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
         """
         super().__init__()
 
+        if isinstance(embeddings, TokenEmbeddings):
+            embeddings = [embeddings]
+
         self.embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embeddings)
         self.__embedding_length = self.embeddings.embedding_length
 

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -39,9 +39,12 @@ class TokenEmbeddings(Embeddings[Sentence]):
 class StackedEmbeddings(TokenEmbeddings):
     """A stack of embeddings, used if you need to combine several different embedding types."""
 
-    def __init__(self, embeddings: List[TokenEmbeddings]):
+    def __init__(self, embeddings: Union[TokenEmbeddings, List[TokenEmbeddings]]):
         """The constructor takes a list of embeddings to be combined."""
         super().__init__()
+
+        if isinstance(embeddings, TokenEmbeddings):
+            embeddings = [embeddings]
 
         self.embeddings = embeddings
 
@@ -762,10 +765,6 @@ class FlairEmbeddings(TokenEmbeddings):
                         offset_backward -= 1
 
                     offset_backward -= len(token.text)
-
-                    # only clone if optimization mode is 'gpu'
-                    if flair.embedding_storage_mode == "gpu":
-                        embedding = embedding.clone()
 
                     token.set_embedding(self.name, embedding)
 

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -39,12 +39,9 @@ class TokenEmbeddings(Embeddings[Sentence]):
 class StackedEmbeddings(TokenEmbeddings):
     """A stack of embeddings, used if you need to combine several different embedding types."""
 
-    def __init__(self, embeddings: Union[TokenEmbeddings, List[TokenEmbeddings]]):
+    def __init__(self, embeddings: List[TokenEmbeddings]):
         """The constructor takes a list of embeddings to be combined."""
         super().__init__()
-
-        if isinstance(embeddings, TokenEmbeddings):
-            embeddings = [embeddings]
 
         self.embeddings = embeddings
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -360,6 +360,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             if nb_padding_tokens > 0:
                 t = pre_allocated_zero_tensor[: self.embeddings.embedding_length * nb_padding_tokens]
                 all_embs.append(t)
+
         sentence_tensor = torch.cat(all_embs).view(
             [
                 len(sentences),

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -34,9 +34,10 @@ from flair.training_utils import (
     AnnealOnPlateau,
     WeightExtractor,
     add_file_handler,
+    identify_dynamic_embeddings,
     init_output_file,
     log_line,
-    store_embeddings, identify_dynamic_embeddings,
+    store_embeddings,
 )
 
 log = logging.getLogger("flair")

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -36,7 +36,7 @@ from flair.training_utils import (
     add_file_handler,
     init_output_file,
     log_line,
-    store_embeddings,
+    store_embeddings, identify_dynamic_embeddings,
 )
 
 log = logging.getLogger("flair")
@@ -356,6 +356,9 @@ class ModelTrainer:
 
         micro_batch_size = mini_batch_chunk_size
 
+        # this field stores the names of all dynamic embeddings in the model (determined after first forward pass)
+        dynamic_embeddings = None
+
         # At any point you can hit Ctrl + C to break out of training early.
         try:
             if create_file_logs:
@@ -507,9 +510,12 @@ class ModelTrainer:
 
                     seen_batches += 1
 
-                    # depending on memory mode, embeddings are moved to CPU, GPU
-                    # or deleted
-                    store_embeddings(batch, embeddings_storage_mode)
+                    # identify dynamic embeddings (always deleted) on first sentence
+                    if not dynamic_embeddings:
+                        dynamic_embeddings = identify_dynamic_embeddings(batch[0])
+
+                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                    store_embeddings(batch, embeddings_storage_mode, dynamic_embeddings)
 
                     batch_time += time.time() - start_time
                     if seen_batches % modulo == 0:
@@ -558,9 +564,8 @@ class ModelTrainer:
                     )
                     result_line += f"\t{train_eval_result.log_line}"
 
-                    # depending on memory mode, embeddings are moved to CPU, GPU
-                    # or deleted
-                    store_embeddings(self.corpus.train, embeddings_storage_mode)
+                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                    store_embeddings(self.corpus.train, embeddings_storage_mode, dynamic_embeddings)
 
                 if log_train_part:
                     train_part_eval_result = self.model.evaluate(
@@ -614,9 +619,8 @@ class ModelTrainer:
 
                     dev_score = dev_eval_result.main_score
 
-                    # depending on memory mode, embeddings are moved to CPU, GPU
-                    # or deleted
-                    store_embeddings(self.corpus.dev, embeddings_storage_mode)
+                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                    store_embeddings(self.corpus.dev, embeddings_storage_mode, dynamic_embeddings)
 
                     if use_tensorboard:
                         writer.add_scalar("dev_loss", dev_eval_result.loss, epoch)
@@ -651,9 +655,8 @@ class ModelTrainer:
                         f" {round(test_eval_result.main_score, 4)}"
                     )
 
-                    # depending on memory mode, embeddings are moved to CPU, GPU
-                    # or deleted
-                    store_embeddings(self.corpus.test, embeddings_storage_mode)
+                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                    store_embeddings(self.corpus.test, embeddings_storage_mode, dynamic_embeddings)
 
                     if use_tensorboard:
                         writer.add_scalar("test_loss", test_eval_result.loss, epoch)

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -5,7 +5,7 @@ from enum import Enum
 from functools import reduce
 from math import inf
 from pathlib import Path
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Optional, Union
 
 from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import mean_absolute_error, mean_squared_error
@@ -365,9 +365,9 @@ def add_file_handler(log, output_file):
     return fh
 
 
-def store_embeddings(data_points: Union[List[DataPoint], Dataset],
-                     storage_mode: str,
-                     dynamic_embeddings: Optional[List[str]] = None):
+def store_embeddings(
+    data_points: Union[List[DataPoint], Dataset], storage_mode: str, dynamic_embeddings: Optional[List[str]] = None
+):
 
     if isinstance(data_points, Dataset):
         data_points = list(_iter_dataset(data_points))

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -5,7 +5,7 @@ from enum import Enum
 from functools import reduce
 from math import inf
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import mean_absolute_error, mean_squared_error
@@ -365,37 +365,41 @@ def add_file_handler(log, output_file):
     return fh
 
 
-def store_embeddings(data_points: Union[List[DataPoint], Dataset], storage_mode: str):
-    # if memory mode option 'none' delete everything
+def store_embeddings(data_points: Union[List[DataPoint], Dataset],
+                     storage_mode: str,
+                     dynamic_embeddings: Optional[List[str]] = None):
+
     if isinstance(data_points, Dataset):
         data_points = list(_iter_dataset(data_points))
 
+    # if memory mode option 'none' delete everything
     if storage_mode == "none":
-        delete_keys = None
-    # else delete only dynamic embeddings (otherwise autograd will keep everything in memory)
-    else:
-        # find out which ones are dynamic embeddings
-        delete_keys = []
-        data_point = data_points[0]
-        if isinstance(data_point, Sentence):
-            first_token = data_point[0]
-            for name, vector in first_token._embeddings.items():
-                if vector.requires_grad:
-                    delete_keys.append(name)
+        dynamic_embeddings = None
 
-        for name, vector in data_point._embeddings.items():
-            if vector.requires_grad:
-                delete_keys.append(name)
+    # if dynamic embedding keys not passed, identify them automatically
+    elif not dynamic_embeddings:
+        dynamic_embeddings = identify_dynamic_embeddings(data_points[0])
 
-        # find out which ones are dynamic embeddings
+    # always delete dynamic embeddings
     for data_point in data_points:
-        data_point.clear_embeddings(delete_keys)
+        data_point.clear_embeddings(dynamic_embeddings)
 
-    # memory management - option 1: send everything to CPU (pin to memory if we train on GPU)
+    # if storage mode is "cpu", send everything to CPU (pin to memory if we train on GPU)
     if storage_mode == "cpu":
         pin_memory = str(flair.device) != "cpu"
         for data_point in data_points:
             data_point.to("cpu", pin_memory=pin_memory)
 
-    # record current embedding storage mode to allow optimization (for instance in FlairEmbeddings class)
-    flair.embedding_storage_mode = storage_mode
+
+def identify_dynamic_embeddings(data_point: DataPoint):
+    dynamic_embeddings = []
+    if isinstance(data_point, Sentence):
+        first_token = data_point[0]
+        for name, vector in first_token._embeddings.items():
+            if vector.requires_grad:
+                dynamic_embeddings.append(name)
+
+    for name, vector in data_point._embeddings.items():
+        if vector.requires_grad:
+            dynamic_embeddings.append(name)
+    return dynamic_embeddings


### PR DESCRIPTION
Refactoring of embedding logic for data points: 
- removes the global variable `embedding_storage_mode`
- moves up `set_embedding()` and `to()` from the data point classes (`Sentence`, `Token`, etc.) to their parent `DataPoint`
- allows dynamic embedding names to be passed to `store_embeddings` for small speed up
- the `set_embedding()` method no longer transfers embeddings to `flair.device` (only when getting this is done now)
- `DocumentPoolEmbeddings` class can now be instantiated only with a single embedding