### PR TITLE
Make JsonlCorpus create span labels

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -189,11 +189,6 @@ class JsonlDataset(FlairDataset):
         for label in labels:
             self._add_label_to_sentence(raw_text, sentence, label[0], label[1], label[2])
 
-        # Tag all other token as Outer (O)
-        for token in sentence:
-            if token.get_label(self.label_type).value == "O":
-                token.set_label(self.label_type, "O")
-
     def _add_label_to_sentence(self, text: str, sentence: Sentence, start: int, end: int, label: str):
         """
         Adds a NE label to a given sentence.
@@ -239,11 +234,7 @@ class JsonlDataset(FlairDataset):
                         Ann: {annotated_part}\nRaw: {text}\nCo: {start_idx}, {end_idx}"
             )
 
-        # Add IOB tags
-        prefix = "B"
-        for token in sentence[start_idx : end_idx + 1]:
-            token.add_label(self.label_type, f"{prefix}-{label}")
-            prefix = "I"
+        sentence[start_idx : end_idx + 1].add_label(self.label_type, label)
 
     def is_in_memory(self) -> bool:
         """

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -736,6 +736,13 @@ def test_simple_folder_jsonl_corpus_should_load(tasks_base_path):
     assert len(corpus.get_all_sentences()) == 11
 
 
+def test_jsonl_corpus_loads_spans(tasks_base_path):
+    corpus = JsonlCorpus(tasks_base_path / "jsonl")
+    assert corpus.train is not None
+    example = corpus.train[0]
+    assert len(example.get_spans("ner")) > 0
+
+
 TRAIN_FILE = "tests/resources/tasks/jsonl/train.jsonl"
 TESTA_FILE = "tests/resources/tasks/jsonl/testa.jsonl"
 TESTB_FILE = "tests/resources/tasks/jsonl/testa.jsonl"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -724,11 +724,8 @@ def test_reading_jsonl_dataset_should_be_successful(tasks_base_path):
     dataset = JsonlDataset(tasks_base_path / "jsonl" / "train.jsonl")
 
     assert len(dataset.sentences) == 5
-    expected_labels = ["O", "O", "B-LOC", "I-LOC"]
-    assert [[label.value for label in t.get_labels("ner")] for t in dataset.sentences[0]] == [
-        [e] for e in expected_labels
-    ]
-    assert [dataset.sentences[0].get_token(i).get_label("ner").value for i in range(1, 5)] == expected_labels
+    assert len(dataset.sentences[0].get_labels("ner")) == 1
+    assert dataset.sentences[0][2:4].get_label("ner").value == "LOC"
 
 
 def test_simple_folder_jsonl_corpus_should_load(tasks_base_path):


### PR DESCRIPTION
since some refactoring, NER labels will be added as span labels instead of following the BIO or BIOES tagging shemas.
This PR updates the JsonlCorpus to follow the newer way of labels and therefore recreates compatibility for JsonlCorpus for Ner trainings