### PR TITLE
tars classifier always predict something on single label

### DIFF
--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -803,6 +803,9 @@ class TARSClassifier(FewshotClassifier):
         if multi_label is None:
             multi_label = self.is_current_task_multi_label()
 
+        if not multi_label:
+            label_threshold = 0.0
+
         # with torch.no_grad():
         if not sentences:
             return sentences


### PR DESCRIPTION
Currently, when TarsClassifier is used in the single-label setting, it can happen, that a prediction results to no label.
I think it makes more sense to have it like in the usual single-label setting, that there is always a class outputted. No matter if the highest logit is positive or not. Simply setting the threshold to 0 for non multi-label sequences should do the trick.