### PR TITLE
pin flake8 to v4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ pytest>=7.0.0
 pytest-mypy
 pytest-isort
 pytest-flake8
+flake8<5.0.0
 flake8-black
 types-Deprecated
 types-dataclasses


### PR DESCRIPTION
As long as https://github.com/tholo/pytest-flake8/pull/88 is not merged, flake8 need to be set to version 4.
i suggest this PR as a temporary fix until the plugins are up to date again.