### PR TITLE
Fast tokenizer reload fix pt.2: Bloom model

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -337,7 +337,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
     def __tokenizer_bytes(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             files = list(self.tokenizer.save_pretrained(temp_dir))
-            if self.tokenizer.is_fast:
+            if self.tokenizer.is_fast and self.tokenizer.slow_tokenizer_class:
                 vocab_files = self.tokenizer.slow_tokenizer_class.vocab_files_names.values()
                 files = [f for f in files if all(v not in f for v in vocab_files)]
             zip_data = BytesIO()

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -441,6 +441,20 @@ def test_transformers_keep_tokenizer_when_saving(results_base_path):
     reloaded_tagger.save(reloaded_tagger_path)
 
 
+def test_transformers_keep_tokenizer_bloom_when_saving(results_base_path):
+    embeddings = TransformerWordEmbeddings("bigscience/bloom-560m")
+    results_base_path.mkdir(exist_ok=True, parents=True)
+    initial_tagger_path = results_base_path / "initial_tokenizer.pk"
+    reloaded_tagger_path = results_base_path / "reloaded_tokenizer.pk"
+
+    initial_tagger = SequenceTagger(embeddings, Dictionary(), "ner")
+
+    initial_tagger.save(initial_tagger_path)
+    reloaded_tagger = SequenceTagger.load(initial_tagger_path)
+
+    reloaded_tagger.save(reloaded_tagger_path)
+
+
 def test_transformer_subword_token_mapping():
     sentence = Sentence("El pasto es verde.")
     embeddings = TransformerWordEmbeddings("PlanTL-GOB-ES/roberta-base-biomedical-es", layers="-1")

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -442,7 +442,7 @@ def test_transformers_keep_tokenizer_when_saving(results_base_path):
 
 
 def test_transformers_keep_tokenizer_bloom_when_saving(results_base_path):
-    embeddings = TransformerWordEmbeddings("bigscience/bloom-560m")
+    embeddings = TransformerWordEmbeddings("Muennighoff/bloom-tiny-random")
     results_base_path.mkdir(exist_ok=True, parents=True)
     initial_tagger_path = results_base_path / "initial_tokenizer.pk"
     reloaded_tagger_path = results_base_path / "reloaded_tokenizer.pk"


### PR DESCRIPTION
Hi,

this PR fixes a fast tokenizer reload bug when using the BigScience Bloom Model.

I got the following error message when fine-tuning a Bloom Model for NER:

```bash
Traceback (most recent call last):                                                                                              
  File "run_ner.py", line 160, in <module>                                                                                  
    main()                                                                                                                  
  File "run_ner.py", line 140, in main                                                                                                                                                                                    
    trainer.fine_tune(                                                                                                      
  File "/mnt/flair-t5-experiments/flair/trainers/trainer.py", line 928, in fine_tune                                        
    return self.train(                                                                                                      
  File "/mnt/flair-t5-experiments/flair/trainers/trainer.py", line 803, in train                                                                                                                                          
    self.model.save(base_path / "best-model.pt", checkpoint=save_optimizer_state)                                                                                                                                         
  File "/mnt/flair-t5-experiments/flair/nn/model.py", line 118, in save                                   
    torch.save(model_state, str(model_file), pickle_protocol=4)                                            
  File "/opt/conda/lib/python3.8/site-packages/torch/serialization.py", line 379, in save                                                                                                                                 
    _save(obj, opened_zipfile, pickle_module, pickle_protocol)                                           
  File "/opt/conda/lib/python3.8/site-packages/torch/serialization.py", line 484, in _save                                                                                                                                
    pickler.dump(obj)                                                                                                       
  File "/mnt/flair-t5-experiments/flair/embeddings/transformer.py", line 934, in __getstate__                                                                                                                             
    super_state = super().__getstate__()                                                                                    
  File "/mnt/flair-t5-experiments/flair/embeddings/transformer.py", line 321, in __getstate__                               
    model_state["tokenizer_data"] = self.__tokenizer_bytes()                                                                                                                                                              
  File "/mnt/flair-t5-experiments/flair/embeddings/transformer.py", line 341, in __tokenizer_bytes                          
    vocab_files = self.tokenizer.slow_tokenizer_class.vocab_files_names.values()                         
AttributeError: 'NoneType' object has no attribute 'vocab_files_names' 
```

The `slow_tokenizer_class` variable is not set, because there's no slow tokenizer for Bloom - and it's set here:

https://github.com/huggingface/transformers/blob/d6eeb871706db0d64ab9ffd79f9545d95286b536/src/transformers/models/bloom/tokenization_bloom_fast.py#L103

So the fix is to test, if the `slow_tokenizer_class` really exists. I did some debugging and after applying this fix, the `files` variable from:

https://github.com/flairNLP/flair/blob/0a0809d251908c54d212fb75b54192caa2f4fe66/flair/embeddings/transformer.py#L337-L348

is then set to:

```bash
['/tmp/tmpm1boz3te/tokenizer_config.json', '/tmp/tmpm1boz3te/special_tokens_map.json', '/tmp/tmpm1boz3te/tokenizer.json']
```

So all necessary files should be stored, see [tokenizer file list](https://huggingface.co/bigscience/bloom-560m/tree/main).