### PR TITLE
fix: patch the missing `document_delmiter` for `lm.__get_state__()`

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -393,8 +393,8 @@ class LanguageModel(nn.Module):
         return perplexity
 
     def __getstate__(self):
-        if "document_delimiter" not in self.__dict__:
-            self.document_delimiter = "\n"
+        # "document_delimiter" property may be missing in some older pre-trained models
+        self.document_delimiter = getattr(self, "document_delimiter", "\n")
 
         # serialize the language models and the constructor arguments (but nothing else)
         model_state = {

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -393,6 +393,8 @@ class LanguageModel(nn.Module):
         return perplexity
 
     def __getstate__(self):
+        if "document_delimiter" not in self.__dict__:
+            self.document_delimiter = "\n"
 
         # serialize the language models and the constructor arguments (but nothing else)
         model_state = {


### PR DESCRIPTION
close: #2503
close: #2554

There are already similar special treatments like https://github.com/flairNLP/flair/blob/master/flair/embeddings/token.py#L724 and https://github.com/flairNLP/flair/blob/master/flair/models/language_model.py#L190, but we will still need this for pre-trained `SequenceTagger` or alike to be pickle-able (for Dill and/or multiprocessing).