### PR TITLE
do not save Path objects to model cards

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -198,7 +198,10 @@ class ModelTrainer:
         local_variables = locals()
         training_parameters = {}
         for parameter in signature(self.train).parameters:
-            training_parameters[parameter] = local_variables[parameter]
+            if isinstance(local_variables[parameter], Path):
+                training_parameters[parameter] = str(local_variables[parameter])
+            else:
+                training_parameters[parameter] = local_variables[parameter]
         model_card["training_parameters"] = training_parameters
 
         if epoch >= max_epochs:


### PR DESCRIPTION
Saving `Path` objects in Pickle can lead to OS incompatibilities, as `Path` is resolved to either `PosixPath` (linux) or `WindowsPath` (windows).
As the model card saves the training parameters, calling with a path can lead that models trained on a linux docker won't be loadable on any Windows machine (and reversed).

This PR gives a simple fix by converting each path to a string before adding it to the ModelCard