### PR TITLE
GH-2786: Add test data for HIPE-2022

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -4258,6 +4258,10 @@ class NER_HIPE_2022(ColumnCorpus):
 
         dataset_splits = hipe_available_splits[version][dataset_name][language]
 
+        if version == "v2.1":
+            # test datasets are only available for >= v2.1
+            dataset_splits.append("test")
+
         for split in dataset_splits:
             cached_path(
                 f"{data_url}/HIPE-2022-{version}-{dataset_name}-{split}-{language}.tsv", data_folder / "original"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -495,7 +495,7 @@ def test_hipe_2022_corpus(tasks_base_path):
         }
     }
 
-    hipe_stats["v2.0"] = hipe_stats["v1.0"].copy()
+    hipe_stats["v2.0"] = copy.deepcopy(hipe_stats["v1.0"])
     hipe_stats["v2.0"]["ajmc"] = {
         "de": {
             "train": {

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -530,10 +530,8 @@ def test_hipe_2022_corpus(tasks_base_path):
             },
         },
     }
-    hipe_stats["v2.0"]["newseye"] = {
-        "de": {
-            "train": {"sents": 20839 + 1, "docs": 7, "labels": ["HumanProd", "LOC", "ORG", "PER"]}  # missing EOD marker
-        }
+    hipe_stats["v2.0"]["newseye"]["de"] = {
+        "train": {"sents": 20839 + 1, "docs": 7, "labels": ["HumanProd", "LOC", "ORG", "PER"]}  # missing EOD marker
     }
     hipe_stats["v2.0"]["sonar"] = {
         "de": {
@@ -549,6 +547,69 @@ def test_hipe_2022_corpus(tasks_base_path):
         "sents": 5743,
         "docs": 158,
         "labels": ["loc", "org", "pers", "prod", "time"],
+    }
+
+    # Test data for v2.1 release
+    hipe_stats["v2.1"]["ajmc"]["de"]["test"] = {
+        "sents": 224,
+        "docs": 16,
+        "labels": ["loc", "object", "pers", "scope", "work"],
+    }
+    hipe_stats["v2.1"]["ajmc"]["en"]["test"] = {
+        "sents": 238,
+        "docs": 13,
+        "labels": ["date", "loc", "pers", "scope", "work"],
+    }
+    hipe_stats["v2.1"]["ajmc"]["fr"]["test"] = {
+        "sents": 188 + 1,  # 1 sentence with missing EOS marker
+        "docs": 15,
+        "labels": ["date", "loc", "pers", "scope", "work"],
+    }
+    hipe_stats["v2.1"]["hipe2020"]["de"]["test"] = {
+        "sents": 1215 + 2,  # 2 sentences with missing EOS marker
+        "docs": 49,
+        "labels": ["loc", "org", "pers", "prod", "time"],
+    }
+    hipe_stats["v2.1"]["hipe2020"]["en"]["test"] = {
+        "sents": 553,
+        "docs": 46,
+        "labels": ["loc", "org", "pers", "prod", "time"],
+    }
+    hipe_stats["v2.1"]["hipe2020"]["fr"]["test"] = {
+        "sents": 1462,
+        "docs": 43,
+        "labels": ["loc", "org", "pers", "prod", "time"],
+    }
+    hipe_stats["v2.1"]["letemps"]["fr"]["test"] = {"sents": 2381, "docs": 51, "labels": ["loc", "org", "pers"]}
+    hipe_stats["v2.1"]["newseye"]["de"]["test"] = {
+        "sents": 3336 + 1,  # 1 missing EOD marker
+        "docs": 13,
+        "labels": ["HumanProd", "LOC", "ORG", "PER"],
+    }
+    hipe_stats["v2.1"]["newseye"]["fi"]["test"] = {
+        "sents": 390 + 1,  # 1 missing EOD marker
+        "docs": 24,
+        "labels": ["HumanProd", "LOC", "ORG", "PER"],
+    }
+    hipe_stats["v2.1"]["newseye"]["fr"]["test"] = {
+        "sents": 2534 + 1,  # 1 missing EOD marker
+        "docs": 35,
+        "labels": ["HumanProd", "LOC", "ORG", "PER"],
+    }
+    hipe_stats["v2.1"]["newseye"]["sv"]["test"] = {
+        "sents": 342 + 1,  # 1 missing EOD marker
+        "docs": 21,
+        "labels": ["HumanProd", "LOC", "ORG", "PER"],
+    }
+    hipe_stats["v2.1"]["sonar"]["de"]["test"] = {
+        "sents": 807 + 8 + 1,  # 8 missing EOS marker + missing EOD
+        "docs": 10,
+        "labels": ["LOC", "ORG", "PER"],
+    }
+    hipe_stats["v2.1"]["topres19th"]["en"]["test"] = {
+        "sents": 2001,
+        "docs": 112,
+        "labels": ["BUILDING", "LOC", "STREET"],
     }
 
     def test_hipe_2022(dataset_version="v2.1", add_document_separator=True):


### PR DESCRIPTION
Hi,

this PR adds test data for the HIPE-2022 shared task.

Test data for all datasets were recently released, see their release notes: https://github.com/hipe-eval/HIPE-2022-data/releases/tag/v2.1-test-all-unmasked