### PR TITLE
GH-2640: tensor forward

### DIFF
--- a/flair/datasets/text_text.py
+++ b/flair/datasets/text_text.py
@@ -579,8 +579,8 @@ class GLUE_MNLI(DataPairCorpus):
                     str(data_folder / "MNLI" / temp_file),
                 )
 
-                with open(data_folder / "MNLI" / dev_filename, "a") as out_file, open(
-                    data_folder / "MNLI" / temp_file
+                with open(data_folder / "MNLI" / dev_filename, "a", encoding="utf-8") as out_file, open(
+                    data_folder / "MNLI" / temp_file, encoding="utf-8"
                 ) as in_file:
                     for line in in_file:
                         fields = line.split("\t")

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -230,7 +230,7 @@ def get_from_cache(url: str, cache_dir: Path) -> Path:
         req = requests.get(url, stream=True, headers={"User-Agent": "Flair"})
         content_length = req.headers.get("Content-Length")
         total = int(content_length) if content_length is not None else None
-        progress = Tqdm.tqdm(unit="B", total=total)
+        progress = Tqdm.tqdm(unit="B", total=total, unit_scale=True, unit_divisor=1024)
         with open(temp_filename, "wb") as temp_file:
             for chunk in req.iter_content(chunk_size=1024):
                 if chunk:  # filter out keep-alive new chunks

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -91,7 +91,7 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
         return bool(data_point.get_labels(self.label_type))
 
     def _embed_prediction_data_point(self, prediction_data_point: Span) -> torch.Tensor:
-        return self.aggregated_embedding(prediction_data_point, self.word_embeddings.get_names()).unsqueeze(0)
+        return self.aggregated_embedding(prediction_data_point, self.word_embeddings.get_names())
 
     def _get_state_dict(self):
         model_state = {

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List
 
 import torch
 
 import flair.embeddings
 import flair.nn
-from flair.data import DataPoint, Dictionary, Sentence, Span
+from flair.data import Dictionary, Sentence, Span
 
 log = logging.getLogger("flair")
 

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -6,6 +6,7 @@ import torch
 import flair.embeddings
 import flair.nn
 from flair.data import Dictionary, Sentence, Span
+from flair.embeddings import Embeddings
 
 log = logging.getLogger("flair")
 
@@ -38,7 +39,6 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
 
         super(EntityLinker, self).__init__(
             label_dictionary=label_dictionary,
-            embeddings=word_embeddings,
             final_embedding_size=word_embeddings.embedding_length * 2
             if pooling_operation == "first_last"
             else word_embeddings.embedding_length,
@@ -76,6 +76,10 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
 
     def emb_mean(self, span, embedding_names):
         return torch.mean(torch.cat([token.get_embedding(embedding_names) for token in span], 0), 0)
+
+    @property
+    def _inner_embeddings(self) -> Embeddings[Sentence]:
+        return self.word_embeddings
 
     def _get_prediction_data_points(self, sentences: List[Sentence]) -> List[Span]:
         entities: List[Span] = []

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -117,9 +117,9 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence]):
         if len(embedding_list) > 0:
             embedded_entity_pairs = torch.cat(embedding_list, 0)
 
-            return embedded_entity_pairs,
+            return (embedded_entity_pairs,)
         else:
-            return torch.zeros(0, self.word_embeddings.embedding_length, device=flair.device),
+            return (torch.zeros(0, self.word_embeddings.embedding_length, device=flair.device),)
 
     def _get_state_dict(self):
         model_state = {

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -83,9 +83,6 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
             entities.extend(sentence.get_spans(self.label_type))
         return entities
 
-    def _get_label_of_datapoint(self, datapoint: Span) -> List[str]:
-        return [datapoint.get_label(self._label_type).value]
-
     def _filter_data_point(self, data_point: Sentence) -> bool:
         return bool(data_point.get_labels(self.label_type))
 

--- a/flair/models/pairwise_classification_model.py
+++ b/flair/models/pairwise_classification_model.py
@@ -1,10 +1,10 @@
-from typing import List, Tuple
+from typing import List
 
 import torch
 
 import flair.embeddings
 import flair.nn
-from flair.data import DataPoint, Sentence, TextPair
+from flair.data import Sentence, TextPair
 
 
 class TextPairClassifier(flair.nn.DefaultClassifier[TextPair, TextPair]):
@@ -65,7 +65,7 @@ class TextPairClassifier(flair.nn.DefaultClassifier[TextPair, TextPair]):
     def label_type(self):
         return self._label_type
 
-    def _get_prediction_data_points(self, sentences: List[TextPair]) -> List[DataPoint]:
+    def _get_prediction_data_points(self, sentences: List[TextPair]) -> List[TextPair]:
         return sentences
 
     def _embed_prediction_data_point(self, prediction_data_point: TextPair) -> torch.Tensor:
@@ -77,13 +77,15 @@ class TextPairClassifier(flair.nn.DefaultClassifier[TextPair, TextPair]):
                     prediction_data_point.first.get_embedding(embedding_names),
                     prediction_data_point.second.get_embedding(embedding_names),
                 ],
-                0
+                0,
             )
         else:
             concatenated_sentence = Sentence(
-                    prediction_data_point.first.to_tokenized_string() + self.sep + prediction_data_point.second.to_tokenized_string(),
-                    use_tokenizer=False,
-                )
+                prediction_data_point.first.to_tokenized_string()
+                + self.sep
+                + prediction_data_point.second.to_tokenized_string(),
+                use_tokenizer=False,
+            )
             self.document_embeddings.embed(concatenated_sentence)
             return concatenated_sentence.get_embedding(embedding_names)
 

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -92,18 +92,19 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
     def _embed_prediction_data_point(self, prediction_data_point: Relation) -> torch.Tensor:
         span_1 = prediction_data_point.first
         span_2 = prediction_data_point.second
+        embedding_names = self.embeddings.get_names()
 
         if self.pooling_operation == "first_last":
             return torch.cat(
                 [
-                    span_1.tokens[0].get_embedding(),
-                    span_1.tokens[-1].get_embedding(),
-                    span_2.tokens[0].get_embedding(),
-                    span_2.tokens[-1].get_embedding(),
+                    span_1.tokens[0].get_embedding(embedding_names),
+                    span_1.tokens[-1].get_embedding(embedding_names),
+                    span_2.tokens[0].get_embedding(embedding_names),
+                    span_2.tokens[-1].get_embedding(embedding_names),
                 ]
             )
         else:
-            return torch.cat([span_1.tokens[0].get_embedding(), span_2.tokens[0].get_embedding()])
+            return torch.cat([span_1.tokens[0].get_embedding(embedding_names), span_2.tokens[0].get_embedding(embedding_names)])
 
     def _print_predictions(self, batch, gold_label_type):
         lines = []

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -21,6 +21,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
         entity_label_type: str,
         entity_pair_filters: List[Tuple[str, str]] = None,
         pooling_operation: str = "first_last",
+        train_on_gold_pairs_only: bool = False,
         **classifierargs,
     ):
         """
@@ -29,6 +30,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
         :param label_dictionary: dictionary of labels you want to predict
         :param beta: Parameter for F-beta score for evaluation and training annealing
         :param loss_weights: Dictionary of weights for labels for the loss function
+        :param train_on_gold_pairs_only: Set true to not train to predict no relation.
         (if any label's weight is unspecified it will default to 1.0)
         """
 
@@ -45,6 +47,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
         # set relation and entity label types
         self._label_type = label_type
         self.entity_label_type = entity_label_type
+        self.train_on_gold_pairs_only = train_on_gold_pairs_only
 
         # whether to use gold entity pairs, and whether to filter entity pairs by type
         if entity_pair_filters is not None:
@@ -138,6 +141,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
             "weight_dict": self.weight_dict,
             "pooling_operation": self.pooling_operation,
             "entity_pair_filters": self.entity_pair_filters,
+            "train_on_gold_pairs_only": self.train_on_gold_pairs_only,
         }
         return model_state
 
@@ -153,6 +157,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
             loss_weights=state.get("weight_dict"),
             pooling_operation=state.get("pooling_operation"),
             entity_pair_filters=state.get("entity_pair_filters"),
+            train_on_gold_pairs_only=state.get("train_on_gold_pairs_only", False),
             **kwargs,
         )
 

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -6,7 +6,7 @@ import torch
 
 import flair.embeddings
 import flair.nn
-from flair.data import DataPoint, Relation, Sentence, Span
+from flair.data import Relation, Sentence, Span
 from flair.file_utils import cached_path
 
 log = logging.getLogger("flair")

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -106,7 +106,9 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
                 ]
             )
         else:
-            return torch.cat([span_1.tokens[0].get_embedding(embedding_names), span_2.tokens[0].get_embedding(embedding_names)])
+            return torch.cat(
+                [span_1.tokens[0].get_embedding(embedding_names), span_2.tokens[0].get_embedding(embedding_names)]
+            )
 
     def _print_predictions(self, batch, gold_label_type):
         lines = []

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -37,7 +37,6 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
         relation_representation_length = 2 * embeddings.embedding_length
         if self.pooling_operation == "first_last":
             relation_representation_length *= 2
-        self.relation_representation_length = relation_representation_length
         super(RelationExtractor, self).__init__(**classifierargs, final_embedding_size=relation_representation_length)
 
         # set embeddings

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -74,7 +74,10 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
                 ):
                     continue
 
-                entity_pairs.append(Relation(span_1, span_2))
+                relation = Relation(span_1, span_2)
+                if self.training and self.train_on_gold_pairs_only and relation.get_label(self.label_type).value == "O":
+                    continue
+                entity_pairs.append(relation)
         return entity_pairs
 
     @property

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -185,9 +185,6 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence]):
 
             embedded_entity_pairs = torch.stack(relation_embeddings)
 
-        if for_prediction:
-            return embedded_entity_pairs, labels, entity_pairs
-
         return embedded_entity_pairs, labels
 
     def _print_predictions(self, batch, gold_label_type):

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -6,7 +6,8 @@ import torch
 
 import flair.embeddings
 import flair.nn
-from flair.data import Relation, Sentence, Span
+from flair.data import Relation, Sentence
+from flair.embeddings import Embeddings
 from flair.file_utils import cached_path
 
 log = logging.getLogger("flair")
@@ -77,7 +78,9 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
                 entity_pairs.append(Relation(span_1, span_2))
         return entity_pairs
 
-    # TODO: as the get_labels logic was removed, I have to still test if it works to just use `relation.get_labels(...)`
+    @property
+    def _inner_embeddings(self) -> Embeddings[Sentence]:
+        return self.embeddings
 
     def _get_prediction_data_points(self, sentences: List[Sentence]) -> List[Relation]:
         entity_pairs: List[Relation] = []
@@ -166,7 +169,3 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
             model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
 
         return model_name
-
-
-def create_position_string(head: Span, tail: Span) -> str:
-    return f"{head.unlabeled_identifier} -> {tail.unlabeled_identifier}"

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -261,36 +261,39 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
         return RNN
 
-    def forward_loss(self, sentences: Union[List[Sentence], Sentence]) -> Tuple[torch.Tensor, int]:
+    def forward_loss(self, sentences: List[Sentence]) -> Tuple[torch.Tensor, int]:
 
         # if there are no sentences, there is no loss
         if len(sentences) == 0:
             return torch.tensor(0.0, dtype=torch.float, device=flair.device, requires_grad=True), 0
 
+        gold_labels = self._prepare_label_tensor(sentences)
+        sentence_tensor, lengths = self._prepare_tensors(sentences)
+
         # forward pass to get scores
-        scores, gold_labels = self.forward(sentences)  # type: ignore
+        scores = self.forward(sentence_tensor, lengths)
 
         # calculate loss given scores and labels
         return self._calculate_loss(scores, gold_labels)
 
-    def forward(self, sentences: Union[List[Sentence], Sentence]):
-        """
-        Forward propagation through network. Returns gold labels of batch in addition.
-        :param sentences: Batch of current sentences
-        """
-        if not isinstance(sentences, list):
-            sentences = [sentences]
+    def _prepare_tensors(self, data_points: Union[List[Sentence], Sentence]) -> Tuple[torch.Tensor, torch.LongTensor]:
+        if not isinstance(data_points, list):
+            sentences = [data_points]
+        else:
+            sentences = data_points
         self.embeddings.embed(sentences)
 
         # make a zero-padded tensor for the whole sentence
         lengths, sentence_tensor = self._make_padded_tensor_for_batch(sentences)
 
-        # sort tensor in decreasing order based on lengths of sentences in batch
-        sorted_lengths, length_indices = lengths.sort(dim=0, descending=True)
-        sentences = [sentences[i] for i in length_indices]
-        sentence_tensor = sentence_tensor[length_indices]
+        return sentence_tensor, lengths
 
-        # ----- Forward Propagation -----
+    def forward(self, sentence_tensor: torch.Tensor, lengths: torch.LongTensor):  # type: ignore[override]
+        """
+        Forward propagation through network.
+        :param sentence_tensor: A tensor representing the batch of sentences.
+        :param lengths: A IntTensor representing the lengths of the respective sentences.
+        """
         if self.use_dropout:
             sentence_tensor = self.dropout(sentence_tensor)
         if self.use_word_dropout:
@@ -302,7 +305,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             sentence_tensor = self.embedding2nn(sentence_tensor)
 
         if self.use_rnn:
-            packed = pack_padded_sequence(sentence_tensor, sorted_lengths, batch_first=True, enforce_sorted=False)
+            packed = pack_padded_sequence(sentence_tensor, lengths, batch_first=True, enforce_sorted=False)
             rnn_output, hidden = self.rnn(packed)
             sentence_tensor, output_lengths = pad_packed_sequence(rnn_output, batch_first=True)
 
@@ -319,34 +322,20 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         # -- A tensor of shape (aggregated sequence length for all sentences in batch, tagset size) for linear layer
         if self.use_crf:
             features = self.crf(features)
-            scores = (features, sorted_lengths, self.crf.transitions)
+            scores = (features, lengths, self.crf.transitions)
         else:
-            scores = self._get_scores_from_features(features, sorted_lengths)
+            scores = self._get_scores_from_features(features, lengths)
 
-        # get the gold labels
-        gold_labels = self._get_gold_labels(sentences)
+        return scores
 
-        return scores, gold_labels
+    def _calculate_loss(self, scores: torch.Tensor, labels: torch.LongTensor) -> Tuple[torch.Tensor, int]:
 
-    def _calculate_loss(self, scores, labels) -> Tuple[torch.Tensor, int]:
-
-        if not any(labels):
+        if labels.size(0) == 0:
             return torch.tensor(0.0, requires_grad=True, device=flair.device), 1
-
-        labels = torch.tensor(
-            [
-                self.label_dictionary.get_idx_for_item(label[0])
-                if len(label) > 0
-                else self.label_dictionary.get_idx_for_item("O")
-                for label in labels
-            ],
-            dtype=torch.long,
-            device=flair.device,
-        )
 
         return self.loss_function(scores, labels), len(labels)
 
-    def _make_padded_tensor_for_batch(self, sentences: List[Sentence]) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _make_padded_tensor_for_batch(self, sentences: List[Sentence]) -> Tuple[torch.LongTensor, torch.Tensor]:
         names = self.embeddings.get_names()
         lengths: List[int] = [len(sentence.tokens) for sentence in sentences]
         longest_token_sequence_in_batch: int = max(lengths)
@@ -371,7 +360,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                 self.embeddings.embedding_length,
             ]
         )
-        return torch.tensor(lengths, dtype=torch.long), sentence_tensor
+        return torch.LongTensor(lengths), sentence_tensor
 
     @staticmethod
     def _get_scores_from_features(features: torch.Tensor, lengths: torch.Tensor):
@@ -388,7 +377,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
         return scores
 
-    def _get_gold_labels(self, sentences: Union[List[Sentence], Sentence]):
+    def _get_gold_labels(self, sentences: List[Sentence]) -> List[str]:
         """
         Extracts gold labels from each sentence.
         :param sentences: List of sentences in batch
@@ -413,12 +402,21 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                         for i in range(span[0].idx, span[-1].idx):
                             sentence_labels[i] = "I-" + label.value
                 all_sentence_labels.extend(sentence_labels)
-            labels = [[label] for label in all_sentence_labels]
+            labels = all_sentence_labels
 
         # all others are regular labels for each token
         else:
-            labels = [[token.get_label(self.label_type, "O").value] for sentence in sentences for token in sentence]
+            labels = [token.get_label(self.label_type, "O").value for sentence in sentences for token in sentence]
 
+        return labels
+
+    def _prepare_label_tensor(self, sentences: List[Sentence]):
+        gold_labels = self._get_gold_labels(sentences)
+        labels = torch.tensor(
+            [self.label_dictionary.get_idx_for_item(label) for label in gold_labels],
+            dtype=torch.long,
+            device=flair.device,
+        )
         return labels
 
     def predict(
@@ -471,18 +469,19 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                 dataloader = tqdm(dataloader, desc="Batch inference")
 
             overall_loss = torch.zeros(1, device=flair.device)
-            batch_no = 0
             label_count = 0
             for batch in dataloader:
-
-                batch_no += 1
 
                 # stop if all sentences are empty
                 if not batch:
                     continue
 
+                # sort the sentences to have descending length
+                batch = sorted(batch, key=len, reverse=True)
+
                 # get features from forward propagation
-                features, gold_labels = self.forward(batch)
+                sentence_tensor, lengths = self._prepare_tensors(batch)
+                features = self.forward(sentence_tensor, lengths)
 
                 # remove previously predicted labels of this type
                 for sentence in batch:
@@ -490,14 +489,10 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
                 # if return_loss, get loss value
                 if return_loss:
+                    gold_labels = self._prepare_label_tensor(batch)
                     loss = self._calculate_loss(features, gold_labels)
                     overall_loss += loss[0]
                     label_count += loss[1]
-
-                # Sort batch in same way as forward propagation
-                lengths = torch.LongTensor([len(sentence) for sentence in batch])
-                _, sort_indices = lengths.sort(dim=0, descending=True)
-                batch = [batch[i] for i in sort_indices]
 
                 # make predictions
                 if self.use_crf:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -266,7 +266,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         # if there are no sentences, there is no loss
         if len(sentences) == 0:
             return torch.tensor(0.0, dtype=torch.float, device=flair.device, requires_grad=True), 0
-
+        sentences = sorted(sentences, key=len, reverse=True)
         gold_labels = self._prepare_label_tensor(sentences)
         sentence_tensor, lengths = self._prepare_tensors(sentences)
 
@@ -305,7 +305,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             sentence_tensor = self.embedding2nn(sentence_tensor)
 
         if self.use_rnn:
-            packed = pack_padded_sequence(sentence_tensor, lengths, batch_first=True, enforce_sorted=False)
+            packed = pack_padded_sequence(sentence_tensor, lengths, batch_first=True)
             rnn_output, hidden = self.rnn(packed)
             sentence_tensor, output_lengths = pad_packed_sequence(rnn_output, batch_first=True)
 
@@ -455,7 +455,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             sentences = [sentence for sentence in sentences if len(sentence) > 0]
 
             # reverse sort all sequences by their length
-            reordered_sentences = sorted(sentences, key=lambda s: len(s), reverse=True)
+            reordered_sentences = sorted(sentences, key=len, reverse=True)
 
             if len(reordered_sentences) == 0:
                 return sentences
@@ -475,9 +475,6 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                 # stop if all sentences are empty
                 if not batch:
                     continue
-
-                # sort the sentences to have descending length
-                batch = sorted(batch, key=len, reverse=True)
 
                 # get features from forward propagation
                 sentence_tensor, lengths = self._prepare_tensors(batch)

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -47,6 +47,12 @@ class FewshotClassifier(flair.nn.Classifier[Sentence]):
         loss = self.tars_model.forward_loss(sentences)
         return loss
 
+    def _prepare_tensors(self, data_points: List[Sentence]) -> Tuple[torch.Tensor, ...]:
+        return self.tars_model._prepare_tensors(data_points)
+
+    def forward(self, *args: torch.Tensor) -> torch.Tensor:
+        return self.tars_model.forward(*args)
+
     @property
     def tars_embeddings(self):
         raise NotImplementedError

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Tuple
 
 import torch
 
@@ -65,8 +65,10 @@ class TextClassifier(flair.nn.DefaultClassifier[Sentence]):
         text_embedding_tensor = torch.cat(text_embedding_list, 0).to(flair.device)
         return (text_embedding_tensor,)
 
-    def _get_prediction_data_points(self, sentences: List[Sentence]) -> List[Sentence]:
-        return sentences
+    def _get_prediction_data_points(self, sentences: List[Sentence]) -> List[DataPoint]:
+        result: List[DataPoint] = []
+        result.extend(sentences)
+        return result
 
     def _get_state_dict(self):
         model_state = {

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -7,6 +7,7 @@ import torch
 import flair.embeddings
 import flair.nn
 from flair.data import Sentence
+from flair.embeddings import Embeddings
 from flair.file_utils import cached_path
 
 log = logging.getLogger("flair")
@@ -42,7 +43,6 @@ class TextClassifier(flair.nn.DefaultClassifier[Sentence, Sentence]):
         super(TextClassifier, self).__init__(
             **classifierargs,
             final_embedding_size=document_embeddings.embedding_length,
-            embeddings=document_embeddings,
         )
 
         self.document_embeddings: flair.embeddings.DocumentEmbeddings = document_embeddings
@@ -70,6 +70,10 @@ class TextClassifier(flair.nn.DefaultClassifier[Sentence, Sentence]):
             "weight_dict": self.weight_dict,
         }
         return model_state
+
+    @property
+    def _inner_embeddings(self) -> Embeddings[Sentence]:
+        return self.document_embeddings
 
     @classmethod
     def _init_model_with_state_dict(cls, state, **kwargs):

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -1,12 +1,12 @@
 import logging
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
 
 import torch
 
 import flair.embeddings
 import flair.nn
-from flair.data import DataPoint, Sentence
+from flair.data import Sentence
 from flair.file_utils import cached_path
 
 log = logging.getLogger("flair")
@@ -40,7 +40,8 @@ class TextClassifier(flair.nn.DefaultClassifier[Sentence, Sentence]):
         """
 
         super(TextClassifier, self).__init__(
-            **classifierargs, final_embedding_size=document_embeddings.embedding_length,
+            **classifierargs,
+            final_embedding_size=document_embeddings.embedding_length,
             embeddings=document_embeddings,
         )
 

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -49,7 +49,7 @@ class TextRegressor(flair.nn.Model[Sentence]):
         return (text_embedding_tensor,)
 
     def forward(self, *args: torch.Tensor) -> torch.Tensor:
-        text_embedding_tensor, = args
+        (text_embedding_tensor,) = args
         label_scores = self.decoder(text_embedding_tensor)
         return label_scores
 

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -64,7 +64,7 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
         )
 
     @property
-    def _embeddings(self) -> Embeddings[Sentence]:
+    def _inner_embeddings(self) -> Embeddings[Sentence]:
         return self._embeddings
 
     def _embed_prediction_data_point(self, prediction_data_point: Token) -> torch.Tensor:

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -1,11 +1,11 @@
 import logging
-from typing import List, Union, Tuple
+from typing import List, Tuple
 
 import torch
 import torch.nn
 
 import flair.nn
-from flair.data import Dictionary, Sentence, DataPoint
+from flair.data import DataPoint, Dictionary, Sentence
 from flair.embeddings import TokenEmbeddings
 
 log = logging.getLogger("flair")

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -65,7 +65,7 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
 
     @property
     def _inner_embeddings(self) -> Embeddings[Sentence]:
-        return self._embeddings
+        return self.embeddings
 
     def _embed_prediction_data_point(self, prediction_data_point: Token) -> torch.Tensor:
         names = self.embeddings.get_names()

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -1,11 +1,10 @@
 import logging
-from typing import List, Tuple
+from typing import List
 
 import torch
-import torch.nn
 
 import flair.nn
-from flair.data import DataPoint, Dictionary, Sentence, Token
+from flair.data import Dictionary, Sentence, Token
 from flair.embeddings import TokenEmbeddings
 
 log = logging.getLogger("flair")
@@ -31,7 +30,10 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
         :param beta: Parameter for F-beta score for evaluation and training annealing
         """
         super().__init__(
-            label_dictionary=tag_dictionary, final_embedding_size=embeddings.embedding_length, **classifierargs, embeddings=embeddings,
+            label_dictionary=tag_dictionary,
+            final_embedding_size=embeddings.embedding_length,
+            **classifierargs,
+            embeddings=embeddings,
         )
 
         # embeddings

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -5,7 +5,7 @@ import torch
 
 import flair.nn
 from flair.data import Dictionary, Sentence, Token
-from flair.embeddings import TokenEmbeddings
+from flair.embeddings import Embeddings, TokenEmbeddings
 
 log = logging.getLogger("flair")
 
@@ -33,7 +33,6 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
             label_dictionary=tag_dictionary,
             final_embedding_size=embeddings.embedding_length,
             **classifierargs,
-            embeddings=embeddings,
         )
 
         # embeddings
@@ -63,6 +62,10 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
             tag_type=state.get("tag_type"),
             **kwargs,
         )
+
+    @property
+    def _embeddings(self) -> Embeddings[Sentence]:
+        return self._embeddings
 
     def _embed_prediction_data_point(self, prediction_data_point: Token) -> torch.Tensor:
         names = self.embeddings.get_names()

--- a/flair/nn/decoder.py
+++ b/flair/nn/decoder.py
@@ -192,10 +192,10 @@ class PrototypicalDecoder(torch.nn.Module):
                     if self.metric_space_decoder is not None:
                         logits = self.metric_space_decoder(logits)
 
-                    for logit, label in zip(logits, labels):
-                        counter.update(label)
+                    for logit, _label in zip(logits, labels):
+                        counter.update(_label)
 
-                        idx = encoder.label_dictionary.get_idx_for_item(label[0])
+                        idx = encoder.label_dictionary.get_idx_for_item(_label[0])
 
                         new_prototypes[idx] += logit
 

--- a/flair/nn/decoder.py
+++ b/flair/nn/decoder.py
@@ -185,7 +185,7 @@ class PrototypicalDecoder(torch.nn.Module):
 
             for batch in tqdm(dataloader):
 
-                logits, labels = encoder.forward_pass(batch)  # type: ignore
+                logits, labels = encoder.get_scores_and_labels(batch)
 
                 if len(labels) > 0:
                     # decode embeddings into prototype space

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -550,6 +550,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         # set up multi-label logic
         self.multi_label = multi_label
         self.multi_label_threshold = multi_label_threshold
+        self.final_embedding_size = final_embedding_size
         self.inverse_model = inverse_model
 
         # init dropouts
@@ -684,7 +685,6 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
     def forward_loss(self, sentences: List[DT]) -> Tuple[torch.Tensor, int]:
 
         # make a forward pass to produce embedded data points and labels
-        breakpoint()
         predict_data_points = self._get_prediction_data_points(sentences)
         labels = self._prepare_label_tensor(predict_data_points)
 
@@ -694,7 +694,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
 
         embedded_tensor = self._prepare_tensors(sentences)
         scores = self.forward(*embedded_tensor)
-        
+
         # calculate the loss
         return self._calculate_loss(scores, labels)
 

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -527,6 +527,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         loss_weights: Dict[str, float] = None,
         decoder: Optional[torch.nn.Module] = None,
         inverse_model: bool = False,
+        train_on_gold_pairs_only: bool = False,
     ):
 
         super().__init__()
@@ -577,6 +578,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             self.loss_function: _Loss = torch.nn.BCEWithLogitsLoss(weight=self.loss_weights)
         else:
             self.loss_function = torch.nn.CrossEntropyLoss(weight=self.loss_weights, reduction="sum")
+        self.train_on_gold_pairs_only = train_on_gold_pairs_only
 
     def _filter_data_point(self, data_point: DT) -> bool:
         """Specify if a data point should be kept. That way you can remove for example empty texts.
@@ -862,6 +864,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             "multi_label",
             "multi_label_threshold",
             "loss_weights",
+            "train_on_gold_pairs_only",
             "inverse_model",
         ]:
             if arg not in kwargs and arg in state:
@@ -879,6 +882,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         state["multi_label"] = self.multi_label
         state["multi_label_threshold"] = self.multi_label_threshold
         state["loss_weights"] = self.loss_weights
+        state["train_on_gold_pairs_only"] = self.train_on_gold_pairs_only
         state["inverse_model"] = self.inverse_model
         if self._custom_decoder:
             state["decoder"] = self.decoder

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -753,7 +753,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             if len(reordered_sentences) == 0:
                 return sentences
 
-            if len(sentences) > mini_batch_size:
+            if len(reordered_sentences) > mini_batch_size:
                 batches: Union[DataLoader, List[List[DT]]] = DataLoader(
                     dataset=FlairDatapointDataset(reordered_sentences),
                     batch_size=mini_batch_size,

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -592,7 +592,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         raise NotImplementedError()
 
     def _prepare_tensors(self, data_points: List[DT]) -> Tuple[torch.Tensor, ...]:
-        filtered_data_points = [dt for dt in data_points if not self._filter_data_point(dt)]
+        filtered_data_points = [dt for dt in data_points if self._filter_data_point(dt)]
         if not filtered_data_points:
             return (torch.zeros(0, self.final_embedding_size, device=flair.device),)
         if self._embeddings is not None:
@@ -684,6 +684,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
     def forward_loss(self, sentences: List[DT]) -> Tuple[torch.Tensor, int]:
 
         # make a forward pass to produce embedded data points and labels
+        breakpoint()
         predict_data_points = self._get_prediction_data_points(sentences)
         labels = self._prepare_label_tensor(predict_data_points)
 

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -663,13 +663,13 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
 
     def get_scores_and_labels(self, batch: List[DT]) -> Tuple[torch.Tensor, List[List[str]]]:
         predict_data_points = self._get_prediction_data_points(batch)
-        labels = [self._get_label_of_datapoint(dp) for dp in predict_data_points]
+        labels = [self._get_label_of_datapoint(dp) for dp in predict_data_points if self._filter_data_point(dp)]
         embedded_tensor = self._prepare_tensors(batch)
         logits = self._transform_embeddings(*embedded_tensor)
         return logits, labels
 
     def _prepare_label_tensor(self, prediction_data_points: List[DT2]) -> torch.Tensor:
-        labels = [self._get_label_of_datapoint(dp) for dp in prediction_data_points]
+        labels = [self._get_label_of_datapoint(dp) for dp in prediction_data_points if self._filter_data_point(dp)]
         if self.multi_label:
             return torch.tensor(
                 [

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -745,6 +745,9 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT]):
                     continue
 
                 tensors = self._prepare_tensors(batch)
+                if tensors[0].size(0) == 0:
+                    continue
+
                 scores = self.forward(*tensors)
 
                 data_points = self._get_prediction_data_points(batch)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -662,14 +662,15 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             self._multi_label_threshold = {"default": x}
 
     def get_scores_and_labels(self, batch: List[DT]) -> Tuple[torch.Tensor, List[List[str]]]:
+        batch = [dp for dp in batch if self._filter_data_point(dp)]
         predict_data_points = self._get_prediction_data_points(batch)
-        labels = [self._get_label_of_datapoint(dp) for dp in predict_data_points if self._filter_data_point(dp)]
+        labels = [self._get_label_of_datapoint(pdp) for pdp in predict_data_points]
         embedded_tensor = self._prepare_tensors(batch)
         logits = self._transform_embeddings(*embedded_tensor)
         return logits, labels
 
     def _prepare_label_tensor(self, prediction_data_points: List[DT2]) -> torch.Tensor:
-        labels = [self._get_label_of_datapoint(dp) for dp in prediction_data_points if self._filter_data_point(dp)]
+        labels = [self._get_label_of_datapoint(dp) for dp in prediction_data_points]
         if self.multi_label:
             return torch.tensor(
                 [
@@ -694,6 +695,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
     def forward_loss(self, sentences: List[DT]) -> Tuple[torch.Tensor, int]:
 
         # make a forward pass to produce embedded data points and labels
+        sentences = [sentence for sentence in sentences if self._filter_data_point(sentence)]
         predict_data_points = self._get_prediction_data_points(sentences)
         labels = self._prepare_label_tensor(predict_data_points)
 
@@ -778,6 +780,9 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             overall_loss = torch.zeros(1, device=flair.device)
             label_count = 0
             for batch in batches:
+
+                batch = [dp for dp in batch if self._filter_data_point(dp)]
+
                 # stop if all sentences are empty
                 if not batch:
                     continue

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 import flair
 from flair import file_utils
-from flair.data import DT, Dictionary, Sentence, DT2
+from flair.data import DT, DT2, Dictionary, Sentence
 from flair.datasets import DataLoader, FlairDatapointDataset
 from flair.embeddings import Embeddings
 from flair.file_utils import Tqdm

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -640,7 +640,10 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         """Extracts the labels from the data points.
         Each data point might return a list of strings, representing multiple labels.
         """
-        return [data_point.get_label(self.label_type).value]
+        if self.multi_label:
+            return [label.value for label in data_point.get_labels(self.label_type)]
+        else:
+            return [data_point.get_label(self.label_type).value]
 
     @property
     def multi_label_threshold(self):

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -604,11 +604,11 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
 
         return (embedded_data_pairs,)
 
-    def forward_pass(
+    def _transform_embeddings(
         self,
         *args: torch.Tensor,
     ) -> torch.Tensor:
-        """This method does a forward pass through the model given a list of tensors as input.
+        """This method does applies a transformation through the model given a list of tensors as input.
         Returns the embeddings that will ran trough a linear decoder layer to calculate logits.
 
         If it is not overwritten, it will act as identity function for of the first tensor.
@@ -616,7 +616,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         return args[0]
 
     def forward(self, *args: torch.Tensor) -> torch.Tensor:
-        emb = self.forward_pass(*args)
+        emb = self._transform_embeddings(*args)
         emb = emb.unsqueeze(1)
         emb = self.dropout(emb)
         emb = self.locked_dropout(emb)
@@ -637,12 +637,11 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         """
         raise NotImplementedError
 
-    @abstractmethod
     def _get_label_of_datapoint(self, data_point: DT2) -> List[str]:
         """Extracts the labels from the data points.
         Each data point might return a list of strings, representing multiple labels.
         """
-        raise NotImplementedError
+        return [data_point.get_label(self.label_type).value]
 
     @property
     def multi_label_threshold(self):

--- a/tests/test_entity_linker.py
+++ b/tests/test_entity_linker.py
@@ -20,5 +20,5 @@ def test_forward_loss():
     # init tagger and do a forward pass
     tagger = EntityLinker(TransformerWordEmbeddings("distilbert-base-uncased"), label_dictionary=Dictionary())
     loss, count = tagger.forward_loss([sentence])
-    assert count == 1
+    assert count == 2
     assert loss.size() == ()

--- a/tests/test_entity_linker.py
+++ b/tests/test_entity_linker.py
@@ -1,0 +1,12 @@
+from flair.data import Dictionary, Sentence
+from flair.embeddings import TransformerWordEmbeddings
+from flair.models import EntityLinker
+
+
+def test_entity_linker_with_no_candidates():
+    linker: EntityLinker = EntityLinker(
+        TransformerWordEmbeddings(model="distilbert-base-uncased"), label_dictionary=Dictionary()
+    )
+
+    sentence = Sentence("I live in Berlin")
+    linker.predict(sentence)

--- a/tests/test_entity_linker.py
+++ b/tests/test_entity_linker.py
@@ -10,3 +10,15 @@ def test_entity_linker_with_no_candidates():
 
     sentence = Sentence("I live in Berlin")
     linker.predict(sentence)
+
+
+def test_forward_loss():
+    sentence = Sentence("I love NYC and hate OYC")
+    sentence[2:3].add_label("nel", "New York City")
+    sentence[5:6].add_label("nel", "Old York City")
+
+    # init tagger and do a forward pass
+    tagger = EntityLinker(TransformerWordEmbeddings("distilbert-base-uncased"), label_dictionary=Dictionary())
+    loss, count = tagger.forward_loss([sentence])
+    assert count == 1
+    assert loss.size() == ()

--- a/tests/test_relation_classifier.py
+++ b/tests/test_relation_classifier.py
@@ -28,6 +28,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         label_dictionary=relation_label_dict,
         label_type="relation",
         entity_label_type="ner",
+        train_on_gold_pairs_only=True,
     )
 
     # initialize trainer

--- a/tests/test_relation_classifier.py
+++ b/tests/test_relation_classifier.py
@@ -19,7 +19,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         column_format={1: "text", 2: "pos", 3: "ner"},
     )
 
-    relation_label_dict = corpus.make_label_dictionary(label_type="relation", add_unk=False)
+    relation_label_dict = corpus.make_label_dictionary(label_type="relation", add_unk=True)
 
     embeddings = TransformerWordEmbeddings()
 
@@ -37,7 +37,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         results_base_path,
         learning_rate=0.1,
         mini_batch_size=2,
-        max_epochs=3,
+        max_epochs=10,
         shuffle=False,
     )
 

--- a/tests/test_relation_classifier.py
+++ b/tests/test_relation_classifier.py
@@ -19,7 +19,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         column_format={1: "text", 2: "pos", 3: "ner"},
     )
 
-    relation_label_dict = corpus.make_label_dictionary(label_type="relation", add_unk=False)
+    relation_label_dict = corpus.make_label_dictionary(label_type="relation")
 
     embeddings = TransformerWordEmbeddings()
 

--- a/tests/test_relation_classifier.py
+++ b/tests/test_relation_classifier.py
@@ -19,7 +19,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         column_format={1: "text", 2: "pos", 3: "ner"},
     )
 
-    relation_label_dict = corpus.make_label_dictionary(label_type="relation")
+    relation_label_dict = corpus.make_label_dictionary(label_type="relation", add_unk=False)
 
     embeddings = TransformerWordEmbeddings()
 

--- a/tests/test_relation_classifier.py
+++ b/tests/test_relation_classifier.py
@@ -28,7 +28,6 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         label_dictionary=relation_label_dict,
         label_type="relation",
         entity_label_type="ner",
-        train_on_gold_pairs_only=True,
     )
 
     # initialize trainer
@@ -45,7 +44,6 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
     del trainer, model, relation_label_dict, corpus
 
     loaded_model: RelationExtractor = RelationExtractor.load(results_base_path / "final-model.pt")
-    loaded_model.train_on_gold_pairs_only = False
 
     sentence = Sentence(["Apple", "was", "founded", "by", "Steve", "Jobs", "."])
     sentence[0:1].add_label("ner", "ORG")

--- a/tests/test_relation_classifier.py
+++ b/tests/test_relation_classifier.py
@@ -19,7 +19,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         column_format={1: "text", 2: "pos", 3: "ner"},
     )
 
-    relation_label_dict = corpus.make_label_dictionary(label_type="relation", add_unk=True)
+    relation_label_dict = corpus.make_label_dictionary(label_type="relation", add_unk=False)
 
     embeddings = TransformerWordEmbeddings()
 
@@ -37,7 +37,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         results_base_path,
         learning_rate=0.1,
         mini_batch_size=2,
-        max_epochs=10,
+        max_epochs=3,
         shuffle=False,
     )
 

--- a/tests/test_text_regressor.py
+++ b/tests/test_text_regressor.py
@@ -27,7 +27,7 @@ def init(tasks_base_path) -> Tuple[Corpus, TextRegressor, ModelTrainer]:
 def test_labels_to_indices(tasks_base_path):
     corpus, model, trainer = init(tasks_base_path)
 
-    result = model._labels_to_indices(corpus.train)
+    result = model._labels_to_tensor(corpus.train)
 
     for i in range(len(corpus.train)):
         expected = round(float(corpus.train[i].labels[0].value), 3)


### PR DESCRIPTION
First PR about https://github.com/flairNLP/flair/issues/2640: refactoring models, such that each model has a `_prepare_tensors` and a `forward` method, where one extracts all tensors out of the data points and the latter only does tensor computations.

That way, JIT tracing and ONNX conversation of the models should be possible.
**Notice:** this is not expected to give a huge speedup, as most computation is within the embeddings, which won't be affected. Due to that, the ONNX conversion is also not documented. 


This PR also adds unit scaling for model downloads when a non-huggingface model is downloaded.
This PR also fixes a bug, that relation extraction models without weight_dict set can be loaded.
This PR also fixes an encoding error, if glue-mnli is loaded on a windows machine
This PR also adds an option to not add a unk token to labels.