### PR TITLE
GH-2972: Change output of .text to original string

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -567,7 +567,7 @@ class Span(_PartOfSentence):
 
     @property
     def text(self) -> str:
-        return " ".join([t.text for t in self.tokens])
+        return "".join([t.text + t.whitespace_after * " " for t in self.tokens])
 
     @property
     def unlabeled_identifier(self) -> str:
@@ -748,7 +748,7 @@ class Sentence(DataPoint):
 
     @property
     def unlabeled_identifier(self):
-        return f'Sentence: "{self.to_tokenized_string()}"'
+        return f'Sentence: "{self.text}"'
 
     def get_relations(self, type: str) -> List[Relation]:
         relations: List[Relation] = []
@@ -882,7 +882,7 @@ class Sentence(DataPoint):
 
     @property
     def text(self):
-        return self.to_tokenized_string()
+        return "".join([t.text + t.whitespace_after * " " for t in self.tokens])
 
     def to_tokenized_string(self) -> str:
 

--- a/flair/data.py
+++ b/flair/data.py
@@ -567,7 +567,7 @@ class Span(_PartOfSentence):
 
     @property
     def text(self) -> str:
-        return "".join([t.text + t.whitespace_after * " " for t in self.tokens])
+        return "".join([t.text + t.whitespace_after * " " for t in self.tokens]).strip()
 
     @property
     def unlabeled_identifier(self) -> str:

--- a/flair/data.py
+++ b/flair/data.py
@@ -748,7 +748,7 @@ class Sentence(DataPoint):
 
     @property
     def unlabeled_identifier(self):
-        return f'Sentence: "{self.text}"'
+        return f'Sentence[{len(self)}]: "{self.text}"'
 
     def get_relations(self, type: str) -> List[Relation]:
         relations: List[Relation] = []

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -24,9 +24,9 @@ import flair
 logger = logging.getLogger("flair")
 
 
-def load_big_file(f: str) -> mmap.mmap:
+def load_big_file(f: str):
     """
-    Workaround for loading a big pickle file. Files over 2GB cause pickle errors on certin Mac and Windows distributions.
+    Workaround for loading a big pickle file. Files over 2GB cause pickle errors on certain Mac and Windows distributions.
     :param f:
     :return:
     """


### PR DESCRIPTION
Closes #2972 

The `.text` property of the `Sentence` and `Span` object currently print a whitespace tokenized version of the string. This PR changes this so that `.text` will print the untokenized string instead. 

```python
# make example sentence
sentence = Sentence("George   Washington was here")
print(sentence)

# get a span from the sentence and print its text
entity = sentence.get_span(0, 2)
print(entity)
print(entity.text)
```

This now prints: 

```console
Sentence: "George   Washington was here"
Span[0:2]: "George   Washington"
George   Washington
```

Before, it printed: 

```console
Sentence: "George Washington was here"
Span[0:2]: "George Washington"
George Washington
```
