### PR TITLE
Add use_spans Sentence.to_dict() parameter

### DIFF
--- a/flair/models/sequence_tagger_utils/bioes.py
+++ b/flair/models/sequence_tagger_utils/bioes.py
@@ -1,14 +1,14 @@
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, List, Tuple
 
 
-def get_spans_from_bio(bioes_tags, bioes_scores=None):
+def get_spans_from_bio(bioes_tags, bioes_scores=None) -> List[Tuple[List[int], float, str]]:
     # add a dummy "O" to close final prediction
     bioes_tags.append("O")
     # return complex list
     found_spans = []
     # internal variables
-    current_tag_weights: Dict[str, float] = defaultdict(lambda: 0.0)
+    current_tag_weights: Dict[str, float] = defaultdict(float)
     previous_tag = "O-"
     current_span = []
     current_span_scores = []
@@ -33,7 +33,7 @@ def get_spans_from_bio(bioes_tags, bioes_scores=None):
             starts_new_span = True
 
         # single tags that change prediction start new spans
-        if bioes_tag[0:2] in ["S-"] and previous_tag[2:] != bioes_tag[2:]:
+        if bioes_tag[0:2] == "S-" and previous_tag[2:] != bioes_tag[2:]:
             starts_new_span = True
 
         # if an existing span is ended (either by reaching O or starting a new span)
@@ -48,7 +48,7 @@ def get_spans_from_bio(bioes_tags, bioes_scores=None):
             # reset for-loop variables for new span
             current_span = []
             current_span_scores = []
-            current_tag_weights = defaultdict(lambda: 0.0)
+            current_tag_weights = defaultdict(float)
 
         if in_span:
             current_span.append(idx)

--- a/tests/test_sentence.py
+++ b/tests/test_sentence.py
@@ -11,9 +11,45 @@ def test_sentence_context():
 
 
 def test_equality():
-
     assert Sentence("Guten Tag!") != Sentence("Good day!")
     assert Sentence("Guten Tag!", use_tokenizer=True) != Sentence("Guten Tag!", use_tokenizer=False)
 
     # TODO: is this desirable? Or should two sentences with same text still be considered different objects?
     assert Sentence("Guten Tag!") == Sentence("Guten Tag!")
+
+
+def test_to_dict():
+    s = Sentence("This is a very interesting sentence is it not")
+    s[1].add_label("ner", "B-Foo")
+    s[2].add_label("ner", "B-Bar")
+    s[3].add_label("ner", "I-Bar")
+    s[4].add_label("ner", "I-Bar")
+    s[5].add_label("ner", "E-Bar")
+
+    assert s.to_dict() == {
+        "text": "This is a very interesting sentence is it not",
+        "all labels": [
+            {"value": "B-Foo", "confidence": 1.0},
+            {"value": "B-Bar", "confidence": 1.0},
+            {"value": "I-Bar", "confidence": 1.0},
+            {"value": "I-Bar", "confidence": 1.0},
+            {"value": "E-Bar", "confidence": 1.0},
+        ],
+    }
+    assert s.to_dict("ner") == {
+        "text": "This is a very interesting sentence is it not",
+        "ner": [
+            {"value": "B-Foo", "confidence": 1.0},
+            {"value": "B-Bar", "confidence": 1.0},
+            {"value": "I-Bar", "confidence": 1.0},
+            {"value": "I-Bar", "confidence": 1.0},
+            {"value": "E-Bar", "confidence": 1.0},
+        ],
+    }
+    assert s.to_dict("ner", use_spans=True) == {
+        "text": "This is a very interesting sentence is it not",
+        "ner": [
+            {"value": "Foo", "start_pos": 5, "end_pos": 7, "confidence": 1.0},
+            {"value": "Bar", "start_pos": 8, "end_pos": 35, "confidence": 1.0},
+        ],
+    }


### PR DESCRIPTION
For flair-0.10 Sentence.to_dict() could decode BIO/BIOES labels and would
show the underlying spans. This adds this functionality back, configurable
via a parameter.