### PR TITLE
Proposal: Return loss per sentence

### DIFF
--- a/flair/models/lemmatizer_model.py
+++ b/flair/models/lemmatizer_model.py
@@ -441,7 +441,7 @@ class Lemmatizer(flair.nn.Classifier[Sentence]):
         # for printing
         line_to_print = ""
 
-        losses: List[torch.Tensor] = []
+        overall_loss = torch.zeros(1, device=flair.device)
         number_tokens_in_total = 0
 
         with torch.no_grad():
@@ -652,7 +652,8 @@ class Lemmatizer(flair.nn.Classifier[Sentence]):
                         tokens_in_batch[i].add_tag(tag_type=label_name, tag_value=predicted_lemma)
 
                 if return_loss:
-                    losses.append(self.forward_loss(batch)[0])
+                    batch_loss = self.forward_loss(batch)[0]
+                    overall_loss += batch_loss.sum()
 
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
@@ -660,7 +661,7 @@ class Lemmatizer(flair.nn.Classifier[Sentence]):
                 log.info(line_to_print)
 
             if return_loss:
-                return torch.cat(losses, 0).detach().cpu().numpy(), number_tokens_in_total
+                return overall_loss, number_tokens_in_total
 
     def _get_state_dict(self):
         model_state = {

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union, overload
+from typing import Dict, List, Optional, Tuple, Union
 from urllib.error import HTTPError
 
 import torch
@@ -9,7 +9,6 @@ import torch.nn
 import torch.nn.functional as F
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 from tqdm import tqdm
-from typing_extensions import Literal
 
 import flair.nn
 from flair.data import Dictionary, Label, Sentence, Span
@@ -419,34 +418,6 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             device=flair.device,
         )
         return labels
-
-    @overload
-    def predict(
-        self,
-        sentences: Union[List[Sentence], Sentence],
-        mini_batch_size: int = 32,
-        return_probabilities_for_all_classes: bool = False,
-        verbose: bool = False,
-        label_name: Optional[str] = None,
-        return_loss: Literal[False] = False,
-        embedding_storage_mode="none",
-        force_token_predictions: bool = False,
-    ) -> None:
-        ...
-
-    @overload
-    def predict(
-        self,
-        sentences: Union[List[Sentence], Sentence],
-        mini_batch_size: int = 32,
-        return_probabilities_for_all_classes: bool = False,
-        verbose: bool = False,
-        label_name: Optional[str] = None,
-        return_loss: Literal[True] = True,
-        embedding_storage_mode="none",
-        force_token_predictions: bool = False,
-    ) -> Tuple[torch.Tensor, int]:
-        ...
 
     def predict(
         self,

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -428,7 +428,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         return_probabilities_for_all_classes: bool = False,
         verbose: bool = False,
         label_name: Optional[str] = None,
-        return_loss=Literal[False],
+        return_loss: Literal[False] = False,
         embedding_storage_mode="none",
         force_token_predictions: bool = False,
     ) -> None:
@@ -442,7 +442,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         return_probabilities_for_all_classes: bool = False,
         verbose: bool = False,
         label_name: Optional[str] = None,
-        return_loss=Literal[True],
+        return_loss: Literal[True] = True,
         embedding_storage_mode="none",
         force_token_predictions: bool = False,
     ) -> Tuple[torch.Tensor, int]:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union, Literal, overload
+from typing import Dict, List, Optional, Tuple, Union, overload
 from urllib.error import HTTPError
 
 import torch
@@ -9,6 +9,7 @@ import torch.nn
 import torch.nn.functional as F
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 from tqdm import tqdm
+from typing_extensions import Literal
 
 import flair.nn
 from flair.data import Dictionary, Label, Sentence, Span

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -250,11 +250,11 @@ class Classifier(Model[DT], typing.Generic[DT]):
                     datapoint.remove_labels("predicted")
                 # predict for batch
                 loss_and_count = self.predict(
-                    batch,
-                    embedding_storage_mode=embedding_storage_mode,
+                    typing.cast(List[DT], batch),
                     mini_batch_size=mini_batch_size,
                     label_name="predicted",
                     return_loss=return_loss,
+                    embedding_storage_mode=embedding_storage_mode,
                 )
 
                 if return_loss:
@@ -474,7 +474,7 @@ class Classifier(Model[DT], typing.Generic[DT]):
         label_name: Optional[str] = None,
         return_loss=False,
         embedding_storage_mode="none",
-    ) -> Optional[Tuple[torch.Tensor, int]]:
+    ):
         """
         Predicts the class labels for the given sentences. The labels are directly added to the sentences.  # noqa: E501
         :param sentences: list of sentences

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -502,6 +502,7 @@ class ModelTrainer:
                         # forward pass
                         loss, datapoint_count = self.model.forward_loss(batch_step)
                         average_over += datapoint_count
+                        loss = loss.sum()
 
                         # Backward
                         if use_amp:
@@ -1020,6 +1021,7 @@ class ModelTrainer:
 
                 # forward pass
                 loss, datapoint_count = self.model.forward_loss(batch)
+                loss = loss.sum()
 
                 # update optimizer and scheduler
                 optimizer.zero_grad()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8-ignore = ["E203", "W503"]  # See https://github.com/PyCQA/pycodestyle/iss
 addopts = "--flake8 --mypy --ignore flair/embeddings/legacy.py --isort"
 filterwarnings = [
     "error",  # Convert all warnings to errors
+    "ignore:operator \\(\\) profile_node",
     "ignore:the imp module is deprecated:DeprecationWarning:past"  # ignore DeprecationWarning from hyperopt dependency
 ]
 markers = [

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -188,7 +188,7 @@ def test_transformer_jit_embeddings(results_base_path):
 
     jit_embeddings.embed(sentence)
     jit_token_embedding = sentence[5].get_embedding().clone()
-    assert torch.isclose(base_token_embedding, jit_token_embedding).all()
+    assert torch.isclose(base_token_embedding, jit_token_embedding, atol=3e-6).all()
     sentence.clear_embeddings()
 
     # use a SequenceTagger to save and reload the embedding in the manner it is supposed to work
@@ -202,7 +202,7 @@ def test_transformer_jit_embeddings(results_base_path):
     loaded_jit_embedding.embed(sentence)
     loaded_jit_token_embedding = sentence[5].get_embedding().clone()
     sentence.clear_embeddings()
-    assert torch.isclose(jit_token_embedding, loaded_jit_token_embedding).all()
+    assert torch.isclose(jit_token_embedding, loaded_jit_token_embedding, atol=3e-6).all()
 
 
 def test_transformer_force_max_length():

--- a/tests/test_entity_linker.py
+++ b/tests/test_entity_linker.py
@@ -21,4 +21,4 @@ def test_forward_loss():
     tagger = EntityLinker(TransformerWordEmbeddings("distilbert-base-uncased"), label_dictionary=Dictionary())
     loss, count = tagger.forward_loss([sentence])
     assert count == 2
-    assert loss.shape == (1,)
+    assert loss.shape == (2,)

--- a/tests/test_entity_linker.py
+++ b/tests/test_entity_linker.py
@@ -21,4 +21,4 @@ def test_forward_loss():
     tagger = EntityLinker(TransformerWordEmbeddings("distilbert-base-uncased"), label_dictionary=Dictionary())
     loss, count = tagger.forward_loss([sentence])
     assert count == 2
-    assert loss.size() == ()
+    assert loss.shape == (1,)

--- a/tests/test_sequence_tagger.py
+++ b/tests/test_sequence_tagger.py
@@ -77,6 +77,18 @@ def test_all_tag_proba_embedding():
 
 
 @pytest.mark.integration
+def test_loss_per_sentence():
+    loaded_model: SequenceTagger = SequenceTagger.load("ner-fast")
+
+    sentence1 = Sentence("I love Berlin")
+    sentence2 = Sentence("I love vienna even more")
+
+    loss, count = loaded_model.predict([sentence1, sentence2], return_loss=True)
+
+    assert loss.shape == (2,)
+
+
+@pytest.mark.integration
 def test_train_load_use_tagger(results_base_path, tasks_base_path):
     corpus = flair.datasets.ColumnCorpus(data_folder=tasks_base_path / "fashion", column_format={0: "text", 3: "ner"})
     tag_dictionary = corpus.make_label_dictionary("ner", add_unk=False)

--- a/tests/test_text_regressor.py
+++ b/tests/test_text_regressor.py
@@ -10,7 +10,7 @@ from flair.trainers import ModelTrainer
 
 
 def init(tasks_base_path) -> Tuple[Corpus, TextRegressor, ModelTrainer]:
-    corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "regression")
+    corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "regression", label_type="label")
 
     glove_embedding: WordEmbeddings = WordEmbeddings("glove")
     document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(


### PR DESCRIPTION
A proposal to return the loss per sentence.
This way, it would be easier to compute uncertainty scores used for [active learning](https://arxiv.org/abs/1707.05928). I made experience in prior projects, that that way one could save up to 40% labelling costs.

Example:
```
loaded_model: SequenceTagger = SequenceTagger.load("ner-fast")

sentence1 = Sentence("I love Berlin")
sentence2 = Sentence("I love vienna even more")

loss, count = loaded_model.predict([sentence1, sentence2], return_loss=True)
```
Here `loss` would be a numpy array with 2 entries, Representing the loss per sentence.

Notice: This is so far just a proposal, I have not tested if everything works properly (for example assure that the order is right), I am currently not sure if this makes sense and if so, how to design it best (We could for example add a field `loss` to the sentence instead.)