### PR TITLE
remove wrong boolean check for loading datasets RE_ENGLISH_CONLL04

### DIFF
--- a/flair/datasets/relation_extraction.py
+++ b/flair/datasets/relation_extraction.py
@@ -372,7 +372,7 @@ class RE_ENGLISH_CONLL04(ColumnCorpus):
         )
         data_file = data_folder / "conll04-train.conllu"
 
-        if True or not data_file.is_file():
+        if not data_file.is_file():
             source_data_folder = data_folder / "original"
             cached_path(f"{conll04_url}train.txt", source_data_folder)
             cached_path(f"{conll04_url}dev.txt", source_data_folder)


### PR DESCRIPTION
Hello,
I found a wrong boolean check-in in `relation extraction conll04 loading` scripts in line [375](https://github.com/flairNLP/flair/blob/f44e7e14e7b9cc9abb517d4488ad368684d3d395/flair/datasets/relation_extraction.py#L375)
I have removed the wrong boolean from the line and it seems fine now.
Please check the details and if possible merge this pull request.

Thanks and regards
Sagor