### PR TITLE
specify test paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ filterwarnings = [
 markers = [
     "integration",
 ]
+testpaths = ["flair", "tests"]
 [tool.mypy]
 ignore_missing_imports = true
 


### PR DESCRIPTION
fixes the testing issues on the current master.
To answer https://github.com/flairNLP/flair/pull/2897#issuecomment-1233082553 :
All the senteval datasets download and unpack a zip file. This zip file contains a very old python 2.7 file which doesn't comply with the isort-flake8-mypy and python3 standards.
As the cache folder is set into the model repo and the tests collect for any file in the repo, hence also that old one.

This PR specifies for pytest where to search for tests, therefore randomly existing files won't be added anymore.