### PR TITLE
#2742 added missing property decorator in PooledFlairEmbeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -865,6 +865,7 @@ class PooledFlairEmbeddings(TokenEmbeddings):
 
         return sentences
 
+    @property
     def embedding_length(self) -> int:
         return self.__embedding_length
 


### PR DESCRIPTION
As reported in #2742, there was a problem with getting the `embedding_length` from the `PooledFlairEmbeddings`.
The `@proberty` decorator was missing above the `embedding_length` method of the PooledFlairEmbedding class.
I added it in token.py (line 868), so now it's:
```
@property
def embedding_length(self) -> int:
    return self.__embedding_length
```
This should resolve the problem in #2742.