### PR TITLE
more precise type hint for eval_on_train_fraction

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -8,7 +8,7 @@ import time
 import warnings
 from inspect import signature
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import torch
 from torch.optim.sgd import SGD
@@ -106,7 +106,7 @@ class ModelTrainer:
         sampler=None,
         use_amp: bool = False,
         amp_opt_level: str = "O1",
-        eval_on_train_fraction: Union[float, Literal["dev"]] = 0.0,
+        eval_on_train_fraction: Union[float, str] = 0.0,
         eval_on_train_shuffle: bool = False,
         save_model_each_k_epochs: int = 0,
         tensorboard_comment: str = "",

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -8,7 +8,7 @@ import time
 import warnings
 from inspect import signature
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, cast
 
 import torch
 from torch.optim.sgd import SGD
@@ -106,7 +106,7 @@ class ModelTrainer:
         sampler=None,
         use_amp: bool = False,
         amp_opt_level: str = "O1",
-        eval_on_train_fraction: float = 0.0,
+        eval_on_train_fraction: Union[float, Literal["dev"]] = 0.0,
         eval_on_train_shuffle: bool = False,
         save_model_each_k_epochs: int = 0,
         tensorboard_comment: str = "",


### PR DESCRIPTION
The train() method of trainer.py accepts an eval_on_train_fraction parameter, with either a float or "dev" literal string value (see docstring). This commit adds the "dev" literal option to the type hint.