### PR TITLE
GH-2928: Unify loss reduction

### DIFF
--- a/flair/models/lemmatizer_model.py
+++ b/flair/models/lemmatizer_model.py
@@ -395,7 +395,7 @@ class Lemmatizer(flair.nn.Classifier[Sentence]):
 
         return self.loss(scores_in_correct_format, target), len(labels)
 
-    def forward_loss(self, sentences: Union[List[Sentence], Sentence]) -> torch.Tensor:
+    def forward_loss(self, sentences: Union[List[Sentence], Sentence]) -> Tuple[torch.Tensor, int]:
         scores, labels = self.forward_pass(sentences)
 
         return self._calculate_loss(scores, labels)

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -56,7 +56,7 @@ class MultitaskModel(flair.nn.Classifier):
     def _prepare_tensors(self, data_points: List[DT]) -> Tuple[torch.Tensor, ...]:
         raise NotImplementedError("`_prepare_tensors` is not used for multitask learning")
 
-    def forward_loss(self, sentences: Union[List[Sentence], Sentence]):
+    def forward_loss(self, sentences: Union[List[Sentence], Sentence]) -> Tuple[torch.Tensor, int]:
         """
         Abstract forward loss implementation of flair.nn.Model's interface.
         Calls the respective forward loss of each model.

--- a/flair/models/sequence_tagger_utils/viterbi.py
+++ b/flair/models/sequence_tagger_utils/viterbi.py
@@ -35,7 +35,7 @@ class ViterbiLoss(torch.nn.Module):
         :param features_tuple: CRF scores from forward method in shape (batch size, seq len, tagset size, tagset size),
             lengths of sentences in batch, transitions from CRF
         :param targets: true tags for sentences which will be converted to matrix indices.
-        :return: average Viterbi Loss over batch size
+        :return: summed Viterbi Loss over all data points
         """
         features, lengths, transitions = features_tuple
 

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -34,9 +34,7 @@ class FewshotClassifier(flair.nn.Classifier[Sentence]):
 
         super(FewshotClassifier, self).__init__()
 
-    def forward_loss(
-        self, data_points: Union[List[Sentence], Sentence]
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, int]]:
+    def forward_loss(self, data_points: Union[List[Sentence], Sentence]) -> Tuple[torch.Tensor, int]:
 
         if not isinstance(data_points, list):
             data_points = [data_points]
@@ -44,8 +42,8 @@ class FewshotClassifier(flair.nn.Classifier[Sentence]):
         # Transform input data into TARS format
         sentences = self._get_tars_formatted_sentences(data_points)
 
-        loss = self.tars_model.forward_loss(sentences)
-        return loss
+        loss, count = self.tars_model.forward_loss(sentences)
+        return loss, count
 
     def _prepare_tensors(self, data_points: List[Sentence]) -> Tuple[torch.Tensor, ...]:
         return self.tars_model._prepare_tensors(data_points)

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -53,13 +53,13 @@ class TextRegressor(flair.nn.Model[Sentence]):
         label_scores = self.decoder(text_embedding_tensor)
         return label_scores
 
-    def forward_loss(self, sentences: List[Sentence]) -> torch.Tensor:
+    def forward_loss(self, sentences: List[Sentence]) -> Tuple[torch.Tensor, int]:
 
         labels = self._labels_to_tensor(sentences)
         text_embedding_tensor = self._prepare_tensors(sentences)
         scores = self.forward(*text_embedding_tensor)
 
-        return self.loss_function(scores.squeeze(1), labels)
+        return self.loss_function(scores.squeeze(1), labels), len(sentences)
 
     def _labels_to_tensor(self, sentences: List[Sentence]):
         indices = [

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -33,7 +33,7 @@ class TextRegressor(flair.nn.Model[Sentence]):
 
         nn.init.xavier_uniform_(self.decoder.weight)
 
-        self.loss_function = nn.MSELoss()
+        self.loss_function = nn.MSELoss(reduction="sum")
 
         # auto-spawn on GPU if available
         self.to(flair.device)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -48,7 +48,7 @@ class Model(torch.nn.Module, typing.Generic[DT]):
         raise NotImplementedError
 
     @abstractmethod
-    def forward_loss(self, data_points: List[DT]) -> Union[torch.Tensor, Tuple[torch.Tensor, int]]:
+    def forward_loss(self, data_points: List[DT]) -> Tuple[torch.Tensor, int]:
         """Performs a forward pass and returns a loss tensor for backpropagation.
         Implement this to enable training."""
         raise NotImplementedError

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -575,7 +575,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             self.gradient_reversal = RevGrad()
 
         if self.multi_label:
-            self.loss_function: _Loss = torch.nn.BCEWithLogitsLoss(weight=self.loss_weights)
+            self.loss_function: _Loss = torch.nn.BCEWithLogitsLoss(weight=self.loss_weights, reduction="sum")
         else:
             self.loss_function = torch.nn.CrossEntropyLoss(weight=self.loss_weights, reduction="sum")
         self.train_on_gold_pairs_only = train_on_gold_pairs_only

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -500,11 +500,8 @@ class ModelTrainer:
                     for batch_step in batch_steps:
 
                         # forward pass
-                        loss = self.model.forward_loss(batch_step)
-
-                        if isinstance(loss, tuple):
-                            average_over += loss[1]
-                            loss = loss[0]
+                        loss, datapoint_count = self.model.forward_loss(batch_step)
+                        average_over += datapoint_count
 
                         # Backward
                         if use_amp:
@@ -1022,9 +1019,7 @@ class ModelTrainer:
                 step += 1
 
                 # forward pass
-                loss = self.model.forward_loss(batch)
-                if isinstance(loss, tuple):
-                    loss = loss[0]
+                loss, datapoint_count = self.model.forward_loss(batch)
 
                 # update optimizer and scheduler
                 optimizer.zero_grad()


### PR DESCRIPTION
Closes #2928 by making sure that all losses are summed over all points, instead of averaged. Also changes the forward_loss signature to always return a tuple consisting of the loss and the number of points.