### PR TITLE
Do not remove other labels of sentence for set_label on Token and Span

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -436,20 +436,19 @@ class _PartOfSentence(DataPoint, ABC):
 
     def add_label(self, typename: str, value: str, score: float = 1.0):
         super().add_label(typename, value, score)
-
-        label = Label(self, value, score)
-        if typename not in self.sentence.annotation_layers:
-            self.sentence.annotation_layers[typename] = [label]
-        else:
-            self.sentence.annotation_layers[typename].append(label)
+        self.sentence.annotation_layers.setdefault(typename, []).append(Label(self, value, score))
 
     def set_label(self, typename: str, value: str, score: float = 1.0):
+        if len(self.annotation_layers.get(typename, [])) > 0:
+            # First we remove any existing labels for this PartOfSentence in self.sentence
+            self.sentence.annotation_layers[typename] = [
+                label for label in self.sentence.annotation_layers.get(typename, []) if label.data_point != self
+            ]
+        self.sentence.annotation_layers.setdefault(typename, []).append(Label(self, value, score))
         super().set_label(typename, value, score)
-        self.sentence.annotation_layers[typename] = [Label(self, value, score)]
         return self
 
     def remove_labels(self, typename: str):
-
         # labels also need to be deleted at Sentence object
         for label in self.get_labels(typename):
             self.sentence.annotation_layers[typename].remove(label)

--- a/tests/test_sentence.py
+++ b/tests/test_sentence.py
@@ -11,9 +11,38 @@ def test_sentence_context():
 
 
 def test_equality():
-
     assert Sentence("Guten Tag!") != Sentence("Good day!")
     assert Sentence("Guten Tag!", use_tokenizer=True) != Sentence("Guten Tag!", use_tokenizer=False)
 
     # TODO: is this desirable? Or should two sentences with same text still be considered different objects?
     assert Sentence("Guten Tag!") == Sentence("Guten Tag!")
+
+
+def test_token_labeling():
+    sentence = Sentence("This sentence will be labled")
+    assert sentence.get_labels("ner") == []
+    assert sentence.get_labels() == []
+    sentence[2].add_label("ner", "B-promise")
+    sentence[3].add_label("ner", "I-promise")
+    sentence[4].add_label("ner", "I-promise")
+    assert [label.value for label in sentence.get_labels()] == ["B-promise", "I-promise", "I-promise"]
+    assert [token.get_label("ner").value for token in sentence] == ["O", "O", "B-promise", "I-promise", "I-promise"]
+    sentence[1].set_label("ner", "B-object")
+    sentence[1].set_label("ner", "B-subject")
+    assert [label.value for label in sentence.get_labels("ner")] == ["B-subject", "B-promise", "I-promise", "I-promise"]
+    assert [token.get_label("ner").value for token in sentence] == [
+        "O",
+        "B-subject",
+        "B-promise",
+        "I-promise",
+        "I-promise",
+    ]
+    sentence.set_label("class", "positive")
+    sentence.remove_labels("ner")
+    assert sentence.get_labels("ner") == []
+    assert [label.value for label in sentence.get_labels()] == ["positive"]
+    sentence[0].add_label("pos", "first")
+    sentence[0].add_label("pos", "primero")
+    sentence[0].add_label("pos", "erstes")
+    assert [label.value for label in sentence.get_labels("pos")] == ["first", "primero", "erstes"]
+    assert sentence[0].get_label("pos").value == "first"


### PR DESCRIPTION
Currently there is a bug when calling set_label on a Token or Span, this will also call set_label on the surrounding sentence. This will remove any other labels in this label_type, from the point of view of the Sentence.

```
>>> from flair.data import Sentence
>>> s = Sentence("one two three")
>>> s[0].set_label("ner", "B-Number")
>>> s
Sentence: "one two three" → ["one"/B-Number]
>>> s[1].set_label("ner", "I-Number")
>>> s
Sentence: "one two three" → ["two"/I-Number]
```

