### PR TITLE
use a different way for mypy to ignore the legacy embeddings when typechecking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,11 @@ markers = [
     "integration",
 ]
 [tool.mypy]
-exclude = "flair/embeddings/legacy.py"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module="flair.embeddings.legacy"
+ignore_errors = true
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
I have absolutely no idea why this is necessary, but the old way of ignoring types withing the `legacy.py` file doesn't work anymore.