### PR TITLE
Reintroduce hyperparameter tuning

### DIFF
--- a/flair/hyperparameter/__init__.py
+++ b/flair/hyperparameter/__init__.py
@@ -1,0 +1,11 @@
+from .parameter import (
+    Parameter,
+    SEQUENCE_TAGGER_PARAMETERS,
+    TRAINING_PARAMETERS,
+    DOCUMENT_EMBEDDING_PARAMETERS,
+)
+from .param_selection import (
+    SequenceTaggerParamSelector,
+    TextClassifierParamSelector,
+    SearchSpace,
+)

--- a/flair/hyperparameter/__init__.py
+++ b/flair/hyperparameter/__init__.py
@@ -1,11 +1,21 @@
-from .parameter import (
-    Parameter,
-    SEQUENCE_TAGGER_PARAMETERS,
-    TRAINING_PARAMETERS,
-    DOCUMENT_EMBEDDING_PARAMETERS,
-)
 from .param_selection import (
+    SearchSpace,
     SequenceTaggerParamSelector,
     TextClassifierParamSelector,
-    SearchSpace,
 )
+from .parameter import (
+    DOCUMENT_EMBEDDING_PARAMETERS,
+    SEQUENCE_TAGGER_PARAMETERS,
+    TRAINING_PARAMETERS,
+    Parameter,
+)
+
+__all__ = [
+    "Parameter",
+    "SEQUENCE_TAGGER_PARAMETERS",
+    "TRAINING_PARAMETERS",
+    "DOCUMENT_EMBEDDING_PARAMETERS",
+    "SequenceTaggerParamSelector",
+    "TextClassifierParamSelector",
+    "SearchSpace",
+]

--- a/flair/hyperparameter/__init__.py
+++ b/flair/hyperparameter/__init__.py
@@ -4,8 +4,8 @@ from .param_selection import (
     TextClassifierParamSelector,
 )
 from .parameter import (
-    TEXT_CLASSIFICATION_PARAMETERS,
     SEQUENCE_TAGGER_PARAMETERS,
+    TEXT_CLASSIFICATION_PARAMETERS,
     TRAINING_PARAMETERS,
     Parameter,
 )

--- a/flair/hyperparameter/__init__.py
+++ b/flair/hyperparameter/__init__.py
@@ -4,7 +4,7 @@ from .param_selection import (
     TextClassifierParamSelector,
 )
 from .parameter import (
-    DOCUMENT_EMBEDDING_PARAMETERS,
+    TEXT_CLASSIFICATION_PARAMETERS,
     SEQUENCE_TAGGER_PARAMETERS,
     TRAINING_PARAMETERS,
     Parameter,
@@ -14,7 +14,7 @@ __all__ = [
     "Parameter",
     "SEQUENCE_TAGGER_PARAMETERS",
     "TRAINING_PARAMETERS",
-    "DOCUMENT_EMBEDDING_PARAMETERS",
+    "TEXT_CLASSIFICATION_PARAMETERS",
     "SequenceTaggerParamSelector",
     "TextClassifierParamSelector",
     "SearchSpace",

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -81,15 +81,15 @@ class ParamSelector(object):
             log.info(f"\t{k}: {str(v)}")
         log_line(log)
 
-        for sent in self.corpus.get_all_sentences():
-            sent.clear_embeddings()
-
         scores = []
         vars = []
 
         for i in range(0, self.training_runs):
             log_line(log)
             log.info(f"Training run: {i + 1}")
+
+            for sent in self.corpus.get_all_sentences():
+                sent.clear_embeddings()
 
             model = self._set_up_model(params)
 

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -1,0 +1,277 @@
+import logging
+from abc import abstractmethod
+from enum import Enum
+from pathlib import Path
+from typing import Tuple, Union
+import numpy as np
+
+from hyperopt import hp, fmin, tpe
+
+import flair.nn
+from flair.data import Corpus
+from flair.embeddings import DocumentPoolEmbeddings, DocumentRNNEmbeddings
+from flair.hyperparameter import Parameter
+from flair.hyperparameter.parameter import (
+    SEQUENCE_TAGGER_PARAMETERS,
+    TRAINING_PARAMETERS,
+    DOCUMENT_EMBEDDING_PARAMETERS,
+    MODEL_TRAINER_PARAMETERS,
+)
+from flair.models import SequenceTagger, TextClassifier
+from flair.trainers import ModelTrainer
+from flair.training_utils import (
+    EvaluationMetric,
+    log_line,
+    init_output_file,
+    add_file_handler,
+)
+
+log = logging.getLogger("flair")
+
+
+class OptimizationValue(Enum):
+    DEV_LOSS = "loss"
+    DEV_SCORE = "score"
+
+
+class SearchSpace(object):
+    def __init__(self):
+        self.search_space = {}
+
+    def add(self, parameter: Parameter, func, **kwargs):
+        self.search_space[parameter.value] = func(parameter.value, **kwargs)
+
+    def get_search_space(self):
+        return hp.choice("parameters", [self.search_space])
+
+
+class ParamSelector(object):
+    def __init__(
+        self,
+        corpus: Corpus,
+        base_path: Union[str, Path],
+        max_epochs: int,
+        evaluation_metric: EvaluationMetric,
+        training_runs: int,
+        optimization_value: OptimizationValue,
+    ):
+        if type(base_path) is str:
+            base_path = Path(base_path)
+
+        self.corpus = corpus
+        self.max_epochs = max_epochs
+        self.base_path = base_path
+        self.evaluation_metric = evaluation_metric
+        self.run = 1
+        self.training_runs = training_runs
+        self.optimization_value = optimization_value
+
+        self.param_selection_file = init_output_file(base_path, "param_selection.txt")
+
+    @abstractmethod
+    def _set_up_model(self, params: dict) -> flair.nn.Model:
+        pass
+
+    def _objective(self, params: dict):
+        log_line(log)
+        log.info(f"Evaluation run: {self.run}")
+        log.info(f"Evaluating parameter combination:")
+        for k, v in params.items():
+            if isinstance(v, Tuple):
+                v = ",".join([str(x) for x in v])
+            log.info(f"\t{k}: {str(v)}")
+        log_line(log)
+
+        for sent in self.corpus.get_all_sentences():
+            sent.clear_embeddings()
+
+        scores = []
+        vars = []
+
+        for i in range(0, self.training_runs):
+            log_line(log)
+            log.info(f"Training run: {i + 1}")
+
+            model = self._set_up_model(params)
+
+            training_params = {
+                key: params[key] for key in params if key in TRAINING_PARAMETERS
+            }
+            model_trainer_parameters = {
+                key: params[key] for key in params if key in MODEL_TRAINER_PARAMETERS
+            }
+
+            trainer: ModelTrainer = ModelTrainer(
+                model, self.corpus, **model_trainer_parameters
+            )
+
+            result = trainer.train(
+                self.base_path,
+                max_epochs=self.max_epochs,
+                param_selection_mode=True,
+                **training_params,
+            )
+
+            # take the average over the last three scores of training
+            if self.optimization_value == OptimizationValue.DEV_LOSS:
+                curr_scores = result["dev_loss_history"][-3:]
+            else:
+                curr_scores = list(
+                    map(lambda s: 1 - s, result["dev_score_history"][-3:])
+                )
+
+            score = sum(curr_scores) / float(len(curr_scores))
+            var = np.var(curr_scores)
+            scores.append(score)
+            vars.append(var)
+
+        # take average over the scores from the different training runs
+        final_score = sum(scores) / float(len(scores))
+        final_var = sum(vars) / float(len(vars))
+
+        test_score = result["test_score"]
+        log_line(log)
+        log.info(f"Done evaluating parameter combination:")
+        for k, v in params.items():
+            if isinstance(v, Tuple):
+                v = ",".join([str(x) for x in v])
+            log.info(f"\t{k}: {v}")
+        log.info(f"{self.optimization_value.value}: {final_score}")
+        log.info(f"variance: {final_var}")
+        log.info(f"test_score: {test_score}\n")
+        log_line(log)
+
+        with open(self.param_selection_file, "a") as f:
+            f.write(f"evaluation run {self.run}\n")
+            for k, v in params.items():
+                if isinstance(v, Tuple):
+                    v = ",".join([str(x) for x in v])
+                f.write(f"\t{k}: {str(v)}\n")
+            f.write(f"{self.optimization_value.value}: {final_score}\n")
+            f.write(f"variance: {final_var}\n")
+            f.write(f"test_score: {test_score}\n")
+            f.write("-" * 100 + "\n")
+
+        self.run += 1
+
+        return {"status": "ok", "loss": final_score, "loss_variance": final_var}
+
+    def optimize(self, space: SearchSpace, max_evals=100):
+        search_space = space.search_space
+        best = fmin(
+            self._objective, search_space, algo=tpe.suggest, max_evals=max_evals
+        )
+
+        log_line(log)
+        log.info("Optimizing parameter configuration done.")
+        log.info("Best parameter configuration found:")
+        for k, v in best.items():
+            log.info(f"\t{k}: {v}")
+        log_line(log)
+
+        with open(self.param_selection_file, "a") as f:
+            f.write("best parameter combination\n")
+            for k, v in best.items():
+                if isinstance(v, Tuple):
+                    v = ",".join([str(x) for x in v])
+                f.write(f"\t{k}: {str(v)}\n")
+
+
+class SequenceTaggerParamSelector(ParamSelector):
+    def __init__(
+        self,
+        corpus: Corpus,
+        tag_type: str,
+        base_path: Union[str, Path],
+        max_epochs: int = 50,
+        evaluation_metric: EvaluationMetric = EvaluationMetric.MICRO_F1_SCORE,
+        training_runs: int = 1,
+        optimization_value: OptimizationValue = OptimizationValue.DEV_LOSS,
+    ):
+        """
+        :param corpus: the corpus
+        :param tag_type: tag type to use
+        :param base_path: the path to the result folder (results will be written to that folder)
+        :param max_epochs: number of epochs to perform on every evaluation run
+        :param evaluation_metric: evaluation metric used during training
+        :param training_runs: number of training runs per evaluation run
+        :param optimization_value: value to optimize
+        """
+        super().__init__(
+            corpus,
+            base_path,
+            max_epochs,
+            evaluation_metric,
+            training_runs,
+            optimization_value,
+        )
+
+        self.tag_type = tag_type
+        self.tag_dictionary = self.corpus.make_label_dictionary(self.tag_type)
+
+    def _set_up_model(self, params: dict):
+        sequence_tagger_params = {
+            key: params[key] for key in params if key in SEQUENCE_TAGGER_PARAMETERS
+        }
+
+        tagger: SequenceTagger = SequenceTagger(
+            tag_dictionary=self.tag_dictionary,
+            tag_type=self.tag_type,
+            **sequence_tagger_params,
+        )
+        return tagger
+
+
+class TextClassifierParamSelector(ParamSelector):
+    def __init__(
+        self,
+        corpus: Corpus,
+        multi_label: bool,
+        base_path: Union[str, Path],
+        document_embedding_type: str,
+        max_epochs: int = 50,
+        evaluation_metric: EvaluationMetric = EvaluationMetric.MICRO_F1_SCORE,
+        training_runs: int = 1,
+        optimization_value: OptimizationValue = OptimizationValue.DEV_LOSS,
+    ):
+        """
+        :param corpus: the corpus
+        :param multi_label: true, if the dataset is multi label, false otherwise
+        :param base_path: the path to the result folder (results will be written to that folder)
+        :param document_embedding_type: either 'lstm', 'mean', 'min', or 'max'
+        :param max_epochs: number of epochs to perform on every evaluation run
+        :param evaluation_metric: evaluation metric used during training
+        :param training_runs: number of training runs per evaluation run
+        :param optimization_value: value to optimize
+        """
+        super().__init__(
+            corpus,
+            base_path,
+            max_epochs,
+            evaluation_metric,
+            training_runs,
+            optimization_value,
+        )
+
+        self.multi_label = multi_label
+        self.document_embedding_type = document_embedding_type
+
+        self.label_dictionary = self.corpus.make_label_dictionary()
+
+    def _set_up_model(self, params: dict):
+        embdding_params = {
+            key: params[key] for key in params if key in DOCUMENT_EMBEDDING_PARAMETERS
+        }
+
+        if self.document_embedding_type == "lstm":
+            document_embedding = DocumentRNNEmbeddings(**embdding_params)
+        else:
+            document_embedding = DocumentPoolEmbeddings(**embdding_params)
+
+        text_classifier: TextClassifier = TextClassifier(
+            label_dictionary=self.label_dictionary,
+            multi_label=self.multi_label,
+            document_embeddings=document_embedding,
+        )
+
+        return text_classifier

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -11,8 +11,8 @@ import flair.nn
 from flair.data import Corpus
 from flair.embeddings import TransformerDocumentEmbeddings
 from flair.hyperparameter.parameter import (
-    TEXT_CLASSIFICATION_PARAMETERS,
     SEQUENCE_TAGGER_PARAMETERS,
+    TEXT_CLASSIFICATION_PARAMETERS,
     TRAINING_PARAMETERS,
     Parameter,
 )
@@ -241,8 +241,7 @@ class TextClassifierParamSelector(ParamSelector):
         self.label_dictionary = self.corpus.make_label_dictionary(self.label_type)
 
     def _set_up_model(self, params: dict):
-        text_classification_params = {
-            key: params[key] for key in params if key in TEXT_CLASSIFICATION_PARAMETERS}
+        text_classification_params = {key: params[key] for key in params if key in TEXT_CLASSIFICATION_PARAMETERS}
 
         document_embedding = TransformerDocumentEmbeddings(**text_classification_params)
 

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -211,6 +211,7 @@ class TextClassifierParamSelector(ParamSelector):
         multi_label: bool,
         base_path: Union[str, Path],
         max_epochs: int = 50,
+        fine_tune: bool = True,
         evaluation_metric: EvaluationMetric = EvaluationMetric.MICRO_F1_SCORE,
         training_runs: int = 1,
         optimization_value: OptimizationValue = OptimizationValue.DEV_LOSS,
@@ -222,6 +223,7 @@ class TextClassifierParamSelector(ParamSelector):
         :param multi_label: true, if the dataset is multi label, false otherwise
         :param base_path: the path to the result folder (results will be written to that folder)
         :param max_epochs: number of epochs to perform on every evaluation run
+        :param fine_tune: if True, allows transformers to be fine-tuned during training
         :param evaluation_metric: evaluation metric used during training
         :param training_runs: number of training runs per evaluation run
         :param optimization_value: value to optimize
@@ -237,13 +239,14 @@ class TextClassifierParamSelector(ParamSelector):
 
         self.multi_label = multi_label
         self.label_type = label_type
+        self.fine_tune = fine_tune
 
         self.label_dictionary = self.corpus.make_label_dictionary(self.label_type)
 
     def _set_up_model(self, params: dict):
         text_classification_params = {key: params[key] for key in params if key in TEXT_CLASSIFICATION_PARAMETERS}
 
-        document_embedding = TransformerDocumentEmbeddings(**text_classification_params)
+        document_embedding = TransformerDocumentEmbeddings(fine_tune=self.fine_tune, **text_classification_params)
 
         text_classifier: TextClassifier = TextClassifier(
             label_dictionary=self.label_dictionary,

--- a/flair/hyperparameter/parameter.py
+++ b/flair/hyperparameter/parameter.py
@@ -1,0 +1,66 @@
+from enum import Enum
+
+
+class Parameter(Enum):
+    EMBEDDINGS = "embeddings"
+    HIDDEN_SIZE = "hidden_size"
+    USE_CRF = "use_crf"
+    USE_RNN = "use_rnn"
+    RNN_LAYERS = "rnn_layers"
+    DROPOUT = "dropout"
+    WORD_DROPOUT = "word_dropout"
+    LOCKED_DROPOUT = "locked_dropout"
+    LEARNING_RATE = "learning_rate"
+    MINI_BATCH_SIZE = "mini_batch_size"
+    ANNEAL_FACTOR = "anneal_factor"
+    ANNEAL_WITH_RESTARTS = "anneal_with_restarts"
+    PATIENCE = "patience"
+    REPROJECT_WORDS = "reproject_words"
+    REPROJECT_WORD_DIMENSION = "reproject_words_dimension"
+    BIDIRECTIONAL = "bidirectional"
+    OPTIMIZER = "optimizer"
+    MOMENTUM = "momentum"
+    DAMPENING = "dampening"
+    WEIGHT_DECAY = "weight_decay"
+    NESTEROV = "nesterov"
+    AMSGRAD = "amsgrad"
+    BETAS = "betas"
+    EPS = "eps"
+
+
+TRAINING_PARAMETERS = [
+    Parameter.LEARNING_RATE.value,
+    Parameter.MINI_BATCH_SIZE.value,
+    Parameter.ANNEAL_FACTOR.value,
+    Parameter.PATIENCE.value,
+    Parameter.ANNEAL_WITH_RESTARTS.value,
+    Parameter.MOMENTUM.value,
+    Parameter.DAMPENING.value,
+    Parameter.WEIGHT_DECAY.value,
+    Parameter.NESTEROV.value,
+    Parameter.AMSGRAD.value,
+    Parameter.BETAS.value,
+    Parameter.EPS.value,
+]
+SEQUENCE_TAGGER_PARAMETERS = [
+    Parameter.EMBEDDINGS.value,
+    Parameter.HIDDEN_SIZE.value,
+    Parameter.RNN_LAYERS.value,
+    Parameter.USE_CRF.value,
+    Parameter.USE_RNN.value,
+    Parameter.DROPOUT.value,
+    Parameter.LOCKED_DROPOUT.value,
+    Parameter.WORD_DROPOUT.value,
+]
+MODEL_TRAINER_PARAMETERS = [Parameter.OPTIMIZER.value]
+DOCUMENT_EMBEDDING_PARAMETERS = [
+    Parameter.EMBEDDINGS.value,
+    Parameter.HIDDEN_SIZE.value,
+    Parameter.RNN_LAYERS.value,
+    Parameter.REPROJECT_WORDS.value,
+    Parameter.REPROJECT_WORD_DIMENSION.value,
+    Parameter.BIDIRECTIONAL.value,
+    Parameter.DROPOUT.value,
+    Parameter.LOCKED_DROPOUT.value,
+    Parameter.WORD_DROPOUT.value,
+]

--- a/flair/hyperparameter/parameter.py
+++ b/flair/hyperparameter/parameter.py
@@ -31,6 +31,7 @@ class Parameter(Enum):
 TRAINING_PARAMETERS = [
     Parameter.LEARNING_RATE.value,
     Parameter.MINI_BATCH_SIZE.value,
+    Parameter.OPTIMIZER.value,
     Parameter.ANNEAL_FACTOR.value,
     Parameter.PATIENCE.value,
     Parameter.ANNEAL_WITH_RESTARTS.value,
@@ -52,7 +53,6 @@ SEQUENCE_TAGGER_PARAMETERS = [
     Parameter.LOCKED_DROPOUT.value,
     Parameter.WORD_DROPOUT.value,
 ]
-MODEL_TRAINER_PARAMETERS = [Parameter.OPTIMIZER.value]
 DOCUMENT_EMBEDDING_PARAMETERS = [
     Parameter.EMBEDDINGS.value,
     Parameter.HIDDEN_SIZE.value,

--- a/flair/hyperparameter/parameter.py
+++ b/flair/hyperparameter/parameter.py
@@ -24,7 +24,6 @@ class Parameter(Enum):
     BETAS = "betas"
     EPS = "eps"
     TRANSFORMER_MODEL = "model"
-    FINE_TUNE = "fine_tune"
     LAYERS = "LAYERS"
 
 
@@ -56,5 +55,4 @@ SEQUENCE_TAGGER_PARAMETERS = [
 TEXT_CLASSIFICATION_PARAMETERS = [
     Parameter.LAYERS.value,
     Parameter.TRANSFORMER_MODEL.value,
-    Parameter.FINE_TUNE.value,
 ]

--- a/flair/hyperparameter/parameter.py
+++ b/flair/hyperparameter/parameter.py
@@ -23,9 +23,9 @@ class Parameter(Enum):
     AMSGRAD = "amsgrad"
     BETAS = "betas"
     EPS = "eps"
-    TRANSFORMER_MODEL = 'model'
-    FINE_TUNE = 'fine_tune'
-    LAYERS = 'LAYERS'
+    TRANSFORMER_MODEL = "model"
+    FINE_TUNE = "fine_tune"
+    LAYERS = "LAYERS"
 
 
 TRAINING_PARAMETERS = [

--- a/flair/hyperparameter/parameter.py
+++ b/flair/hyperparameter/parameter.py
@@ -15,9 +15,6 @@ class Parameter(Enum):
     ANNEAL_FACTOR = "anneal_factor"
     ANNEAL_WITH_RESTARTS = "anneal_with_restarts"
     PATIENCE = "patience"
-    REPROJECT_WORDS = "reproject_words"
-    REPROJECT_WORD_DIMENSION = "reproject_words_dimension"
-    BIDIRECTIONAL = "bidirectional"
     OPTIMIZER = "optimizer"
     MOMENTUM = "momentum"
     DAMPENING = "dampening"
@@ -26,6 +23,9 @@ class Parameter(Enum):
     AMSGRAD = "amsgrad"
     BETAS = "betas"
     EPS = "eps"
+    TRANSFORMER_MODEL = 'model'
+    FINE_TUNE = 'fine_tune'
+    LAYERS = 'LAYERS'
 
 
 TRAINING_PARAMETERS = [
@@ -53,14 +53,8 @@ SEQUENCE_TAGGER_PARAMETERS = [
     Parameter.LOCKED_DROPOUT.value,
     Parameter.WORD_DROPOUT.value,
 ]
-DOCUMENT_EMBEDDING_PARAMETERS = [
-    Parameter.EMBEDDINGS.value,
-    Parameter.HIDDEN_SIZE.value,
-    Parameter.RNN_LAYERS.value,
-    Parameter.REPROJECT_WORDS.value,
-    Parameter.REPROJECT_WORD_DIMENSION.value,
-    Parameter.BIDIRECTIONAL.value,
-    Parameter.DROPOUT.value,
-    Parameter.LOCKED_DROPOUT.value,
-    Parameter.WORD_DROPOUT.value,
+TEXT_CLASSIFICATION_PARAMETERS = [
+    Parameter.LAYERS.value,
+    Parameter.TRANSFORMER_MODEL.value,
+    Parameter.FINE_TUNE.value,
 ]

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -933,19 +933,21 @@ class ModelTrainer:
         self,
         base_path: Union[Path, str],
         optimizer,
-        mini_batch_size: int = 32,
+        file_name: str = "learning_rate.tsv",
         start_learning_rate: float = 1e-7,
         end_learning_rate: float = 10,
-        iterations: int = 1000,
+        iterations: int = 100,
+        mini_batch_size: int = 32,
         stop_early: bool = True,
-        file_name: str = "learning_rate.tsv",
+        smoothing_factor: float = 0.98,
         **kwargs,
     ) -> Path:
         best_loss = None
+        moving_avg_loss = 0.0
 
         # cast string to Path
-        base_path = Path(base_path)
-        base_path.mkdir(exist_ok=True, parents=True)
+        if type(base_path) is str:
+            base_path = Path(base_path)
         learning_rate_tsv = init_output_file(base_path, file_name)
 
         with open(learning_rate_tsv, "a") as f:
@@ -961,14 +963,8 @@ class ModelTrainer:
         self.model.train()
 
         step = 0
-
-        loss_list = []
-        average_loss_list = []
-
         while step < iterations:
-
             batch_loader = DataLoader(train_data, batch_size=mini_batch_size, shuffle=True)
-
             for batch in batch_loader:
                 step += 1
 
@@ -982,38 +978,31 @@ class ModelTrainer:
                 loss.backward()
                 torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
                 optimizer.step()
-                scheduler.step()
+                scheduler.step(step)
 
                 learning_rate = scheduler.get_lr()[0]
 
-                # append current loss to list of losses for all iterations
-                loss_list.append(loss.item())
-
-                # compute averaged loss
-                import statistics
-
-                moving_avg_loss = statistics.mean(loss_list)
-                average_loss_list.append(moving_avg_loss)
-
-                if len(average_loss_list) > 10:
-                    drop = average_loss_list[-10] - moving_avg_loss
+                loss_item = loss.item()
+                if step == 1:
+                    best_loss = loss_item
                 else:
-                    drop = 0.0
-
-                if not best_loss or moving_avg_loss < best_loss:
-                    best_loss = moving_avg_loss
+                    if smoothing_factor > 0:
+                        moving_avg_loss = smoothing_factor * moving_avg_loss + (1 - smoothing_factor) * loss_item
+                        loss_item = moving_avg_loss / (1 - smoothing_factor ** (step + 1))
+                    if loss_item < best_loss:  # type: ignore
+                        best_loss = loss  # type: ignore
 
                 if step > iterations:
                     break
 
-                if stop_early and (moving_avg_loss > 4 * best_loss or torch.isnan(loss)):
+                if stop_early and (loss_item > 4 * best_loss or torch.isnan(loss)):  # type: ignore
                     log_line(log)
                     log.info("loss diverged - stopping early!")
                     step = iterations
                     break
 
                 with open(str(learning_rate_tsv), "a") as f:
-                    f.write(f"{step}\t{learning_rate}\t{loss.item()}" f"\t{moving_avg_loss}\t{drop}\n")
+                    f.write(f"{step}\t{datetime.datetime.now():%H:%M:%S}\t{learning_rate}\t{loss_item}\n")
 
             self.model.load_state_dict(model_state)
             self.model.to(flair.device)

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -978,7 +978,7 @@ class ModelTrainer:
                 loss.backward()
                 torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
                 optimizer.step()
-                scheduler.step(step)
+                scheduler.step()
 
                 learning_rate = scheduler.get_lr()[0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,11 @@ exclude = '''
 [tool.pytest.ini_options]
 flake8-max-line-length = 210
 flake8-ignore = ["E203", "W503"]  # See https://github.com/PyCQA/pycodestyle/issues/373
-addopts = "-W error --flake8 --mypy --ignore flair/data_fetcher.py --ignore flair/embeddings/legacy.py --isort"
+addopts = "--flake8 --mypy --ignore flair/data_fetcher.py --ignore flair/embeddings/legacy.py --isort"
+filterwarnings = [
+    "error",  # Convert all warnings to errors
+    "ignore:the imp module is deprecated:DeprecationWarning:past"  # ignore DeprecationWarning from hyperopt dependency
+]
 markers = [
     "integration",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ mpld3==0.3
 scikit-learn>=0.21.3
 sqlitedict>=1.6.0
 deprecated>=1.2.4
+hyperopt>=0.2.7
 transformers>=4.0.0
 bpemb>=0.3.2
 regex

--- a/resources/docs/KOR_docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
+++ b/resources/docs/KOR_docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
@@ -20,6 +20,7 @@ corpus = TREC_6()
 
 ```python
 from hyperopt import hp
+from flair.embeddings import FlairEmbeddings, WordEmbeddings
 from flair.hyperparameter.param_selection import SearchSpace, Parameter
 # 검색 공간을 정의하세요.
 search_space = SearchSpace()
@@ -54,8 +55,12 @@ hyperopt가 수행해야 하는 최대 평가 실행 횟수를 정의할 수 있
 ```python
 from flair.hyperparameter.param_selection import TextClassifierParamSelector, OptimizationValue
 # 매개변수 선택기 생성
+
+label_type = 'question_class'
+
 param_selector = TextClassifierParamSelector(
-    corpus, 
+    corpus,
+    label_type,
     False, 
     'resources/results', 
     'lstm',
@@ -90,6 +95,7 @@ from flair.datasets import WNUT_17
 from flair.embeddings import TokenEmbeddings, WordEmbeddings, StackedEmbeddings
 from flair.trainers import ModelTrainer
 from typing import List
+from torch.optim.adam import Adam
 # 1. 말뭉치 가져오기
 corpus = WNUT_17().downsample(0.1)
 print(corpus)
@@ -113,27 +119,11 @@ tagger: SequenceTagger = SequenceTagger(hidden_size=256,
 # 6. 트레이너 초기화하기
 trainer: ModelTrainer = ModelTrainer(tagger, corpus)
 # 7. 학습률 찾기
-learning_rate_tsv = trainer.find_learning_rate('resources/taggers/example-ner',
-                                                    'learning_rate.tsv')
+learning_rate_tsv = trainer.find_learning_rate('resources/taggers/example-ner', Adam)
 # 8. 학습률 찾기 곡선 그리기
 from flair.visual.training_curves import Plotter
 plotter = Plotter()
 plotter.plot_learning_rate(learning_rate_tsv)
-```
-
-## Custom Optimizers
-
-이제 'ModelTrainer'를 초기화할 때 PyTorch의 최적화 프로그램을 훈련에 사용할 수 있습니다. 옵티마이저에 추가 옵션을 제공하려면 `weight_decay` 예제와 같이 지정하기만 하면 됩니다:
-
-```python
-from torch.optim.adam import Adam
-trainer = ModelTrainer(tagger, corpus,
-                       optimizer=Adam)
-                                     
-trainer.train(
-    "resources/taggers/example",
-    weight_decay=1e-4
-)
 ```
 
 ## Next

--- a/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
+++ b/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
@@ -1,0 +1,166 @@
+# Tutorial 8: Model Tuning
+
+This is part 8 of the tutorial, in which we look into how we can improve the quality of our model by selecting
+the right set of model and hyper parameters.
+
+## Selecting Hyper Parameters
+
+Flair includes a wrapper for the well-known hyper parameter selection tool
+[hyperopt](https://github.com/hyperopt/hyperopt).
+
+First you need to load your corpus. If you want to load the [AGNews corpus](https://www.di.unipi.it/~gulli/AG_corpus_of_news_articles.html)
+used in the following example, you first need to download it and convert it into the correct format. Please
+check [tutorial 6](/resources/docs/TUTORIAL_6_CORPUS.md) for more details.
+```python
+from flair.datasets import TREC_6
+
+# load your corpus
+corpus = TREC_6()
+```
+
+Second you need to define the search space of parameters.
+Therefore, you can use all
+[parameter expressions](https://github.com/hyperopt/hyperopt/wiki/FMin#21-parameter-expressions) defined by hyperopt.
+
+```python
+from hyperopt import hp
+from flair.hyperparameter.param_selection import SearchSpace, Parameter
+
+# define your search space
+search_space = SearchSpace()
+search_space.add(Parameter.EMBEDDINGS, hp.choice, options=[
+    [ WordEmbeddings('en') ], 
+    [ FlairEmbeddings('news-forward'), FlairEmbeddings('news-backward') ]
+])
+search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[32, 64, 128])
+search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
+search_space.add(Parameter.DROPOUT, hp.uniform, low=0.0, high=0.5)
+search_space.add(Parameter.LEARNING_RATE, hp.choice, options=[0.05, 0.1, 0.15, 0.2])
+search_space.add(Parameter.MINI_BATCH_SIZE, hp.choice, options=[8, 16, 32])
+```
+
+Attention: You should always add your embeddings to the search space (as shown above). If you don't want to test
+different kind of embeddings, simply pass just one embedding option to the search space, which will then be used in
+every test run. Here is an example:
+```python
+search_space.add(Parameter.EMBEDDINGS, hp.choice, options=[
+    [ FlairEmbeddings('news-forward'), FlairEmbeddings('news-backward') ]
+])
+```
+
+In the last step you have to create the actual parameter selector. 
+Depending on the task you need either to define a `TextClassifierParamSelector` or a `SequenceTaggerParamSelector` and 
+start the optimization.
+You can define the maximum number of evaluation runs hyperopt should perform (`max_evals`).
+A evaluation run performs the specified number of epochs (`max_epochs`). 
+To overcome the issue of noisy evaluation scores, we take the average over the last three evaluation scores (either
+`dev_score` or `dev_loss`) from the evaluation run, which represents the final score and will be passed to hyperopt.
+Additionally, you can specify the number of runs per evaluation run (`training_runs`). 
+If you specify more than one training run, one evaluation run will be executed the specified number of times.
+The final evaluation score will be the average over all those runs.
+
+```python
+from flair.hyperparameter.param_selection import TextClassifierParamSelector, OptimizationValue
+
+# create the parameter selector
+param_selector = TextClassifierParamSelector(
+    corpus, 
+    False, 
+    'resources/results', 
+    'lstm',
+    max_epochs=50, 
+    training_runs=3,
+    optimization_value=OptimizationValue.DEV_SCORE
+)
+
+# start the optimization
+param_selector.optimize(search_space, max_evals=100)
+```
+
+The parameter settings and the evaluation scores will be written to `param_selection.txt` in the result directory.
+While selecting the best parameter combination we do not store any model to disk. We also do not perform a test run
+during training, we just evaluate the model once after training on the test set for logging purpose.
+
+## Finding the best Learning Rate
+
+The learning rate is one of the most important hyper parameter and it fundamentally depends on the topology of the loss
+landscape via the architecture of your model and the training data it consumes. An optimal learning will improve your
+training speed and hopefully give more performant models. A simple technique described by Leslie Smith's
+[Cyclical Learning Rates for Training](https://arxiv.org/abs/1506.01186) paper is to train your model starting with a
+very low learning rate and increases the learning rate exponentially at every batch update of SGD. By plotting the loss
+with respect to the learning rate we will typically observe three distinct phases: for low learning rates the loss does
+not improve, an optimal learning rate range where the loss drops the steepest and the final phase where the loss
+explodes as the learning rate becomes too big. With such a plot, the optimal learning rate selection is as easy as
+picking the highest one from the optimal phase.
+
+In order to run such an experiment start with your initialized `ModelTrainer` and call `find_learning_rate()` with the
+`base_path` and the file name in which to records the learning rates and losses. Then plot the generated results via the
+`Plotter`'s `plot_learning_rate()` function and have a look at the `learning_rate.png` image to select the optimal
+learning rate:
+
+```python
+from flair.datasets import WNUT_17
+from flair.embeddings import TokenEmbeddings, WordEmbeddings, StackedEmbeddings
+from flair.trainers import ModelTrainer
+from typing import List
+
+# 1. get the corpus
+corpus = WNUT_17().downsample(0.1)
+print(corpus)
+
+# 2. what tag do we want to predict?
+tag_type = 'ner'
+
+# 3. make the tag dictionary from the corpus
+tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
+print(tag_dictionary.idx2item)
+
+# 4. initialize embeddings
+embedding_types: List[TokenEmbeddings] = [
+    WordEmbeddings('glove'),
+]
+
+embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)
+
+# 5. initialize sequence tagger
+from flair.models import SequenceTagger
+
+tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+                                        embeddings=embeddings,
+                                        tag_dictionary=tag_dictionary,
+                                        tag_type=tag_type,
+                                        use_crf=True)
+
+# 6. initialize trainer
+trainer: ModelTrainer = ModelTrainer(tagger, corpus)
+
+# 7. find learning rate
+learning_rate_tsv = trainer.find_learning_rate('resources/taggers/example-ner',
+                                                    'learning_rate.tsv')
+
+# 8. plot the learning rate finder curve
+from flair.visual.training_curves import Plotter
+plotter = Plotter()
+plotter.plot_learning_rate(learning_rate_tsv)
+```
+
+## Custom Optimizers
+
+You can now use any of PyTorch's optimizers for training when initializing a `ModelTrainer`. To give the optimizer any
+extra options just specify it as shown with the `weight_decay` example:
+
+```python
+from torch.optim.adam import Adam
+
+trainer = ModelTrainer(tagger, corpus,
+                       optimizer=Adam)
+                                     
+trainer.train(
+    "resources/taggers/example",
+    weight_decay=1e-4
+)
+```
+
+## Next
+
+The last tutorial is about [training your own embeddings](/resources/docs/TUTORIAL_9_TRAINING_LM_EMBEDDINGS.md).

--- a/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
+++ b/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
@@ -24,6 +24,7 @@ Therefore, you can use all
 
 ```python
 from hyperopt import hp
+from flair.embeddings import FlairEmbeddings, WordEmbeddings
 from flair.hyperparameter.param_selection import SearchSpace, Parameter
 
 # define your search space
@@ -62,9 +63,13 @@ The final evaluation score will be the average over all those runs.
 ```python
 from flair.hyperparameter.param_selection import TextClassifierParamSelector, OptimizationValue
 
+# what label do we want to predict?
+label_type = 'question_class'
+
 # create the parameter selector
 param_selector = TextClassifierParamSelector(
-    corpus, 
+    corpus,
+    label_type, 
     False, 
     'resources/results', 
     'lstm',
@@ -94,7 +99,7 @@ explodes as the learning rate becomes too big. With such a plot, the optimal lea
 picking the highest one from the optimal phase.
 
 In order to run such an experiment start with your initialized `ModelTrainer` and call `find_learning_rate()` with the
-`base_path` and the file name in which to records the learning rates and losses. Then plot the generated results via the
+`base_path` and the optimizer (in our case `torch.optim.adam.Adam`). Then plot the generated results via the
 `Plotter`'s `plot_learning_rate()` function and have a look at the `learning_rate.png` image to select the optimal
 learning rate:
 
@@ -103,6 +108,7 @@ from flair.datasets import WNUT_17
 from flair.embeddings import TokenEmbeddings, WordEmbeddings, StackedEmbeddings
 from flair.trainers import ModelTrainer
 from typing import List
+from torch.optim.adam import Adam
 
 # 1. get the corpus
 corpus = WNUT_17().downsample(0.1)
@@ -135,8 +141,7 @@ tagger: SequenceTagger = SequenceTagger(hidden_size=256,
 trainer: ModelTrainer = ModelTrainer(tagger, corpus)
 
 # 7. find learning rate
-learning_rate_tsv = trainer.find_learning_rate('resources/taggers/example-ner',
-                                                    'learning_rate.tsv')
+learning_rate_tsv = trainer.find_learning_rate('resources/taggers/example-ner', Adam)
 
 # 8. plot the learning rate finder curve
 from flair.visual.training_curves import Plotter
@@ -144,22 +149,7 @@ plotter = Plotter()
 plotter.plot_learning_rate(learning_rate_tsv)
 ```
 
-## Custom Optimizers
-
-You can now use any of PyTorch's optimizers for training when initializing a `ModelTrainer`. To give the optimizer any
-extra options just specify it as shown with the `weight_decay` example:
-
-```python
-from torch.optim.adam import Adam
-
-trainer = ModelTrainer(tagger, corpus,
-                       optimizer=Adam)
-                                     
-trainer.train(
-    "resources/taggers/example",
-    weight_decay=1e-4
-)
-```
+The learning rates and losses will be written to `learning_rate.tsv`.
 
 ## Next
 

--- a/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
+++ b/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
@@ -77,8 +77,8 @@ training, we just evaluate the model once after training on the test set for log
 Hyperparameter tuning for text classification in Flair uses `TransformerDocumentEmbeddings` and allows
 choosing between a number of parameters. You can tune the `TRANSFORMER_MODEL` parameter that defines the name of
 HuggingFace transformer model used, the `LAYERS` parameter defining which layers to take for embedding (the default
-is -1 - topmost layer) and the `FINE_TUNE` boolean parameter that determines whether the transformers are fine-tuned
-during training.
+is -1 - topmost layer) as well as the usual training-related hyperparameters such as `LEARNING_RATE` and
+`MINI_BATCH_SIZE`.
 
 First, you need to load your corpus.
 ```python
@@ -104,7 +104,6 @@ search_space.add(Parameter.MINI_BATCH_SIZE, hp.choice, options=[8, 16, 32])
 
 # define transformer embedding hyperparameters
 search_space.add(Parameter.TRANSFORMER_MODEL, hp.choice, options=['bert-base-uncased', 'roberta-base'])
-search_space.add(Parameter.FINE_TUNE, hp.choice, options=[True, False])
 ```
 
 Note that the first two hyperparameters affect training whereas the last two affect the transformer document
@@ -126,6 +125,7 @@ param_selector = TextClassifierParamSelector(
     False, 
     'resources/results', 
     max_epochs=50, 
+    fine_tune=True,
     training_runs=3,
     optimization_value=OptimizationValue.DEV_SCORE
 )

--- a/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
+++ b/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
@@ -3,35 +3,33 @@
 This is part 8 of the tutorial, in which we look into how we can improve the quality of our model by selecting
 the right set of model and hyper parameters.
 
-## Selecting Hyper Parameters
-
-Flair includes a wrapper for the well-known hyper parameter selection tool
+Flair features hyperparameter tuning for sequence labelling and text classification as part of a wrapper for
+the well-known hyper parameter selection tool
 [hyperopt](https://github.com/hyperopt/hyperopt).
 
-First you need to load your corpus. If you want to load the [AGNews corpus](https://www.di.unipi.it/~gulli/AG_corpus_of_news_articles.html)
-used in the following example, you first need to download it and convert it into the correct format. Please
-check [tutorial 6](/resources/docs/TUTORIAL_6_CORPUS.md) for more details.
+## Selecting hyperparameters for sequence labelling
+First, you need to load your corpus.
 ```python
-from flair.datasets import TREC_6
+from flair.datasets import WNUT_17
 
-# load your corpus
-corpus = TREC_6()
+# load your corpus and downsample a bit for faster execution of this tutorial
+corpus = WNUT_17().downsample(0.1)
 ```
 
-Second you need to define the search space of parameters.
+Second, you need to define the search space of parameters.
 Therefore, you can use all
 [parameter expressions](https://github.com/hyperopt/hyperopt/wiki/FMin#21-parameter-expressions) defined by hyperopt.
 
 ```python
 from hyperopt import hp
-from flair.embeddings import FlairEmbeddings, WordEmbeddings
+from flair.embeddings import FlairEmbeddings, StackedEmbeddings, WordEmbeddings
 from flair.hyperparameter.param_selection import SearchSpace, Parameter
 
 # define your search space
 search_space = SearchSpace()
 search_space.add(Parameter.EMBEDDINGS, hp.choice, options=[
-    [ WordEmbeddings('en') ], 
-    [ FlairEmbeddings('news-forward'), FlairEmbeddings('news-backward') ]
+    WordEmbeddings('en'),
+    StackedEmbeddings([FlairEmbeddings('news-forward'), FlairEmbeddings('news-backward')])
 ])
 search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[32, 64, 128])
 search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
@@ -42,23 +40,78 @@ search_space.add(Parameter.MINI_BATCH_SIZE, hp.choice, options=[8, 16, 32])
 
 Attention: You should always add your embeddings to the search space (as shown above). If you don't want to test
 different kind of embeddings, simply pass just one embedding option to the search space, which will then be used in
-every test run. Here is an example:
-```python
-search_space.add(Parameter.EMBEDDINGS, hp.choice, options=[
-    [ FlairEmbeddings('news-forward'), FlairEmbeddings('news-backward') ]
-])
-```
+every test run.
 
-In the last step you have to create the actual parameter selector. 
-Depending on the task you need either to define a `TextClassifierParamSelector` or a `SequenceTaggerParamSelector` and 
-start the optimization.
+In the last step you have to create the actual parameter selector using the `SequenceTaggerParamSelector` class
+and start the optimization.
+
 You can define the maximum number of evaluation runs hyperopt should perform (`max_evals`).
-A evaluation run performs the specified number of epochs (`max_epochs`). 
+A evaluation run performs the specified number of epochs (`max_epochs`).
 To overcome the issue of noisy evaluation scores, we take the average over the last three evaluation scores (either
 `dev_score` or `dev_loss`) from the evaluation run, which represents the final score and will be passed to hyperopt.
-Additionally, you can specify the number of runs per evaluation run (`training_runs`). 
+Additionally, you can specify the number of runs per evaluation run (`training_runs`).
 If you specify more than one training run, one evaluation run will be executed the specified number of times.
 The final evaluation score will be the average over all those runs.
+
+```python
+from flair.hyperparameter.param_selection import SequenceTaggerParamSelector
+
+# create the parameter selector
+param_selector = SequenceTaggerParamSelector(corpus,
+                                             'ner',
+                                             'resources/results',
+                                             training_runs=3,
+                                             max_epochs=50
+)
+
+# start the optimization
+param_selector.optimize(search_space, max_evals=100)
+```
+
+The parameter settings and the evaluation scores will be written to param_selection.txt in the result directory. While
+selecting the best parameter combination we do not store any model to disk. We also do not perform a test run during
+training, we just evaluate the model once after training on the test set for logging purpose.
+
+## Selecting hyperparameters for text classification
+
+Hyperparameter tuning for text classification in Flair uses `TransformerDocumentEmbeddings` and allows
+choosing between a number of parameters. You can tune the `TRANSFORMER_MODEL` parameter that defines the name of
+HuggingFace transformer model used, the `LAYERS` parameter defining which layers to take for embedding (the default
+is -1 - topmost layer) and the `FINE_TUNE` boolean parameter that determines whether the transformers are fine-tuned
+during training.
+
+First, you need to load your corpus.
+```python
+from flair.datasets import TREC_6
+
+# load your corpus
+corpus = TREC_6()
+```
+
+Second, you need to define the search space of parameters.
+Therefore, you can use all
+[parameter expressions](https://github.com/hyperopt/hyperopt/wiki/FMin#21-parameter-expressions) defined by hyperopt.
+
+```python
+from hyperopt import hp
+from flair.hyperparameter.param_selection import SearchSpace, Parameter
+
+search_space = SearchSpace()
+
+# define training hyperparameters
+search_space.add(Parameter.LEARNING_RATE, hp.choice, options=[0.05, 0.1, 0.15, 0.2])
+search_space.add(Parameter.MINI_BATCH_SIZE, hp.choice, options=[8, 16, 32])
+
+# define transformer embedding hyperparameters
+search_space.add(Parameter.TRANSFORMER_MODEL, hp.choice, options=['bert-base-uncased', 'roberta-base'])
+search_space.add(Parameter.FINE_TUNE, hp.choice, options=[True, False])
+```
+
+Note that the first two hyperparameters affect training whereas the last two affect the transformer document
+embeddings.
+
+In the last step you have to create the actual parameter selector using the `TextClassifierParamSelector` class
+and start the optimization.
 
 ```python
 from flair.hyperparameter.param_selection import TextClassifierParamSelector, OptimizationValue
@@ -72,7 +125,6 @@ param_selector = TextClassifierParamSelector(
     label_type, 
     False, 
     'resources/results', 
-    'lstm',
     max_epochs=50, 
     training_runs=3,
     optimization_value=OptimizationValue.DEV_SCORE
@@ -83,8 +135,6 @@ param_selector.optimize(search_space, max_evals=100)
 ```
 
 The parameter settings and the evaluation scores will be written to `param_selection.txt` in the result directory.
-While selecting the best parameter combination we do not store any model to disk. We also do not perform a test run
-during training, we just evaluate the model once after training on the test set for logging purpose.
 
 ## Finding the best Learning Rate
 

--- a/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
+++ b/resources/docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
@@ -168,7 +168,7 @@ print(corpus)
 tag_type = 'ner'
 
 # 3. make the tag dictionary from the corpus
-tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
+tag_dictionary = corpus.make_label_dictionary(label_type=tag_type)
 print(tag_dictionary.idx2item)
 
 # 4. initialize embeddings

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -1,0 +1,92 @@
+import shutil
+
+import pytest
+from hyperopt import hp
+from torch.optim import SGD
+
+from flair.embeddings import WordEmbeddings, StackedEmbeddings, FlairEmbeddings
+from flair.hyperparameter import (
+    SearchSpace,
+    Parameter,
+    SequenceTaggerParamSelector,
+    TextClassifierParamSelector,
+)
+import flair.datasets
+
+glove_embedding: WordEmbeddings = WordEmbeddings("glove")
+
+
+@pytest.mark.skip
+def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
+    corpus = flair.datasets.ColumnCorpus(
+        data_folder=tasks_base_path / "fashion", column_format={0: "text", 3: "ner"}
+    )
+
+    # define search space
+    search_space = SearchSpace()
+
+    # sequence tagger parameter
+    search_space.add(
+        Parameter.EMBEDDINGS,
+        hp.choice,
+        options=[StackedEmbeddings([glove_embedding])],
+    )
+    search_space.add(Parameter.USE_CRF, hp.choice, options=[True, False])
+    search_space.add(Parameter.DROPOUT, hp.uniform, low=0.25, high=0.75)
+    search_space.add(Parameter.WORD_DROPOUT, hp.uniform, low=0.0, high=0.25)
+    search_space.add(Parameter.LOCKED_DROPOUT, hp.uniform, low=0.0, high=0.5)
+    search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[64, 128])
+    search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
+
+    # model trainer parameter
+    search_space.add(Parameter.OPTIMIZER, hp.choice, options=[SGD])
+
+    # training parameter
+    search_space.add(Parameter.MINI_BATCH_SIZE, hp.choice, options=[4, 8, 32])
+    search_space.add(Parameter.LEARNING_RATE, hp.uniform, low=0.01, high=1)
+    search_space.add(Parameter.ANNEAL_FACTOR, hp.uniform, low=0.3, high=0.75)
+    search_space.add(Parameter.PATIENCE, hp.choice, options=[3, 5])
+    search_space.add(Parameter.WEIGHT_DECAY, hp.uniform, low=0.01, high=1)
+
+    # find best parameter settings
+    optimizer = SequenceTaggerParamSelector(
+        corpus, "ner", results_base_path, max_epochs=2
+    )
+    optimizer.optimize(search_space, max_evals=2)
+
+    # clean up results directory
+    shutil.rmtree(results_base_path)
+    del optimizer, search_space
+
+
+@pytest.mark.skip
+def test_text_classifier_param_selector(results_base_path, tasks_base_path):
+    corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
+
+    search_space = SearchSpace()
+
+    # document embeddings parameter
+    search_space.add(Parameter.EMBEDDINGS, hp.choice, options=[[glove_embedding]])
+    search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[64, 128, 256, 512])
+    search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
+    search_space.add(Parameter.REPROJECT_WORDS, hp.choice, options=[True, False])
+    search_space.add(Parameter.REPROJECT_WORD_DIMENSION, hp.choice, options=[64, 128])
+    search_space.add(Parameter.BIDIRECTIONAL, hp.choice, options=[True, False])
+    search_space.add(Parameter.DROPOUT, hp.uniform, low=0.25, high=0.75)
+    search_space.add(Parameter.WORD_DROPOUT, hp.uniform, low=0.25, high=0.75)
+    search_space.add(Parameter.LOCKED_DROPOUT, hp.uniform, low=0.25, high=0.75)
+
+    # training parameter
+    search_space.add(Parameter.LEARNING_RATE, hp.uniform, low=0, high=1)
+    search_space.add(Parameter.MINI_BATCH_SIZE, hp.choice, options=[4, 8, 16, 32])
+    search_space.add(Parameter.ANNEAL_FACTOR, hp.uniform, low=0, high=0.75)
+    search_space.add(Parameter.PATIENCE, hp.choice, options=[3, 5])
+
+    param_selector = TextClassifierParamSelector(
+        corpus, False, results_base_path, document_embedding_type="lstm", max_epochs=2
+    )
+    param_selector.optimize(search_space, max_evals=2)
+
+    # clean up results directory
+    shutil.rmtree(results_base_path)
+    del param_selector, search_space

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -4,23 +4,21 @@ import pytest
 from hyperopt import hp
 from torch.optim import SGD
 
-from flair.embeddings import WordEmbeddings, StackedEmbeddings, FlairEmbeddings
+import flair.datasets
+from flair.embeddings import StackedEmbeddings, WordEmbeddings
 from flair.hyperparameter import (
-    SearchSpace,
     Parameter,
+    SearchSpace,
     SequenceTaggerParamSelector,
     TextClassifierParamSelector,
 )
-import flair.datasets
 
 glove_embedding: WordEmbeddings = WordEmbeddings("glove")
 
 
-@pytest.mark.skip
+@pytest.mark.integration
 def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
-    corpus = flair.datasets.ColumnCorpus(
-        data_folder=tasks_base_path / "fashion", column_format={0: "text", 3: "ner"}
-    )
+    corpus = flair.datasets.ColumnCorpus(data_folder=tasks_base_path / "fashion", column_format={0: "text", 3: "ner"})
 
     # define search space
     search_space = SearchSpace()
@@ -49,9 +47,7 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
     search_space.add(Parameter.WEIGHT_DECAY, hp.uniform, low=0.01, high=1)
 
     # find best parameter settings
-    optimizer = SequenceTaggerParamSelector(
-        corpus, "ner", results_base_path, max_epochs=2
-    )
+    optimizer = SequenceTaggerParamSelector(corpus, "ner", results_base_path, max_epochs=2)
     optimizer.optimize(search_space, max_evals=2)
 
     # clean up results directory
@@ -59,9 +55,10 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
     del optimizer, search_space
 
 
-@pytest.mark.skip
+@pytest.mark.integration
 def test_text_classifier_param_selector(results_base_path, tasks_base_path):
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
+    label_type = "sentiment"
 
     search_space = SearchSpace()
 
@@ -83,7 +80,7 @@ def test_text_classifier_param_selector(results_base_path, tasks_base_path):
     search_space.add(Parameter.PATIENCE, hp.choice, options=[3, 5])
 
     param_selector = TextClassifierParamSelector(
-        corpus, False, results_base_path, document_embedding_type="lstm", max_epochs=2
+        corpus, label_type, False, results_base_path, document_embedding_type="lstm", max_epochs=2
     )
     param_selector.optimize(search_space, max_evals=2)
 

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -63,7 +63,6 @@ def test_text_classifier_param_selector(results_base_path, tasks_base_path):
     search_space = SearchSpace()
 
     # document embeddings parameter
-    search_space.add(Parameter.FINE_TUNE, hp.choice, options=[True, False])
     search_space.add(Parameter.TRANSFORMER_MODEL, hp.choice, options=["albert-base-v1"])
     search_space.add(Parameter.LAYERS, hp.choice, options=["-1", "-2"])
 

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -64,7 +64,7 @@ def test_text_classifier_param_selector(results_base_path, tasks_base_path):
 
     # document embeddings parameter
     search_space.add(Parameter.FINE_TUNE, hp.choice, options=[True, False])
-    search_space.add(Parameter.TRANSFORMER_MODEL, hp.choice, options=["bert-base-uncased", "roberta-base"])
+    search_space.add(Parameter.TRANSFORMER_MODEL, hp.choice, options=["albert-base-v1"])
     search_space.add(Parameter.LAYERS, hp.choice, options=["-1", "-2"])
 
     # training parameter

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -63,15 +63,9 @@ def test_text_classifier_param_selector(results_base_path, tasks_base_path):
     search_space = SearchSpace()
 
     # document embeddings parameter
-    search_space.add(Parameter.EMBEDDINGS, hp.choice, options=[[glove_embedding]])
-    search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[64, 128, 256, 512])
-    search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
-    search_space.add(Parameter.REPROJECT_WORDS, hp.choice, options=[True, False])
-    search_space.add(Parameter.REPROJECT_WORD_DIMENSION, hp.choice, options=[64, 128])
-    search_space.add(Parameter.BIDIRECTIONAL, hp.choice, options=[True, False])
-    search_space.add(Parameter.DROPOUT, hp.uniform, low=0.25, high=0.75)
-    search_space.add(Parameter.WORD_DROPOUT, hp.uniform, low=0.25, high=0.75)
-    search_space.add(Parameter.LOCKED_DROPOUT, hp.uniform, low=0.25, high=0.75)
+    search_space.add(Parameter.FINE_TUNE, hp.choice, options=[True, False])
+    search_space.add(Parameter.TRANSFORMER_MODEL, hp.choice, options=["bert-base-uncased", "roberta-base"])
+    search_space.add(Parameter.LAYERS, hp.choice, options=["-1", "-2"])
 
     # training parameter
     search_space.add(Parameter.LEARNING_RATE, hp.uniform, low=0, high=1)
@@ -79,9 +73,7 @@ def test_text_classifier_param_selector(results_base_path, tasks_base_path):
     search_space.add(Parameter.ANNEAL_FACTOR, hp.uniform, low=0, high=0.75)
     search_space.add(Parameter.PATIENCE, hp.choice, options=[3, 5])
 
-    param_selector = TextClassifierParamSelector(
-        corpus, label_type, False, results_base_path, document_embedding_type="lstm", max_epochs=2
-    )
+    param_selector = TextClassifierParamSelector(corpus, label_type, False, results_base_path, max_epochs=2)
     param_selector.optimize(search_space, max_evals=2)
 
     # clean up results directory


### PR DESCRIPTION
This PR reintroduces hyperparameter tuning in Flair
closes #2632

A number of small changes was required so I split this PR into appropriately named commits where each commit is an isolated change to the code base. For example, there is a separate commit that reverts the deletion or hyperparameter tuning in Flair - this helps us quickly see which code changes are new and which simply reintroduce the old code.

The changes and their corresponding commits include:
1. [Revert "Removes hyperparameter features"](https://github.com/flairNLP/flair/commit/c9591b9482afcd3971497fe88afb14bc394bd516)[](https://github.com/tadejmagajna)  Reverts the removal of all hyperparameter runing code
2. [Updating the param selection docs for the v0.10 syntax](https://github.com/flairNLP/flair/commit/32ebc4c13ddfcebf60a0c8487000d1359a497e86). This updates the README tutorial for English and Korean (I did my best with Korean here) to fit the new v0.10 compliant syntax.
3. [Adding hyperopt back to requirements.txt](https://github.com/flairNLP/flair/commit/f0c9f42a31468b4ee76497dd18a9d02f277b3479) adds the most recent version of hyperopt back to requirements
4. [Fixing paramselection code to work with changes in Flair v0.10](https://github.com/flairNLP/flair/commit/2995cc43153516f9709f58c33c449899dd7bf5f1) This updates the original hyperparameter syntax to work with changes applied in v0.10 such as, for example, the `make_label_dictionary(label_type)` requiring the `label_type` argument
5. [Fixing bug where embeddings got added twice on multiple training runs](https://github.com/flairNLP/flair/commit/0a140b8a7803c44228b4943a22dab3a67f6d87b8)[](https://github.com/tadejmagajna). This provides a temporary solution for #2600 where embeddings were added to tokens multiple times and this caused crashes (can be reproduced by running the TUTORIAL_8 code). Note that the fix probably does probably slow the execution down a bit, but it only affects runs where `training_runs>1`
6. [Enabling and fixing tests for param selection](https://github.com/flairNLP/flair/commit/a63f988a5db2c8471947d24f77cd302f803b5ed6). Here I reintroduce hyperparameter tests, apply some fixes to them and enable them again because they were previously disabled for some reason. There was also a deprecation warning related to some dependency of Hyperopt. To fix it I applied a change to to `pyproject.toml` where I swapped the `-W` parameter for the more-readable `filterwarnings` parameter and made it ignore that specific `DeprecationWarning`.
7. [Automatic code formatting of param selection tests](https://github.com/flairNLP/flair/commit/ebaa9fe4ca37f91964bc84c5c7244ba1a41c06e7) auto code formatting

Please do me know if there are any other parts of the hyperparameter tuning code I forgot to make compliant with the current Flair syntax