### PR TITLE
Add deprecation warning for SentenceDataset rename

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -1,5 +1,11 @@
 # Expose base classses
-from .base import DataLoader, FlairDatapointDataset, MongoDataset, StringDataset
+from .base import (
+    DataLoader,
+    FlairDatapointDataset,
+    MongoDataset,
+    SentenceDataset,
+    StringDataset,
+)
 
 # Expose all biomedical data sets used for the evaluation of BioBERT
 # -
@@ -290,6 +296,7 @@ from .treebanks import (
 __all__ = [
     "DataLoader",
     "FlairDatapointDataset",
+    "SentenceDataset",
     "MongoDataset",
     "StringDataset",
     "ANAT_EM",

--- a/flair/datasets/base.py
+++ b/flair/datasets/base.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Generic, List, Union
 
 import torch.utils.data.dataloader
+from deprecated import deprecated
 from torch.utils.data.dataset import ConcatDataset, Subset
 
 from flair.data import DT, FlairDataset, Sentence, Tokenizer
@@ -74,27 +75,33 @@ class DataLoader(torch.utils.data.dataloader.DataLoader):
 
 class FlairDatapointDataset(FlairDataset, Generic[DT]):
     """
-    A simple Dataset object to wrap a List of Sentence
+    A simple Dataset object to wrap a List of Datapoints, for example Sentences
     """
 
-    def __init__(self, sentences: Union[DT, List[DT]]):
+    def __init__(self, datapoints: Union[DT, List[DT]]):
         """
-        Instantiate SentenceDataset
-        :param sentences: Sentence or List of Sentence that make up SentenceDataset
+        Instantiate FlairDatapointDataset
+        :param sentences: DT or List of DT that make up FlairDatapointDataset
         """
         # cast to list if necessary
-        if not isinstance(sentences, list):
-            sentences = [sentences]
-        self.sentences = sentences
+        if not isinstance(datapoints, list):
+            datapoints = [datapoints]
+        self.datapoints = datapoints
 
     def is_in_memory(self) -> bool:
         return True
 
     def __len__(self):
-        return len(self.sentences)
+        return len(self.datapoints)
 
     def __getitem__(self, index: int = 0) -> DT:
-        return self.sentences[index]
+        return self.datapoints[index]
+
+
+class SentenceDataset(FlairDatapointDataset):
+    @deprecated(version="0.11", reason="The 'SentenceDataset' class was renamed to 'FlairDatapointDataset'")
+    def __init__(self, sentences: Union[Sentence, List[Sentence]]):
+        super().__init__(sentences)
 
 
 class StringDataset(FlairDataset):

--- a/tests/test_corpus_dictionary.py
+++ b/tests/test_corpus_dictionary.py
@@ -1,8 +1,10 @@
 import os
 
+import pytest
+
 import flair
 from flair.data import Corpus, Dictionary, Label, Sentence
-from flair.datasets import FlairDatapointDataset
+from flair.datasets import FlairDatapointDataset, SentenceDataset
 
 
 def test_dictionary_get_items_with_unk():
@@ -77,6 +79,11 @@ def test_dictionary_save_and_load():
 
     # clean up file
     os.remove(file_path)
+
+
+def test_deprecated_sentence_dataset():
+    with pytest.warns(DeprecationWarning):  # test to make sure the warning comes, but class works
+        SentenceDataset([Sentence("Short sentences are short")])
 
 
 def test_tagged_corpus_get_all_sentences():


### PR DESCRIPTION
With 0.11, SentenceDataset was renamed to FlairDatapointDataset. There was
no deprecation or fall-back, this code adds the deprecation fallback with
a message to guide users to the new class name.

Alternatively, the deprecation could also be removed, allowing the
SentenceDataset class to continue without warning.