### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1027,7 +1027,7 @@ class MultiTagger:
         """
         if any(["hunflair" in name for name in self.name_to_tagger.keys()]):
             if "spacy" not in sys.modules:
-                logging.warn(
+                logging.warning(
                     "We recommend to use SciSpaCy for tokenization and sentence splitting "
                     "if HunFlair is applied to biomedical text, e.g.\n\n"
                     "from flair.tokenization import SciSpacySentenceSplitter\n"


### PR DESCRIPTION
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444