### PR TITLE
Remove unnecessary more-itertools pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ janome
 gdown==3.12.2
 huggingface-hub
 conllu>=4.0
-more-itertools~=8.8.0
+more-itertools
 wikipedia-api
 pptree


### PR DESCRIPTION
The dependency and the pin were added in https://github.com/flairNLP/flair/pull/2312/files. more-itertools is a pretty stable library and the one function that is used has been present for the last 6 major versions.