### PR TITLE
Add time elapsed to training printout

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -602,7 +602,7 @@ class Span(_PartOfSentence):
 
     @property
     def embedding(self):
-        pass
+        return self.get_embedding()
 
 
 class Relation(_PartOfSentence):

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -238,6 +238,7 @@ class Classifier(Model[DT], typing.Generic[DT]):
                 # remove any previously predicted labels
                 for datapoint in batch:
                     datapoint.remove_labels("predicted")
+
                 # predict for batch
                 loss_and_count = self.predict(
                     batch,
@@ -594,7 +595,6 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
         return [
             data_point
             for sentence in sentences
-            if self._filter_data_point(sentence)
             for data_point in self._get_data_points_from_sentence(sentence)
         ]
 
@@ -757,6 +757,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             label_count = 0
             for batch in batches:
 
+                # filter data points in batch
                 batch = [dp for dp in batch if self._filter_data_point(dp)]
 
                 # stop if all sentences are empty

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -592,11 +592,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
 
     def _get_data_points_for_batch(self, sentences: List[DT]) -> List[DT2]:
         """Returns the data_points to which labels are added (Sentence, Span, Token, ... objects)"""
-        return [
-            data_point
-            for sentence in sentences
-            for data_point in self._get_data_points_from_sentence(sentence)
-        ]
+        return [data_point for sentence in sentences for data_point in self._get_data_points_from_sentence(sentence)]
 
     def _get_label_of_datapoint(self, data_point: DT2) -> List[str]:
         """Extracts the labels from the data points.

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -473,6 +473,8 @@ class ModelTrainer:
                     log_line(log)
                     break
 
+                start_time = time.time()
+
                 batch_loader = DataLoader(
                     train_data,
                     batch_size=mini_batch_size,
@@ -491,11 +493,8 @@ class ModelTrainer:
                 modulo = max(1, int(total_number_of_batches / 10))
 
                 # process mini-batches
-                batch_time = 0.0
                 average_over = 0
                 for batch_no, batch in enumerate(batch_loader):
-
-                    start_time = time.time()
 
                     # zero the gradients on the model and optimizer
                     self.model.zero_grad()
@@ -545,7 +544,6 @@ class ModelTrainer:
 
                     seen_batches += 1
 
-                    batch_time += time.time() - start_time
                     if seen_batches % modulo == 0:
                         momentum_info = ""
                         if cycle_momentum:
@@ -556,13 +554,13 @@ class ModelTrainer:
                         intermittent_loss = train_loss / average_over if average_over > 0 else train_loss / seen_batches
 
                         log.info(
-                            f"epoch {epoch} - iter {seen_batches}/"
-                            f"{total_number_of_batches} - loss "
-                            f"{intermittent_loss:.8f} - samples/sec:"
-                            f" {mini_batch_size * modulo / batch_time:.2f}"
+                            f"epoch {epoch}"
+                            f" - iter {seen_batches}/{total_number_of_batches}"
+                            f" - loss {intermittent_loss:.8f}"
+                            f" - time/sec: {(time.time() - start_time):.2f}"
+                            f" - samples/sec: {average_over / (time.time() - start_time):.2f}"
                             f" - lr: {lr_info}{momentum_info}"
                         )
-                        batch_time = 0.0
                         iteration = epoch * total_number_of_batches + batch_no
                         if not param_selection_mode and write_weights:
                             weight_extractor.extract_weights(self.model.state_dict(), iteration)

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -557,7 +557,7 @@ class ModelTrainer:
                             f"epoch {epoch}"
                             f" - iter {seen_batches}/{total_number_of_batches}"
                             f" - loss {intermittent_loss:.8f}"
-                            f" - time/sec: {(time.time() - start_time):.2f}"
+                            f" - time (sec): {(time.time() - start_time):.2f}"
                             f" - samples/sec: {average_over / (time.time() - start_time):.2f}"
                             f" - lr: {lr_info}{momentum_info}"
                         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest>=7.0.0,!=7.2.0
+mypy==0.982
 pytest-mypy
 pytest-isort
 pytest-flake8


### PR DESCRIPTION
This PR changes the printout such that time-elapsed (in seconds) is printed during an epoch. 

Before: 

```console
2022-09-03 21:40:57,619 ----------------------------------------------------------------------------------------------------
2022-09-03 21:41:01,344 epoch 1 - iter 122/1227 - loss 0.93329908 - samples/sec: 131.96 - lr: 0.000030
2022-09-03 21:41:04,131 epoch 1 - iter 244/1227 - loss 0.74046559 - samples/sec: 176.79 - lr: 0.000030
2022-09-03 21:41:06,914 epoch 1 - iter 366/1227 - loss 0.64291181 - samples/sec: 177.01 - lr: 0.000030
2022-09-03 21:41:10,129 epoch 1 - iter 488/1227 - loss 0.60704054 - samples/sec: 153.07 - lr: 0.000030
```

After: 

```console
2022-11-08 11:14:26,681 ----------------------------------------------------------------------------------------------------
2022-11-08 11:14:32,333 epoch 1 - iter 122/1227 - loss 0.93329908 - time (sec): 5.65 - samples/sec: 86.35 - lr: 0.000030
2022-11-08 11:14:37,495 epoch 1 - iter 244/1227 - loss 0.74046560 - time (sec): 10.81 - samples/sec: 90.26 - lr: 0.000030
2022-11-08 11:14:42,687 epoch 1 - iter 366/1227 - loss 0.64291186 - time (sec): 16.01 - samples/sec: 91.47 - lr: 0.000030
2022-11-08 11:14:47,662 epoch 1 - iter 488/1227 - loss 0.60704056 - time (sec): 20.98 - samples/sec: 93.04 - lr: 0.000030
```

Additional small changes: 
- filter data points only once in DefaultClassifier
- Span can return its embedding