### PR TITLE
Use recommended lazy loading from HuggingFace hub

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -916,13 +916,13 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                 model_folder = model_name
 
             # Lazy import
-            from huggingface_hub.file_download import hf_hub_download
+            import huggingface_hub
 
             try:
-                model_path = hf_hub_download(
-                    model_name,
-                    hf_model_name,
+                model_path = huggingface_hub.hf_hub_download(
+                    repo_id = model_name,
                     revision=revision,
+                    filename=hf_model_name,
                     library_name="flair",
                     library_version=flair.__version__,
                     cache_dir=flair.cache_root / "models" / model_folder,


### PR DESCRIPTION
https://github.com/huggingface/huggingface_hub/releases
Loading a model in `flair == 0.11.3` and `huggingface_hub == 0.8.1` gives the warning
```
/home/ubuntu/.local/lib/python3.9/site-packages/huggingface_hub/file_download.py:560: FutureWarning: `cached_download` is the legacy way to download files from the HF hub, please consider upgrading to `hf_hub_download`
  warnings.warn(
```
This change starts using the recommended way to load a model. Requires `huggingface_hub >= 0.8.1`.