### PR TITLE
GH-2763: remove legacy TransformerXLEmbeddings class

### DIFF
--- a/flair/embeddings/__init__.py
+++ b/flair/embeddings/__init__.py
@@ -33,7 +33,6 @@ from .legacy import (
     OpenAIGPT2Embeddings,
     OpenAIGPTEmbeddings,
     RoBERTaEmbeddings,
-    TransformerXLEmbeddings,
     XLMEmbeddings,
     XLMRobertaEmbeddings,
     XLNetEmbeddings,

--- a/flair/embeddings/legacy.py
+++ b/flair/embeddings/legacy.py
@@ -8,9 +8,6 @@ from deprecated import deprecated
 from transformers import (
     AlbertModel,
     AlbertTokenizer,
-    AutoConfig,
-    AutoModel,
-    AutoTokenizer,
     BertModel,
     BertTokenizer,
     CamembertModel,
@@ -23,9 +20,6 @@ from transformers import (
     PreTrainedTokenizer,
     RobertaModel,
     RobertaTokenizer,
-    T5Tokenizer,
-    TransfoXLModel,
-    TransfoXLTokenizer,
     XLMModel,
     XLMRobertaModel,
     XLMRobertaTokenizer,
@@ -345,67 +339,6 @@ class CharLMEmbeddings(TokenEmbeddings):
                 ]
 
         return sentences
-
-    def __str__(self):
-        return self.name
-
-
-class TransformerXLEmbeddings(TokenEmbeddings):
-    @deprecated(
-        version="0.4.5",
-        reason="Use 'TransformerWordEmbeddings' for all transformer-based word embeddings",
-    )
-    def __init__(
-        self,
-        pretrained_model_name_or_path: str = "transfo-xl-wt103",
-        layers: str = "1,2,3",
-        use_scalar_mix: bool = False,
-    ):
-        """Transformer-XL embeddings, as proposed in Dai et al., 2019.
-        :param pretrained_model_name_or_path: name or path of Transformer-XL model
-        :param layers: comma-separated list of layers
-        :param use_scalar_mix: defines the usage of scalar mix for specified layer(s)
-        """
-        super().__init__()
-
-        self.tokenizer = TransfoXLTokenizer.from_pretrained(pretrained_model_name_or_path)
-        self.model = TransfoXLModel.from_pretrained(
-            pretrained_model_name_or_path=pretrained_model_name_or_path,
-            output_hidden_states=True,
-        )
-        self.name = pretrained_model_name_or_path
-        self.layers: List[int] = [int(layer) for layer in layers.split(",")]
-        self.use_scalar_mix = use_scalar_mix
-        self.static_embeddings = True
-
-        dummy_sentence: Sentence = Sentence()
-        dummy_sentence.add_token(Token("hello"))
-        embedded_dummy = self.embed(dummy_sentence)
-        self.__embedding_length: int = len(embedded_dummy[0].get_token(1).get_embedding())
-
-    @property
-    def embedding_length(self) -> int:
-        return self.__embedding_length
-
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
-        self.model.to(flair.device)
-        self.model.eval()
-
-        sentences = _get_transformer_sentence_embeddings(
-            sentences=sentences,
-            tokenizer=self.tokenizer,
-            model=self.model,
-            name=self.name,
-            layers=self.layers,
-            pooling_operation="first",
-            use_scalar_mix=self.use_scalar_mix,
-            eos_token="<eos>",
-        )
-
-        return sentences
-
-    def extra_repr(self):
-        return "model={}".format(self.name)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Closes #2763 

The recent transformers update (4.19.0, see https://github.com/huggingface/transformers/pull/17049) removed the sacremoses dependency which was required by a legacy embedding class in Flair (marked as deprecated since Flair 0.4.5). This PR fixes the issue by removing the legacy class. 

(All other legacy embeddings in Flair should be removed as well before the next bigger release to avoid such problems in the future.)