### PR TITLE
Fix left-over cases of token.get_tag(), which was renamed

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -983,20 +983,6 @@ class Sentence(DataPoint):
     def __repr__(self):
         return self.__str__()
 
-    def __copy__(self):
-        s = Sentence()
-        for token in self.tokens:
-            nt = Token(token.text)
-            for tag_type in token.tags:
-                nt.add_label(
-                    tag_type,
-                    token.get_tag(tag_type).value,
-                    token.get_tag(tag_type).score,
-                )
-
-            s.add_token(nt)
-        return s
-
     @property
     def start_position(self) -> int:
         return 0
@@ -1418,7 +1404,7 @@ class Corpus:
         for sent in sentences:
             for token in sent.tokens:
                 if label_type in token.annotation_layers.keys():
-                    label = token.get_tag(label_type)
+                    label = token.get_label(label_type)
                     label_count[label.value] += 1
         return label_count
 
@@ -1521,7 +1507,7 @@ class Corpus:
         tag_dictionary.add_item("O")
         for sentence in _iter_dataset(self.get_all_sentences()):
             for token in sentence.tokens:
-                tag_dictionary.add_item(token.get_tag(tag_type).value)
+                tag_dictionary.add_item(token.get_label(tag_type).value)
         tag_dictionary.add_item("<START>")
         tag_dictionary.add_item("<STOP>")
         return tag_dictionary

--- a/tests/test_corpus_dictionary.py
+++ b/tests/test_corpus_dictionary.py
@@ -157,6 +157,44 @@ def test_tagged_corpus_make_label_dictionary():
     assert "class_1" in label_dict.get_items()
     assert "class_2" in label_dict.get_items()
 
+    with pytest.warns(DeprecationWarning):  # test to make sure the warning comes, but function works
+        corpus.make_tag_dictionary("label")
+
+
+def test_obtain_statistics():
+    sentence_1 = Sentence("The snake hissed to the mountain goat")
+    sentence_1_labels = "  O   B-Ani O      O  O   B-Ani    E-Ani".split()
+    sentence_2 = Sentence("Saber    tooth tigers are extinct")
+    sentence_2_labels = "  B-Ani    I-Ani E-Ani  O   O".split()
+
+    for sentence, labels in [(sentence_1, sentence_1_labels), (sentence_2, sentence_2_labels)]:
+        assert len(sentence) == len(labels)
+        for token, label in zip(sentence, labels):
+            token.add_label("ner", label)
+    corpus = Corpus(
+        FlairDatapointDataset([sentence_1, sentence_2]),
+        FlairDatapointDataset([]),
+        FlairDatapointDataset([sentence_2]),
+    )
+    statistics = corpus.obtain_statistics("ner", pretty_print=False)
+    assert statistics == {
+        "TRAIN": {
+            "dataset": "TRAIN",
+            "total_number_of_documents": 2,
+            "number_of_documents_per_class": {"O": 6, "B-Ani": 3, "E-Ani": 2, "I-Ani": 1},
+            "number_of_tokens_per_tag": {"O": 6, "B-Ani": 3, "E-Ani": 2, "I-Ani": 1},
+            "number_of_tokens": {"total": 12, "min": 5, "max": 7, "avg": 6.0},
+        },
+        "TEST": {
+            "dataset": "TEST",
+            "total_number_of_documents": 1,
+            "number_of_documents_per_class": {"B-Ani": 1, "I-Ani": 1, "E-Ani": 1, "O": 2},
+            "number_of_tokens_per_tag": {"B-Ani": 1, "I-Ani": 1, "E-Ani": 1, "O": 2},
+            "number_of_tokens": {"total": 5, "min": 5, "max": 5, "avg": 5.0},
+        },
+        "DEV": {},
+    }
+
 
 def test_tagged_corpus_statistics():
     train_sentence = Sentence("I love Berlin.", use_tokenizer=True).add_label("label", "class_1")


### PR DESCRIPTION
Fixes some cases where .get_tag() was still being called on tokens.

Removed Sentence.__copy__ method, which was not working for multiple
reasons (not only get_tag). We could fix __copy__, is it used?