### PR TITLE
fix reloading fast tokenizers

### DIFF
--- a/flair/embeddings/base.py
+++ b/flair/embeddings/base.py
@@ -340,7 +340,10 @@ class TransformerEmbedding(Embeddings[Sentence]):
 
     def _tokenizer_bytes(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            files = self.tokenizer.save_pretrained(temp_dir)
+            files = list(self.tokenizer.save_pretrained(temp_dir))
+            if self.tokenizer.is_fast:
+                vocab_files = self.tokenizer.slow_tokenizer_class.vocab_files_names.values()
+                files = [f for f in files if all(v not in f for v in vocab_files)]
             zip_data = BytesIO()
             zip_obj = zipfile.ZipFile(zip_data, "w")
             for f in files:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -14,7 +14,7 @@ from flair.embeddings import (
     TransformerWordEmbeddings,
     WordEmbeddings,
 )
-from flair.models import LanguageModel
+from flair.models import LanguageModel, SequenceTagger
 
 glove: TokenEmbeddings = WordEmbeddings("turian")
 flair_embedding: TokenEmbeddings = FlairEmbeddings("news-forward-fast")
@@ -319,3 +319,17 @@ def test_document_cnn_embeddings():
 
     assert len(sentence.get_embedding()) == 0
     del embeddings
+
+
+def test_transformers_keep_tokenizer_when_saving(results_base_path):
+    embeddings = TransformerWordEmbeddings("sentence-transformers/paraphrase-albert-small-v2")
+    results_base_path.mkdir(exist_ok=True, parents=True)
+    initial_tagger_path = results_base_path / "initial_tokenizer.pk"
+    reloaded_tagger_path = results_base_path / "reloaded_tokenizer.pk"
+
+    initial_tagger = SequenceTagger(embeddings, Dictionary(), "ner")
+
+    initial_tagger.save(initial_tagger_path)
+    reloaded_tagger = SequenceTagger.load(initial_tagger_path)
+
+    reloaded_tagger.save(reloaded_tagger_path)


### PR DESCRIPTION
Solves https://github.com/flairNLP/flair/issues/2614
context:
The slow variant of tokenizers relies on sentencepiece which are saved in the respective files defined in `vocab_files_names`, when a fast tokenizer is created and will be saved, it creates a `tokenizer.json` file which basically contains all information, however it still tries to persist the `vocab_file_names` even if they are not required anymore. It cannot recreate the `vocab_file_names` without rebuilding the sentencepiece objects, so it rather tries to copy the file, if one is specified.
Excluding those files makes those not be specified → it won't try to copy the file
