### PR TITLE
Bf/test dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ types-Deprecated
 types-dataclasses
 types-tabulate
 types-requests
+pytest-github-actions-annotate-failures

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,8 @@
-pytest==6.2.5
+pytest>=7.0.0
 pytest-mypy
 pytest-isort
-pytest-flake8
+pytest-flake8-v2
 flake8-black
-flake8<4.0.0
 types-Deprecated
 types-dataclasses
 types-tabulate


### PR DESCRIPTION
update pytest and flake8 versions (all plugins are pytest 7.0 compatible by now)

try out https://github.com/utgwkk/pytest-github-actions-annotate-failures which should annotate pytest errors and therefore provide easier feedback for possible errors