### PR TITLE
GH-2717: Add option to ignore labels in dataset

### DIFF
--- a/flair/datasets/relation_extraction.py
+++ b/flair/datasets/relation_extraction.py
@@ -39,6 +39,7 @@ class RE_ENGLISH_SEMEVAL2010(ColumnCorpus):
         base_path: Union[str, Path] = None,
         in_memory: bool = True,
         augment_train: bool = False,
+        **corpusargs,
     ):
         """
         SemEval-2010 Task 8 on Multi-Way Classification of Semantic Relations Between Pairs of
@@ -83,6 +84,7 @@ class RE_ENGLISH_SEMEVAL2010(ColumnCorpus):
             column_format={1: "text", 2: "ner"},
             comment_symbol="# ",
             in_memory=in_memory,
+            **corpusargs,
         )
 
     def extract_and_convert_to_conllu(self, data_file, data_folder, augment_train):
@@ -227,7 +229,7 @@ class RE_ENGLISH_SEMEVAL2010(ColumnCorpus):
 
 
 class RE_ENGLISH_TACRED(ColumnCorpus):
-    def __init__(self, base_path: Union[str, Path] = None, in_memory: bool = True):
+    def __init__(self, base_path: Union[str, Path] = None, in_memory: bool = True, **corpusargs):
         """
         TAC Relation Extraction Dataset with 41 relations from https://nlp.stanford.edu/projects/tacred/.
         Manual download is required for this dataset.
@@ -260,6 +262,7 @@ class RE_ENGLISH_TACRED(ColumnCorpus):
             column_format={1: "text", 2: "ner"},
             comment_symbol="# ",
             in_memory=in_memory,
+            **corpusargs,
         )
 
     def extract_and_convert_to_conllu(self, data_file, data_folder):
@@ -351,7 +354,7 @@ class RE_ENGLISH_TACRED(ColumnCorpus):
 
 
 class RE_ENGLISH_CONLL04(ColumnCorpus):
-    def __init__(self, base_path: Union[str, Path] = None, in_memory: bool = True):
+    def __init__(self, base_path: Union[str, Path] = None, in_memory: bool = True, **corpusargs):
         if not base_path:
             base_path = flair.cache_root / "datasets"
         else:
@@ -385,6 +388,7 @@ class RE_ENGLISH_CONLL04(ColumnCorpus):
             in_memory=in_memory,
             column_format={1: "text", 2: "ner"},
             comment_symbol="# ",
+            **corpusargs,
         )
 
     def _parse_incr(self, source_file) -> Iterable[conllu.TokenList]:
@@ -536,6 +540,7 @@ class RE_ENGLISH_DRUGPROT(ColumnCorpus):
         base_path: Union[str, Path] = None,
         in_memory: bool = True,
         sentence_splitter: SentenceSplitter = SegtokSentenceSplitter(),
+        **corpusargs,
     ):
         """
         DrugProt corpus: Biocreative VII Track 1 from https://zenodo.org/record/5119892#.YSdSaVuxU5k/ on
@@ -570,6 +575,7 @@ class RE_ENGLISH_DRUGPROT(ColumnCorpus):
             sample_missing_splits=False,
             column_format={1: "text", 2: "ner", 3: "ner"},
             comment_symbol="# ",
+            **corpusargs,
         )
 
     def extract_and_convert_to_conllu(self, data_file, data_folder):

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -662,7 +662,8 @@ class ColumnDataset(FlairDataset):
                     for span_indices, score, label in predicted_spans:
                         span = sentence[span_indices[0] : span_indices[-1] + 1]
                         value = self._remap_label(label)
-                        span.add_label(span_level_tag_columns[span_column], value=value, score=score)
+                        if value != 'O':
+                            span.add_label(span_level_tag_columns[span_column], value=value, score=score)
                 except Exception:
                     pass
 
@@ -681,7 +682,9 @@ class ColumnDataset(FlairDataset):
                     relation = Relation(
                         first=sentence[head_start - 1 : head_end], second=sentence[tail_start - 1 : tail_end]
                     )
-                    relation.add_label(typename="relation", value=self._remap_label(label))
+                    remapped = self._remap_label(label)
+                    if remapped != 'O':
+                        relation.add_label(typename="relation", value=remapped)
 
         if len(sentence) > 0:
             return sentence
@@ -719,7 +722,8 @@ class ColumnDataset(FlairDataset):
                                 # add each other feature as label-value pair
                                 label_name = feature.split("=")[0]
                                 label_value = self._remap_label(feature.split("=")[1])
-                                token.add_label(label_name, label_value)
+                                if label_value != 'O':
+                                    token.add_label(label_name, label_value)
 
                     else:
                         # get the task name (e.g. 'ner')
@@ -727,7 +731,8 @@ class ColumnDataset(FlairDataset):
                         # get the label value
                         label_value = self._remap_label(fields[column])
                         # add label
-                        token.add_label(label_name, label_value)
+                        if label_value != 'O':
+                            token.add_label(label_name, label_value)
 
                 if column_name_map[column] == self.SPACE_AFTER_KEY and fields[column] == "-":
                     token.whitespace_after = False

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -662,7 +662,7 @@ class ColumnDataset(FlairDataset):
                     for span_indices, score, label in predicted_spans:
                         span = sentence[span_indices[0] : span_indices[-1] + 1]
                         value = self._remap_label(label)
-                        if value != 'O':
+                        if value != "O":
                             span.add_label(span_level_tag_columns[span_column], value=value, score=score)
                 except Exception:
                     pass
@@ -683,7 +683,7 @@ class ColumnDataset(FlairDataset):
                         first=sentence[head_start - 1 : head_end], second=sentence[tail_start - 1 : tail_end]
                     )
                     remapped = self._remap_label(label)
-                    if remapped != 'O':
+                    if remapped != "O":
                         relation.add_label(typename="relation", value=remapped)
 
         if len(sentence) > 0:
@@ -722,7 +722,7 @@ class ColumnDataset(FlairDataset):
                                 # add each other feature as label-value pair
                                 label_name = feature.split("=")[0]
                                 label_value = self._remap_label(feature.split("=")[1])
-                                if label_value != 'O':
+                                if label_value != "O":
                                     token.add_label(label_name, label_value)
 
                     else:
@@ -731,7 +731,7 @@ class ColumnDataset(FlairDataset):
                         # get the label value
                         label_value = self._remap_label(fields[column])
                         # add label
-                        if label_value != 'O':
+                        if label_value != "O":
                             token.add_label(label_name, label_value)
 
                 if column_name_map[column] == self.SPACE_AFTER_KEY and fields[column] == "-":


### PR DESCRIPTION
This PR adds the option to ignore selected labels in any dataset that inherits from `ColumnCorpus` (i.e. nearly all datasets in Flair).

You can use the label_name_map to achieve this, by mapping all labels you don't want to learn to 'O'. The following snippet shows how to rename and ignore WNUT 17 labels so that it looks like the NER classes from CoNLL-03: 

```python
from flair.datasets import WNUT_17

# load WNUT 17 corpus with all regular labels
corpus = WNUT_17(in_memory=False)
print(corpus.make_label_dictionary('ner'))

# load WNUT 17 but rename the label 'person' to 'PER', location to 'LOC' and both 'group' and 'corporation' to ORG
corpus = WNUT_17(in_memory=False, label_name_map={
    'person': 'PER',
    'location': 'LOC',
    'group': 'ORG',
    'corporation': 'ORG',
})
print(corpus.make_label_dictionary('ner'))

# load WNUT 17 and rename like above but also ignore all 'creative-work' and 'product' entities
corpus = WNUT_17(in_memory=False, label_name_map={
    'person': 'PER',
    'location': 'LOC',
    'group': 'ORG',
    'corporation': 'ORG',
    'product': 'O',
    'creative-work': 'O', # by renaming to 'O' this tag gets ignored
})
print(corpus.make_label_dictionary('ner'))
```

This should print: 
~~~
Dictionary with 4 tags: <unk>, PER, LOC, ORG
~~~