### PR TITLE
Update konoha upper bound

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pytest-isort
 pytest-flake8
 flake8-black
 flake8<4.0.0
+importlib-metadata<4.3
 types-Deprecated
 types-dataclasses
 types-tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ langdetect
 lxml
 ftfy
 sentencepiece==0.1.95
-konoha<5.0.0,>=4.0.0
+konoha<6.0.0,>=4.0.0
 janome
 gdown==4.4.0
 huggingface-hub


### PR DESCRIPTION
You can find the list of changes in konoha 5.0 here:
https://github.com/himkt/konoha/releases/tag/v5.0.0

None of them appear to affect flair.

(In general, I recommend against potentially unnecessary pins in
libraries. The reason I'm here is actually because konoha in turn
had an unnecessary pin of another library that we needed to update)