### PR TITLE
update hf-hub version

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -922,13 +922,13 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                 model_folder = model_name
 
             # Lazy import
-            from huggingface_hub import cached_download, hf_hub_url
-
-            url = hf_hub_url(model_name, revision=revision, filename=hf_model_name)
+            from huggingface_hub.file_download import hf_hub_download
 
             try:
-                model_path = cached_download(
-                    url=url,
+                model_path = hf_hub_download(
+                    model_name,
+                    hf_model_name,
+                    revision=revision,
                     library_name="flair",
                     library_version=flair.__version__,
                     cache_dir=flair.cache_root / "models" / model_folder,
@@ -937,13 +937,13 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                 # output information
                 log.error("-" * 80)
                 log.error(
-                    f"ACHTUNG: The key '{model_name}' was neither found on the ModelHub nor is this a valid path to a file on your system!"
+                    f"ERROR: The key '{model_name}' was neither found on the ModelHub nor is this a valid path to a file on your system!"
                 )
-                # log.error(f" - Error message: {e}")
                 log.error(" -> Please check https://huggingface.co/models?filter=flair for all available models.")
                 log.error(" -> Alternatively, point to a model file on your local drive.")
                 log.error("-" * 80)
                 Path(flair.cache_root / "models" / model_folder).rmdir()  # remove folder again if not valid
+                raise
 
         return model_path
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ sentencepiece==0.1.95
 konoha<5.0.0,>=4.0.0
 janome
 gdown==4.4.0
-huggingface-hub
+huggingface-hub>=0.8.1
 conllu>=4.0
 more-itertools
 wikipedia-api


### PR DESCRIPTION
The newest release of the huggingface hub releases a new way of downloading models with additional features such as lazy loading and  git-aware cache file layouting.

I suppose there is no good reason to use older versions, so I added a pin of the version to force upgrades