### PR TITLE
use transformers sentencepiece requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,13 @@ scikit-learn>=0.21.3
 sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.2.7
-transformers>=4.0.0
+transformers[sentencepiece]>=4.0.0
 bpemb>=0.3.2
 regex
 tabulate
 langdetect
 lxml
 ftfy
-sentencepiece==0.1.95
 konoha<5.0.0,>=4.0.0
 janome
 gdown==4.4.0


### PR DESCRIPTION
fixes https://github.com/flairNLP/flair/issues/2833

As flair doesn't use sentencepiece itself, but lets transformers use it indirectly, I propose to let the transformers package handle that dependency. 
This has two advantages:
a) we can use a more broad range of sentencepiece versions
b) if there are any new versions that break something, the transformers guys will handle it

Note: relies on https://github.com/flairNLP/flair/pull/2827 to be merged first for passing tests