### PR TITLE
Add support for v2.0 of HIPE-2022 data

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -4260,7 +4260,7 @@ class NER_HIPE_2022(ColumnCorpus):
             f_out.write(lines[0] + "\n")
 
             for line in lines[1:]:
-                if line.startswith(" 	"):
+                if line.startswith(" \t"):
                     # Workaround for empty tokens
                     continue
 

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -4183,7 +4183,7 @@ class NER_HIPE_2022(ColumnCorpus):
         }
 
         # v2.0 only adds new language and splits for AJMC dataset
-        hipe_available_splits["v2.0"] = hipe_available_splits.get("v1.0").copy()
+        hipe_available_splits["v2.0"] = hipe_available_splits["v1.0"].copy()
         hipe_available_splits["v2.0"]["ajmc"] = {"de": ["train", "dev"], "en": ["train", "dev"], "fr": ["train", "dev"]}
 
         eos_marker = "EndOfSentence"

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -4242,6 +4242,7 @@ class NER_HIPE_2022(ColumnCorpus):
             in_memory=in_memory,
             document_separator_token="-DOCSTART-",
             skip_first_line=True,
+            column_delimiter="\t",
             comment_symbol="# ",
             sample_missing_splits=sample_missing_splits,
             **corpusargs,
@@ -4259,7 +4260,11 @@ class NER_HIPE_2022(ColumnCorpus):
             f_out.write(lines[0] + "\n")
 
             for line in lines[1:]:
-                line = line.rstrip()
+                if line.startswith(" 	"):
+                    # Workaround for empty tokens
+                    continue
+
+                line = line.strip()
 
                 # Add "real" document marker
                 if add_document_separator and line.startswith(document_separator):

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -4137,7 +4137,7 @@ class NER_HIPE_2022(ColumnCorpus):
         tag_to_bioes: str = "ner",
         in_memory: bool = True,
         version: str = "v2.0",
-        branch_name: str = "release-v2.0",
+        branch_name: str = "main",
         dev_split_name="dev",
         add_document_separator=False,
         sample_missing_splits=False,

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -4136,7 +4136,8 @@ class NER_HIPE_2022(ColumnCorpus):
         base_path: Union[str, Path] = None,
         tag_to_bioes: str = "ner",
         in_memory: bool = True,
-        version: str = "v1.0",
+        version: str = "v2.0",
+        branch_name: str = "release-v2.0",
         dev_split_name="dev",
         add_document_separator=False,
         sample_missing_splits=False,
@@ -4152,6 +4153,7 @@ class NER_HIPE_2022(ColumnCorpus):
         :tag_to_bioes: Dataset will automatically transformed into BIOES format (internally).
         :in_memory: If True, keeps dataset in memory giving speedups in training.
         :version: Version of CLEF-HIPE dataset. Currently only v1.0 is supported and available.
+        :branch_name: Defines git branch name of HIPE data repository (main by default).
         :dev_split_name: Defines default name of development split (dev by default). Only the NewsEye dataset has
         currently two development splits: dev and dev2.
         :add_document_separator: If True, a special document seperator will be introduced. This is highly
@@ -4180,19 +4182,25 @@ class NER_HIPE_2022(ColumnCorpus):
             }
         }
 
+        # v2.0 only adds new language and splits for AJMC dataset
+        hipe_available_splits["v2.0"] = hipe_available_splits.get("v1.0").copy()
+        hipe_available_splits["v2.0"]["ajmc"] = {"de": ["train", "dev"], "en": ["train", "dev"], "fr": ["train", "dev"]}
+
         eos_marker = "EndOfSentence"
         document_separator = "# hipe2022:document_id"
 
         # Special document marker for sample splits in AJMC dataset
-        if f"{version}/{dataset_name}" == "v1.0/ajmc":
+        if f"{dataset_name}" == "ajmc":
             document_separator = "# hipe2022:original_source"
 
         columns = {0: "text", 1: "ner"}
 
         dataset_base = self.__class__.__name__.lower()
-        data_folder = base_path / dataset_base / dataset_name / language
+        data_folder = base_path / dataset_base / version / dataset_name / language
 
-        data_url = f"https://github.com/hipe-eval/HIPE-2022-data/raw/main/data/{version}/{dataset_name}/{language}"
+        data_url = (
+            f"https://github.com/hipe-eval/HIPE-2022-data/raw/{branch_name}/data/{version}/{dataset_name}/{language}"
+        )
 
         dataset_splits = hipe_available_splits[version][dataset_name][language]
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -429,6 +429,10 @@ def test_hipe_2022_corpus(tasks_base_path):
             "dev": {"sents": 201 + 1, "docs": 17},  # 1 sentence with missing EOS marker
         },
     }
+    hipe_stats["v2.0"]["newseye"] = {"de": {"train": {"sents": 20839 + 1, "docs": 7}}}  # missing EOD marker
+    hipe_stats["v2.0"]["sonar"] = {
+        "de": {"dev": {"sents": 816 + 10, "docs": 10}}  # 9 sentences with missing EOS marker + missing EOD
+    }
 
     def test_hipe_2022(dataset_version="v1.0", add_document_separator=True):
         for dataset_name, languages in hipe_stats[dataset_version].items():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -373,65 +373,120 @@ def test_hipe_2022_corpus(tasks_base_path):
     # We have manually checked, that these numbers are correct:
     hipe_stats = {
         "v1.0": {
-            "ajmc": {"de": {"sample": {"sents": 119, "docs": 8}}, "en": {"sample": {"sents": 83, "docs": 5}}},
+            "ajmc": {
+                "de": {"sample": {"sents": 119, "docs": 8, "labels": ["date", "loc", "pers", "scope", "work"]}},
+                "en": {"sample": {"sents": 83, "docs": 5, "labels": ["date", "loc", "pers", "scope", "work"]}},
+            },
             "hipe2020": {
                 "de": {
-                    "train": {"sents": 3470 + 2, "docs": 103},  # 2 sentences with missing EOS marker
-                    "dev": {
-                        "sents": 1202,
-                        "docs": 33,
+                    "train": {
+                        "sents": 3470 + 2,  # 2 sentences with missing EOS marker
+                        "docs": 103,
+                        "labels": ["loc", "org", "pers", "prod", "time"],
                     },
+                    "dev": {"sents": 1202, "docs": 33, "labels": ["loc", "org", "pers", "prod", "time"]},
                 },
-                "en": {"dev": {"sents": 1045, "docs": 80}},
-                "fr": {"train": {"sents": 5743, "docs": 158}, "dev": {"sents": 1244, "docs": 43}},
+                "en": {"dev": {"sents": 1045, "docs": 80, "labels": ["loc", "org", "pers", "prod", "time"]}},
+                "fr": {
+                    "train": {"sents": 5743, "docs": 158, "labels": ["loc", "org", "pers", "prod", "time", "comp"]},
+                    "dev": {"sents": 1244, "docs": 43, "labels": ["loc", "org", "pers", "prod", "time"]},
+                },
             },
-            "letemps": {"fr": {"train": {"sents": 14051, "docs": 414}, "dev": {"sents": 1341, "docs": 51}}},
+            "letemps": {
+                "fr": {
+                    "train": {"sents": 14051, "docs": 414, "labels": ["loc", "org", "pers"]},
+                    "dev": {"sents": 1341, "docs": 51, "labels": ["loc", "org", "pers"]},
+                }
+            },
             "newseye": {
                 # +1 offset, because of missing EOS marker at EOD
                 "de": {
-                    "train": {"sents": 23646 + 1, "docs": 11},
-                    "dev": {"sents": 1110 + 1, "docs": 12},
-                    "dev2": {"sents": 1541 + 1, "docs": 12},
+                    "train": {"sents": 23646 + 1, "docs": 11, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev": {"sents": 1110 + 1, "docs": 12, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev2": {"sents": 1541 + 1, "docs": 12, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
                 },
                 "fi": {
-                    "train": {"sents": 1141 + 1, "docs": 24},
-                    "dev": {"sents": 140 + 1, "docs": 24},
-                    "dev2": {"sents": 104 + 1, "docs": 21},
+                    "train": {"sents": 1141 + 1, "docs": 24, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev": {"sents": 140 + 1, "docs": 24, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev2": {"sents": 104 + 1, "docs": 21, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
                 },
                 "fr": {
-                    "train": {"sents": 7106 + 1, "docs": 35},
-                    "dev": {"sents": 662 + 1, "docs": 35},
-                    "dev2": {"sents": 1016 + 1, "docs": 35},
+                    "train": {"sents": 7106 + 1, "docs": 35, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev": {"sents": 662 + 1, "docs": 35, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev2": {"sents": 1016 + 1, "docs": 35, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
                 },
                 "sv": {
-                    "train": {"sents": 1063 + 1, "docs": 21},
-                    "dev": {"sents": 126 + 1, "docs": 21},
-                    "dev2": {"sents": 136 + 1, "docs": 21},
+                    "train": {"sents": 1063 + 1, "docs": 21, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev": {"sents": 126 + 1, "docs": 21, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
+                    "dev2": {"sents": 136 + 1, "docs": 21, "labels": ["HumanProd", "LOC", "ORG", "PER"]},
                 },
             },
-            "sonar": {"de": {"dev": {"sents": 1603 + 10, "docs": 10}}},  # 10 sentences with missing EOS marker
-            "topres19th": {"en": {"train": {"sents": 5874, "docs": 309}, "dev": {"sents": 646, "docs": 34}}},
+            "sonar": {
+                "de": {
+                    "dev": {
+                        "sents": 1603 + 10,  # 10 sentences with missing EOS marker
+                        "docs": 10,
+                        "labels": ["LOC", "ORG", "PER"],
+                    }
+                }
+            },
+            "topres19th": {
+                "en": {
+                    "train": {"sents": 5874, "docs": 309, "labels": ["BUILDING", "LOC", "STREET"]},
+                    "dev": {"sents": 646, "docs": 34, "labels": ["BUILDING", "LOC", "STREET"]},
+                }
+            },
         }
     }
 
     hipe_stats["v2.0"] = hipe_stats.get("v1.0").copy()
     hipe_stats["v2.0"]["ajmc"] = {
         "de": {
-            "train": {"sents": 1022 + 2, "docs": 76},  # 2 sentences with missing EOS marker
-            "dev": {"sents": 192, "docs": 14},
+            "train": {
+                "sents": 1022 + 2,  # 2 sentences with missing EOS marker
+                "docs": 76,
+                "labels": ["date", "loc", "object", "pers", "scope", "work"],
+            },
+            "dev": {"sents": 192, "docs": 14, "labels": ["loc", "object", "pers", "scope", "work"]},
         },
         "en": {
-            "train": {"sents": 1153 + 1, "docs": 60},  # 1 sentence with missing EOS marker
-            "dev": {"sents": 251 + 1, "docs": 14},  # 1 sentence with missing EOS marker
+            "train": {
+                "sents": 1153 + 1,  # 1 sentence with missing EOS marker
+                "docs": 60,
+                "labels": ["date", "loc", "object", "pers", "scope", "work"],
+            },
+            "dev": {
+                "sents": 251 + 1,  # 1 sentence with missing EOS marker
+                "docs": 14,
+                "labels": ["date", "loc", "pers", "scope", "work"],
+            },
         },
         "fr": {
-            "train": {"sents": 893 + 1, "docs": 72},  # 1 sentence with missing EOS marker
-            "dev": {"sents": 201 + 1, "docs": 17},  # 1 sentence with missing EOS marker
+            "train": {
+                "sents": 893 + 1,  # 1 sentence with missing EOS marker
+                "docs": 72,
+                "labels": ["date", "loc", "object", "pers", "scope", "work"],
+            },
+            "dev": {
+                "sents": 201 + 1,  # 1 sentence with missing EOS marker
+                "docs": 17,
+                "labels": ["pers", "scope", "work"],
+            },
         },
     }
-    hipe_stats["v2.0"]["newseye"] = {"de": {"train": {"sents": 20839 + 1, "docs": 7}}}  # missing EOD marker
+    hipe_stats["v2.0"]["newseye"] = {
+        "de": {
+            "train": {"sents": 20839 + 1, "docs": 7, "labels": ["HumanProd", "LOC", "ORG", "PER"]}  # missing EOD marker
+        }
+    }
     hipe_stats["v2.0"]["sonar"] = {
-        "de": {"dev": {"sents": 816 + 10, "docs": 10}}  # 9 sentences with missing EOS marker + missing EOD
+        "de": {
+            "dev": {
+                "sents": 816 + 10,  # 9 sentences with missing EOS marker + missing EOD
+                "docs": 10,
+                "labels": ["LOC", "ORG", "PER"],
+            }
+        }
     }
 
     def test_hipe_2022(dataset_version="v1.0", add_document_separator=True):
@@ -450,16 +505,34 @@ def test_hipe_2022_corpus(tasks_base_path):
                 for split_name, stats in splits.items():
                     split_description = f"{dataset_name}/{language}@{split_name}"
 
-                    total_sentences = sum(stats.values()) if add_document_separator else stats["sents"]
+                    current_sents = stats["sents"]
+                    current_docs = stats["docs"]
+                    current_labels = set(stats["labels"] + ["<unk>"])
+
+                    total_sentences = current_sents + current_docs if add_document_separator else stats["sents"]
 
                     if split_name == "train":
                         assert (
                             len(corpus.train) == total_sentences
                         ), f"Sentence count mismatch for {split_description}: {len(corpus.train)} vs. {total_sentences}"
+
+                        gold_labels = set(corpus.make_label_dictionary(label_type="ner").get_items())
+
+                        assert (
+                            current_labels == gold_labels
+                        ), f"Label mismatch for {split_description}: {current_labels} vs. {gold_labels}"
+
                     elif split_name in ["dev", "sample"]:
                         assert (
                             len(corpus.dev) == total_sentences
                         ), f"Sentence count mismatch for {split_description}: {len(corpus.dev)} vs. {total_sentences}"
+
+                        corpus._train = corpus._dev
+                        gold_labels = set(corpus.make_label_dictionary(label_type="ner").get_items())
+
+                        assert (
+                            current_labels == gold_labels
+                        ), f"Label mismatch for {split_description}: {current_labels} vs. {gold_labels}"
                     elif split_name == "dev2":
                         corpus = flair.datasets.NER_HIPE_2022(
                             version=dataset_version,
@@ -469,9 +542,16 @@ def test_hipe_2022_corpus(tasks_base_path):
                             add_document_separator=add_document_separator,
                         )
 
+                        corpus._train = corpus._dev
+                        gold_labels = set(corpus.make_label_dictionary(label_type="ner").get_items())
+
                         assert (
                             len(corpus.dev) == total_sentences
                         ), f"Sentence count mismatch for {split_description}: {len(corpus.dev)} vs. {total_sentences}"
+
+                        assert (
+                            current_labels == gold_labels
+                        ), f"Label mismatch for {split_description}: {current_labels} vs. {gold_labels}"
 
     test_hipe_2022(dataset_version="v1.0", add_document_separator=True)
     test_hipe_2022(dataset_version="v1.0", add_document_separator=False)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,5 @@
 import shutil
 
-from importlib_metadata import version
-
 import pytest
 
 import flair

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -439,7 +439,7 @@ def test_hipe_2022_corpus(tasks_base_path):
         }
     }
 
-    hipe_stats["v2.0"] = hipe_stats.get("v1.0").copy()
+    hipe_stats["v2.0"] = hipe_stats["v1.0"].copy()
     hipe_stats["v2.0"]["ajmc"] = {
         "de": {
             "train": {

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,7 @@
 import shutil
 
+from importlib_metadata import version
+
 import pytest
 
 import flair
@@ -414,12 +416,29 @@ def test_hipe_2022_corpus(tasks_base_path):
         }
     }
 
+    hipe_stats["v2.0"] = hipe_stats.get("v1.0").copy()
+    hipe_stats["v2.0"]["ajmc"] = {
+        "de": {
+            "train": {"sents": 1022 + 2, "docs": 76},  # 2 sentences with missing EOS marker
+            "dev": {"sents": 192, "docs": 14},
+        },
+        "en": {
+            "train": {"sents": 1153 + 1, "docs": 60},  # 1 sentence with missing EOS marker
+            "dev": {"sents": 251 + 1, "docs": 14},  # 1 sentence with missing EOS marker
+        },
+        "fr": {
+            "train": {"sents": 893 + 1, "docs": 72},  # 1 sentence with missing EOS marker
+            "dev": {"sents": 201 + 1, "docs": 17},  # 1 sentence with missing EOS marker
+        },
+    }
+
     def test_hipe_2022(dataset_version="v1.0", add_document_separator=True):
         for dataset_name, languages in hipe_stats[dataset_version].items():
             for language in languages:
                 splits = languages[language]
 
                 corpus = flair.datasets.NER_HIPE_2022(
+                    version=dataset_version,
                     dataset_name=dataset_name,
                     language=language,
                     dev_split_name="dev",
@@ -441,6 +460,7 @@ def test_hipe_2022_corpus(tasks_base_path):
                         ), f"Sentence count mismatch for {split_description}: {len(corpus.dev)} vs. {total_sentences}"
                     elif split_name == "dev2":
                         corpus = flair.datasets.NER_HIPE_2022(
+                            version=dataset_version,
                             dataset_name=dataset_name,
                             language=language,
                             dev_split_name="dev2",
@@ -451,8 +471,10 @@ def test_hipe_2022_corpus(tasks_base_path):
                             len(corpus.dev) == total_sentences
                         ), f"Sentence count mismatch for {split_description}: {len(corpus.dev)} vs. {total_sentences}"
 
-    test_hipe_2022(add_document_separator=True)
-    test_hipe_2022(add_document_separator=False)
+    test_hipe_2022(dataset_version="v1.0", add_document_separator=True)
+    test_hipe_2022(dataset_version="v1.0", add_document_separator=False)
+    test_hipe_2022(dataset_version="v2.0", add_document_separator=True)
+    test_hipe_2022(dataset_version="v2.0", add_document_separator=False)
 
 
 def test_multi_file_jsonl_corpus_should_use_label_type(tasks_base_path):


### PR DESCRIPTION
Hi,

this PR adds support for v2.0 of the HIPE-2022 dataset.

The following changes were introduced:

* Version number is now part of the (internal, chached) dataset path. Now, `~/.flair/datasets/ner_hipe_2022` gets the version number appended, e.g. `~/.flair/datasets/ner_hipe_2022/v2.0`.
* The branch name argument is added to the `NER_HIPE_2022` constructor. It is now possible to specify the desired branch name for the HIPE upstream data repo.
* New splits (train and dev) for German, English and French for the AJMC dataset are introduced with the v2.0.
* SONAR Dev split is updated.
* NewsEye German train split is filtered (removal of unannotated documents).
* Extensive tests for label dictionary (all datasets/languages/splits) added.

PR in the HIPE upstream data repo: https://github.com/hipe-eval/HIPE-2022-data/pull/3 and [release notes here](https://github.com/hipe-eval/HIPE-2022-data/releases/tag/v2.0).