### PR TITLE
fix wrong initialisations of label (where data_type was missing) and …

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -198,7 +198,7 @@ class Label:
     score needs to be between 0.0 and 1.0. Default value for the score is 1.0.
     """
 
-    def __init__(self, data_point, value: Optional[str], score: float = 1.0):
+    def __init__(self, data_point: "DataPoint", value: Optional[str], score: float = 1.0):
         self._value = value
         self._score = score
         self.data_point: DataPoint = data_point

--- a/flair/models/diagnosis/distance_prediction_model.py
+++ b/flair/models/diagnosis/distance_prediction_model.py
@@ -12,7 +12,7 @@ from torch.utils.data.dataset import Dataset
 
 import flair.embeddings
 import flair.nn
-from flair.data import Label, Sentence, _iter_dataset
+from flair.data import Sentence, _iter_dataset
 from flair.training_utils import MetricRegression, Result, store_embeddings
 
 log = logging.getLogger("flair")
@@ -476,30 +476,11 @@ class DistancePredictor(flair.nn.Model[Sentence]):
             log.warning("Ignore {} sentence(s) with no tokens.".format(len(sentences) - len(filtered_sentences)))
         return filtered_sentences
 
-    def _obtain_labels(self, scores: List[List[float]], predict_prob: bool = False) -> List[List[Label]]:
-        """
-        Predicts the labels of sentences.
-        :param scores: the prediction scores from the model
-        :return: list of predicted labels
-        """
-
-        if predict_prob:
-            return [self._predict_label_prob(s) for s in scores]
-
-        return [self._get_single_label(s) for s in scores]
-
     def _get_single_label(self, label_scores):  # -> List[Label]:
         softmax = torch.nn.functional.softmax(label_scores, dim=0)
         conf, idx = torch.max(softmax, 0)
 
         return idx.item()
-
-    def _predict_label_prob(self, label_scores) -> List[Label]:
-        softmax = torch.nn.functional.softmax(label_scores, dim=0)
-        label_probs = []
-        for idx, conf in enumerate(softmax):
-            label_probs.append(Label(str(idx), conf.item()))
-        return label_probs
 
     def __str__(self):
         return (

--- a/tests/test_sequence_tagger.py
+++ b/tests/test_sequence_tagger.py
@@ -52,6 +52,21 @@ def test_load_use_tagger_keep_embedding():
 
 
 @pytest.mark.integration
+def test_all_tag_proba_embedding():
+    loaded_model: SequenceTagger = SequenceTagger.load("ner")
+
+    sentence = Sentence("I love Berlin")
+    loaded_model.predict(sentence, return_probabilities_for_all_classes=True)
+    for token in sentence:
+        assert len(token.get_tags_proba_dist(loaded_model.tag_type)) == len(loaded_model.label_dictionary)
+        score_sum = 0
+        for label in token.get_tags_proba_dist(loaded_model.tag_type):
+            assert label.data_point == token
+            score_sum += label.score
+        assert abs(score_sum - 1.0) < 1.0e-5
+
+
+@pytest.mark.integration
 def test_train_load_use_tagger(results_base_path, tasks_base_path):
     corpus = flair.datasets.ColumnCorpus(data_folder=tasks_base_path / "fashion", column_format={0: "text", 3: "ner"})
     tag_dictionary = corpus.make_label_dictionary("ner")


### PR DESCRIPTION
I noticed that predicting a sentence via a sequence tagger and passing 'return_probabilities_for_all_classes=True' lead to some issues like it works only on cpu and produces corrupted labels that cannot be displayed properly.
To mitigate the issuse with the creation of currpted labels, I updated the type hints and also looked at the distance prediction model as it also had a function.
For the distance prediction model I noticed that the respective functions are not used (and it also doesn't have a predict function, which I find strange) hence I deleted them.
 