### PR TITLE
github actions cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      TRANSFORMERS_CACHE: ~/cache/transformers
+      FLAIR_CACHE_ROOT: ~/cache/flair
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.6
@@ -19,5 +22,11 @@ jobs:
         run: pip install -r requirements-dev.txt
       - name: Show installed dependencies
         run: pip freeze
+      - name: Cache downloaded models/datasets
+        uses: actions/cache@v3
+        with:
+          path: ~/cache
+          key: cache-v1
+          # TODO: remove this comment in the follow up commit where the cache is already created.
       - name: Run tests
         run: pytest --runintegration -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,5 @@ jobs:
         with:
           path: ./cache
           key: cache-v1.1
-          # TODO: remove this comment in the follow up commit where the cache is already created.
       - name: Run tests
         run: pytest --runintegration -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      TRANSFORMERS_CACHE: ~/cache/transformers
-      FLAIR_CACHE_ROOT: ~/cache/flair
+      TRANSFORMERS_CACHE: ./cache/transformers
+      FLAIR_CACHE_ROOT: ./cache/flair
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.6
@@ -25,8 +25,8 @@ jobs:
       - name: Cache downloaded models/datasets
         uses: actions/cache@v3
         with:
-          path: ~/cache
-          key: cache-v1
+          path: ./cache
+          key: cache-v1.1
           # TODO: remove this comment in the follow up commit where the cache is already created.
       - name: Run tests
         run: pytest --runintegration -vv

--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -7,6 +7,7 @@ from transformers import set_seed as hf_set_seed
 
 # global variable: cache_root
 cache_root = Path(os.getenv("FLAIR_CACHE_ROOT", Path(Path.home(), ".flair")))
+cache_root.mkdir(exist_ok=True, parents=True)
 
 # global variable: device
 if torch.cuda.is_available():

--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -7,7 +7,6 @@ from transformers import set_seed as hf_set_seed
 
 # global variable: cache_root
 cache_root = Path(os.getenv("FLAIR_CACHE_ROOT", Path(Path.home(), ".flair")))
-cache_root.mkdir(exist_ok=True, parents=True)
 
 # global variable: device
 if torch.cuda.is_available():

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -82,8 +82,7 @@ def cached_path(url_or_filename: str, cache_dir: Union[str, Path]) -> Path:
     return the path to the cached file. If it's already a local path,
     make sure the file exists and then return the path.
     """
-    if type(cache_dir) is str:
-        cache_dir = Path(cache_dir)
+    cache_dir = Path(cache_dir)
 
     if flair.cache_root not in cache_dir.parents:
         dataset_cache = flair.cache_root / cache_dir

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -84,7 +84,11 @@ def cached_path(url_or_filename: str, cache_dir: Union[str, Path]) -> Path:
     """
     if type(cache_dir) is str:
         cache_dir = Path(cache_dir)
-    dataset_cache = flair.cache_root / cache_dir
+
+    if flair.cache_root not in cache_dir.parents:
+        dataset_cache = flair.cache_root / cache_dir
+    else:
+        dataset_cache = cache_dir
 
     parsed = urlparse(url_or_filename)
 


### PR DESCRIPTION
cache models/datasets that are used in pytest. This should speed up tests on all parts that involve downloading flair or huggingface specific models/embeddings/datasets.

If at some point the cache leads to incorrect tests (e.g. a model is updated without getting a new name), the cache can be reset by updating `key: cache-v1` to `key: cache-v<n>` (n being an incremental number) such that the next pass downloads all models again. The old cache key will then be available for one more week and then be automatically deleted.

This PR also fixes a small bug, where cached paths have repeated folder structure if the cached path (e.g. setting the cache folder to `cache/flair` lead to the structure being `cache/flair/cache/flair/embeddings/...` instead of `cache/flair`

comparing the last two test runs (first one was uncached, second was cached) there is a difference of 5:37, even when removing the time the uncached needed for uploading the cache) wich leads to a reduction of ~34%