### PR TITLE
Fix the SciSpacyTokenizer.tokenize() bug

### DIFF
--- a/flair/tokenization.py
+++ b/flair/tokenization.py
@@ -256,7 +256,7 @@ class SciSpacyTokenizer(Tokenizer):
         sentence = self.model(text)
         words: List[str] = []
         for word in sentence:
-            word.append(word)
+            words.append(word.text)
         return words
 
     @property


### PR DESCRIPTION
Fixes #2710 

Makes sure the words are added to the correct list variable and that strings (not SpaCy Token objects) are returned.