### PR TITLE
Refactor Token and Sentence Positional Properties

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -732,30 +732,22 @@ class Sentence(DataPoint):
             words = tokenizer.tokenize(text)
         else:
             words = text
+            text = " ".join(words)
 
         # determine token positions and whitespace_after flag
-        current_offset = 0
-        previous_word_offset = -1
-        previous_token = None
+        current_offset: int = 0
+        previous_token: Optional[Token] = None
         for word in words:
-            try:
-                word_offset = text.index(word, current_offset)
-                start_position = word_offset
-                delta_offset = start_position - current_offset
-            except ValueError:
-                word_offset = previous_word_offset + 1
-                start_position = current_offset + 1 if current_offset > 0 else current_offset
-                delta_offset = start_position - current_offset
+            word_start_position: int = text.index(word, current_offset)
+            delta_offset: int = word_start_position - current_offset
 
-            if word:
-                token = Token(text=word, start_position=start_position)
-                self.add_token(token)
+            token: Token = Token(text=word, start_position=word_start_position)
+            self.add_token(token)
 
             if previous_token is not None:
                 previous_token.whitespace_after = delta_offset
 
-            current_offset = word_offset + len(word)
-            previous_word_offset = current_offset - 1
+            current_offset = token.end_position
             previous_token = token
 
         # the last token has no whitespace after
@@ -1010,7 +1002,9 @@ class Sentence(DataPoint):
 
     @property
     def end_position(self) -> int:
-        return self[-1].end_position + self[-1].whitespace_after
+        # The sentence's start position is not propagated to its tokens.
+        # Therefore, we need to add the sentence's start position to its last token's end position, including whitespaces.
+        return self.start_position + self[-1].end_position + self[-1].whitespace_after
 
     def get_language_code(self) -> str:
         if self.language_code is None:

--- a/flair/data.py
+++ b/flair/data.py
@@ -712,8 +712,7 @@ class Sentence(DataPoint):
 
         self.language_code: Optional[str] = language_code
 
-        self.start_pos = start_position
-        self.end_pos = start_position + len(text)
+        self._start_position = start_position
 
         # the tokenizer used for this sentence
         if isinstance(use_tokenizer, Tokenizer):
@@ -1003,11 +1002,15 @@ class Sentence(DataPoint):
 
     @property
     def start_position(self) -> int:
-        return 0
+        return self._start_position
+
+    @start_position.setter
+    def start_position(self, value: int) -> None:
+        self._start_position = value
 
     @property
     def end_position(self) -> int:
-        return len(self.to_original_text())
+        return self[-1].end_position + self[-1].whitespace_after
 
     def get_language_code(self) -> str:
         if self.language_code is None:

--- a/flair/data.py
+++ b/flair/data.py
@@ -504,8 +504,7 @@ class Token(_PartOfSentence):
         self.head_id: Optional[int] = head_id
         self.whitespace_after: int = whitespace_after
 
-        self.start_pos = start_position
-        self.end_pos = start_position + len(text)
+        self._start_position = start_position
 
         self._embeddings: Dict = {}
         self.tags_proba_dist: Dict[str, List[Label]] = {}
@@ -518,7 +517,7 @@ class Token(_PartOfSentence):
             raise ValueError
 
     @property
-    def text(self):
+    def text(self) -> str:
         return self.form
 
     @property
@@ -538,11 +537,15 @@ class Token(_PartOfSentence):
 
     @property
     def start_position(self) -> int:
-        return self.start_pos
+        return self._start_position
+
+    @start_position.setter
+    def start_position(self, value: int) -> None:
+        self._start_position = value
 
     @property
     def end_position(self) -> int:
-        return self.end_pos
+        return self.start_position + len(self.text)
 
     @property
     def embedding(self):
@@ -815,8 +818,7 @@ class Sentence(DataPoint):
         token.sentence = self
         token._internal_index = len(self.tokens) + 1
         if token.start_position == 0 and len(self) > 0:
-            token.start_pos = len(self.to_original_text()) + self[-1].whitespace_after
-            token.end_pos = token.start_pos + len(token.text)
+            token.start_position = len(self.to_original_text()) + self[-1].whitespace_after
 
         # append token to sentence
         self.tokens.append(token)
@@ -958,7 +960,7 @@ class Sentence(DataPoint):
         if len(self) == 0:
             return ""
         # otherwise, return concatenation of tokens with the correct offsets
-        return self[0].start_pos * " " + "".join([t.text + t.whitespace_after * " " for t in self.tokens]).strip()
+        return self[0].start_position * " " + "".join([t.text + t.whitespace_after * " " for t in self.tokens]).strip()
 
     def to_dict(self, tag_type: str = None):
         labels = []

--- a/flair/datasets/biomedical.py
+++ b/flair/datasets/biomedical.py
@@ -384,9 +384,9 @@ class CoNLLWriter:
 
                     for flair_token in sentence.tokens:
                         token = flair_token.text.strip()
-                        assert sentence.start_pos is not None
+                        assert sentence.start_position is not None
                         assert flair_token.start_position is not None
-                        offset = sentence.start_pos + flair_token.start_position
+                        offset = sentence.start_position + flair_token.start_position
 
                         if current_entity and offset >= current_entity.char_span.stop:
                             in_entity = False

--- a/flair/datasets/biomedical.py
+++ b/flair/datasets/biomedical.py
@@ -385,8 +385,8 @@ class CoNLLWriter:
                     for flair_token in sentence.tokens:
                         token = flair_token.text.strip()
                         assert sentence.start_pos is not None
-                        assert flair_token.start_pos is not None
-                        offset = sentence.start_pos + flair_token.start_pos
+                        assert flair_token.start_position is not None
+                        offset = sentence.start_pos + flair_token.start_position
 
                         if current_entity and offset >= current_entity.char_span.stop:
                             in_entity = False

--- a/flair/datasets/entity_linking.py
+++ b/flair/datasets/entity_linking.py
@@ -158,10 +158,10 @@ class NEL_ENGLISH_AQUAINT(ColumnCorpus):
                                 # set annotation for tokens of entity mention
                                 first = True
                                 for token in sentences[sentence_index].tokens:
-                                    assert token.start_pos is not None
-                                    assert token.end_pos is not None
+                                    assert token.start_position is not None
+                                    assert token.end_position is not None
                                     if (
-                                        token.start_pos >= mention_start and token.end_pos <= mention_end
+                                        token.start_position >= mention_start and token.end_position <= mention_end
                                     ):  # token belongs to entity mention
                                         if first:
                                             token.set_label(typename="nel", value="B-" + wikiname)
@@ -631,10 +631,10 @@ class NEL_ENGLISH_IITB(ColumnCorpus):
                                 # set annotation for tokens of entity mention
                                 first = True
                                 for token in sentences[sentence_index].tokens:
-                                    assert token.start_pos is not None
-                                    assert token.end_pos is not None
+                                    assert token.start_position is not None
+                                    assert token.end_position is not None
                                     if (
-                                        token.start_pos >= mention_start and token.end_pos <= mention_end
+                                        token.start_position >= mention_start and token.end_position <= mention_end
                                     ):  # token belongs to entity mention
                                         assert elem[1].text is not None
                                         if first:
@@ -928,18 +928,18 @@ class NEL_ENGLISH_REDDIT(ColumnCorpus):
             if links:
                 # Keep track which is the correct corresponding entity link, in cases where there is >1 link in a sentence
                 link_index = [
-                    j for j, v in enumerate(links) if (sentence[i].start_pos >= v[0] and sentence[i].end_pos <= v[1])
+                    j for j, v in enumerate(links) if (sentence[i].start_position >= v[0] and sentence[i].end_position <= v[1])
                 ]
                 # Write the token with a corresponding tag to file
                 try:
-                    if any(sentence[i].start_pos == v[0] and sentence[i].end_pos == v[1] for j, v in enumerate(links)):
+                    if any(sentence[i].start_position == v[0] and sentence[i].end_position == v[1] for j, v in enumerate(links)):
                         outfile.writelines(sentence[i].text + "\tS-" + links[link_index[0]][2] + "\n")
                     elif any(
-                        sentence[i].start_pos == v[0] and sentence[i].end_pos != v[1] for j, v in enumerate(links)
+                        sentence[i].start_position == v[0] and sentence[i].end_position != v[1] for j, v in enumerate(links)
                     ):
                         outfile.writelines(sentence[i].text + "\tB-" + links[link_index[0]][2] + "\n")
                     elif any(
-                        sentence[i].start_pos >= v[0] and sentence[i].end_pos <= v[1] for j, v in enumerate(links)
+                        sentence[i].start_position >= v[0] and sentence[i].end_position <= v[1] for j, v in enumerate(links)
                     ):
                         outfile.writelines(sentence[i].text + "\tI-" + links[link_index[0]][2] + "\n")
                     else:

--- a/flair/datasets/entity_linking.py
+++ b/flair/datasets/entity_linking.py
@@ -138,7 +138,7 @@ class NEL_ENGLISH_AQUAINT(ColumnCorpus):
 
                             # sentence splitting and tokenization
                             sentences = sentence_splitter.split(string)
-                            sentence_offsets = [sentence.start_pos or 0 for sentence in sentences]
+                            sentence_offsets = [sentence.start_position or 0 for sentence in sentences]
 
                             # iterate through all annotations and add to corresponding tokens
                             for mention_start, mention_length, wikiname in zip(indices, lengths, wikinames):
@@ -603,7 +603,7 @@ class NEL_ENGLISH_IITB(ColumnCorpus):
 
                         # split sentences and tokenize
                         sentences = sentence_splitter.split(text)
-                        sentence_offsets = [sentence.start_pos or 0 for sentence in sentences]
+                        sentence_offsets = [sentence.start_position or 0 for sentence in sentences]
 
                         # iterate through all annotations and add to corresponding tokens
                         for elem in root:

--- a/flair/datasets/entity_linking.py
+++ b/flair/datasets/entity_linking.py
@@ -928,18 +928,25 @@ class NEL_ENGLISH_REDDIT(ColumnCorpus):
             if links:
                 # Keep track which is the correct corresponding entity link, in cases where there is >1 link in a sentence
                 link_index = [
-                    j for j, v in enumerate(links) if (sentence[i].start_position >= v[0] and sentence[i].end_position <= v[1])
+                    j
+                    for j, v in enumerate(links)
+                    if (sentence[i].start_position >= v[0] and sentence[i].end_position <= v[1])
                 ]
                 # Write the token with a corresponding tag to file
                 try:
-                    if any(sentence[i].start_position == v[0] and sentence[i].end_position == v[1] for j, v in enumerate(links)):
+                    if any(
+                        sentence[i].start_position == v[0] and sentence[i].end_position == v[1]
+                        for j, v in enumerate(links)
+                    ):
                         outfile.writelines(sentence[i].text + "\tS-" + links[link_index[0]][2] + "\n")
                     elif any(
-                        sentence[i].start_position == v[0] and sentence[i].end_position != v[1] for j, v in enumerate(links)
+                        sentence[i].start_position == v[0] and sentence[i].end_position != v[1]
+                        for j, v in enumerate(links)
                     ):
                         outfile.writelines(sentence[i].text + "\tB-" + links[link_index[0]][2] + "\n")
                     elif any(
-                        sentence[i].start_position >= v[0] and sentence[i].end_position <= v[1] for j, v in enumerate(links)
+                        sentence[i].start_position >= v[0] and sentence[i].end_position <= v[1]
+                        for j, v in enumerate(links)
                     ):
                         outfile.writelines(sentence[i].text + "\tI-" + links[link_index[0]][2] + "\n")
                     else:

--- a/flair/datasets/relation_extraction.py
+++ b/flair/datasets/relation_extraction.py
@@ -687,10 +687,10 @@ class RE_ENGLISH_DRUGPROT(ColumnCorpus):
             (abstract_offset, abstract_sentences),
         ]:
             for sent in sents:
-                assert sent.start_pos is not None
-                assert sent.end_pos is not None
-                sent_char_start = sent.start_pos + offset
-                sent_char_end = sent.end_pos + offset
+                assert sent.start_position is not None
+                assert sent.end_position is not None
+                sent_char_start = sent.start_position + offset
+                sent_char_end = sent.end_position + offset
 
                 entities_in_sent = set()
                 for entity_id, (_, char_start, char_end, _) in entities.items():
@@ -701,8 +701,8 @@ class RE_ENGLISH_DRUGPROT(ColumnCorpus):
 
                 token_offsets = [
                     (
-                        sent.start_pos + (token.start_position or 0) + offset,
-                        sent.start_pos + (token.end_position or 0) + offset,
+                        sent.start_position + (token.start_position or 0) + offset,
+                        sent.start_position + (token.end_position or 0) + offset,
                     )
                     for token in sent.tokens
                 ]

--- a/flair/datasets/relation_extraction.py
+++ b/flair/datasets/relation_extraction.py
@@ -701,8 +701,8 @@ class RE_ENGLISH_DRUGPROT(ColumnCorpus):
 
                 token_offsets = [
                     (
-                        sent.start_pos + (token.start_pos or 0) + offset,
-                        sent.start_pos + (token.end_pos or 0) + offset,
+                        sent.start_pos + (token.start_position or 0) + offset,
+                        sent.start_pos + (token.end_position or 0) + offset,
                     )
                     for token in sent.tokens
                 ]

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -216,10 +216,10 @@ class JsonlDataset(FlairDataset):
         start_idx = -1
         end_idx = -1
         for token in sentence:
-            if token.start_pos <= start <= token.end_pos and start_idx == -1:
+            if token.start_position <= start <= token.end_position and start_idx == -1:
                 start_idx = token.idx - 1
 
-            if token.start_pos <= end <= token.end_pos and end_idx == -1:
+            if token.start_position <= end <= token.end_position and end_idx == -1:
                 end_idx = token.idx - 1
 
         # If end index is not found set to last token
@@ -740,12 +740,11 @@ class ColumnDataset(FlairDataset):
         if last_token is None:
             start = 0
         else:
-            assert last_token.end_pos is not None
-            start = last_token.end_pos
+            assert last_token.end_position is not None
+            start = last_token.end_position
             if last_token.whitespace_after > 0:
                 start += last_token.whitespace_after
-        token.start_pos = start
-        token.end_pos = token.start_pos + len(token.text)
+        token.start_position = start
         return token
 
     def _remap_label(self, tag):

--- a/flair/models/regexp_tagger.py
+++ b/flair/models/regexp_tagger.py
@@ -19,8 +19,8 @@ class TokenCollection:
 
     def __post_init__(self):
         for token in self.tokens:
-            self.__tokens_start_pos.append(token.start_pos)
-            self.__tokens_end_pos.append(token.end_pos)
+            self.__tokens_start_pos.append(token.start_position)
+            self.__tokens_end_pos.append(token.end_position)
 
     @property
     def tokens(self) -> List[Token]:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -88,8 +88,8 @@ def test_load_sequence_labeling_whitespace_after(tasks_base_path):
     assert corpus.train[0].to_tokenized_string() == "It is a German - owned firm ."
     assert corpus.train[0].to_plain_string() == "It is a German-owned firm."
     for token in corpus.train[0]:
-        assert token.start_pos is not None
-        assert token.end_pos is not None
+        assert token.start_position is not None
+        assert token.end_position is not None
 
 
 def test_load_column_corpus_options(tasks_base_path):

--- a/tests/test_sentence.py
+++ b/tests/test_sentence.py
@@ -46,3 +46,30 @@ def test_token_labeling():
     sentence[0].add_label("pos", "erstes")
     assert [label.value for label in sentence.get_labels("pos")] == ["first", "primero", "erstes"]
     assert sentence[0].get_label("pos").value == "first"
+
+
+def test_start_end_position_untokenized() -> None:
+    sentence: Sentence = Sentence("This is a sentence.", start_position=10)
+    assert sentence.start_position == 10
+    assert sentence.end_position == 29
+    assert [(token.start_position, token.end_position) for token in sentence] == [
+        (0, 4),
+        (5, 7),
+        (8, 9),
+        (10, 18),
+        (18, 19),
+    ]
+
+
+def test_start_end_position_pretokenized() -> None:
+    # Initializing a Sentence this way assumes that there is a space after each token
+    sentence: Sentence = Sentence(["This", "is", "a", "sentence", "."], start_position=10)
+    assert sentence.start_position == 10
+    assert sentence.end_position == 30
+    assert [(token.start_position, token.end_position) for token in sentence] == [
+        (0, 4),
+        (5, 7),
+        (8, 9),
+        (10, 18),
+        (19, 20),
+    ]

--- a/tests/test_tokenize_sentence.py
+++ b/tests/test_tokenize_sentence.py
@@ -211,17 +211,17 @@ def test_split_text_segtok():
     segtok_splitter = SegtokSentenceSplitter()
     sentences = segtok_splitter.split("I love Berlin. " "Berlin is a great city.")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 4
-    assert sentences[1].start_pos == 15
+    assert sentences[1].start_position == 15
     assert len(sentences[1].tokens) == 6
 
     segtok_splitter = SegtokSentenceSplitter(tokenizer=TokenizerWrapper(no_op_tokenizer))
     sentences = segtok_splitter.split("I love Berlin. " "Berlin is a great city.")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 1
-    assert sentences[1].start_pos == 15
+    assert sentences[1].start_position == 15
     assert len(sentences[1].tokens) == 1
 
 
@@ -229,13 +229,13 @@ def test_split_text_nosplit():
     no_splitter = NoSentenceSplitter()
     sentences = no_splitter.split("I love Berlin")
     assert len(sentences) == 1
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 3
 
     no_splitter = NoSentenceSplitter(TokenizerWrapper(no_op_tokenizer))
     sentences = no_splitter.split("I love Berlin")
     assert len(sentences) == 1
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 1
 
 
@@ -244,17 +244,17 @@ def test_split_text_on_tag():
 
     sentences = tag_splitter.split("I love Berlin#!Me too")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 3
-    assert sentences[1].start_pos == 15
+    assert sentences[1].start_position == 15
     assert len(sentences[1].tokens) == 2
 
     tag_splitter = TagSentenceSplitter(tag="#!", tokenizer=TokenizerWrapper(no_op_tokenizer))
     sentences = tag_splitter.split("I love Berlin#!Me too")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 1
-    assert sentences[1].start_pos == 15
+    assert sentences[1].start_position == 15
     assert len(sentences[1].tokens) == 1
 
     sentences = tag_splitter.split("I love Berlin Me too")
@@ -272,16 +272,16 @@ def test_split_text_on_newline():
 
     sentences = newline_splitter.split("I love Berlin\nMe too")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 3
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[1].tokens) == 2
 
     newline_splitter = NewlineSentenceSplitter(tokenizer=TokenizerWrapper(no_op_tokenizer))
     sentences = newline_splitter.split("I love Berlin\nMe too")
     assert len(sentences) == 2
     assert len(sentences[0].tokens) == 1
-    assert sentences[1].start_pos == 14
+    assert sentences[1].start_position == 14
     assert len(sentences[1].tokens) == 1
 
     sentences = newline_splitter.split("I love Berlin Me too")
@@ -300,24 +300,24 @@ def test_split_text_spacy():
 
     sentences = spacy_splitter.split("This a sentence. " "And here is another one.")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 4
-    assert sentences[1].start_pos == 17
+    assert sentences[1].start_position == 17
     assert len(sentences[1].tokens) == 6
 
     sentences = spacy_splitter.split("VF inhibits something. ACE-dependent (GH+) issuses too.")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 4
-    assert sentences[1].start_pos == 23
+    assert sentences[1].start_position == 23
     assert len(sentences[1].tokens) == 7
 
     spacy_splitter = SpacySentenceSplitter("en_core_sci_sm", tokenizer=TokenizerWrapper(no_op_tokenizer))
     sentences = spacy_splitter.split("This a sentence. " "And here is another one.")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 1
-    assert sentences[1].start_pos == 17
+    assert sentences[1].start_position == 17
     assert len(sentences[1].tokens) == 1
 
 
@@ -326,9 +326,9 @@ def test_split_text_scispacy():
     scispacy_splitter = SciSpacySentenceSplitter()
     sentences = scispacy_splitter.split("VF inhibits something. ACE-dependent (GH+) issuses too.")
     assert len(sentences) == 2
-    assert sentences[0].start_pos == 0
+    assert sentences[0].start_position == 0
     assert len(sentences[0].tokens) == 4
-    assert sentences[1].start_pos == 23
+    assert sentences[1].start_position == 23
     assert len(sentences[1].tokens) == 9
 
 

--- a/tests/test_tokenize_sentence.py
+++ b/tests/test_tokenize_sentence.py
@@ -32,7 +32,7 @@ def test_create_sentence_with_newline():
 
     sentence: Sentence = Sentence("I \t ich \n you \t du \n", use_tokenizer=False)
     assert 8 == len(sentence.tokens)
-    assert 0 == sentence.tokens[0].start_pos
+    assert 0 == sentence.tokens[0].start_position
     assert "\n" == sentence.tokens[3].text
 
 
@@ -100,11 +100,11 @@ def test_create_sentence_without_tokenizer():
     sentence: Sentence = Sentence("I love Berlin.", use_tokenizer=False)
 
     assert 3 == len(sentence.tokens)
-    assert 0 == sentence.tokens[0].start_pos
+    assert 0 == sentence.tokens[0].start_position
     assert "I" == sentence.tokens[0].text
-    assert 2 == sentence.tokens[1].start_pos
+    assert 2 == sentence.tokens[1].start_position
     assert "love" == sentence.tokens[1].text
-    assert 7 == sentence.tokens[2].start_pos
+    assert 7 == sentence.tokens[2].start_position
     assert "Berlin." == sentence.tokens[2].text
 
 
@@ -112,13 +112,13 @@ def test_create_sentence_with_default_tokenizer():
     sentence: Sentence = Sentence("I love Berlin.", use_tokenizer=True)
 
     assert 4 == len(sentence.tokens)
-    assert 0 == sentence.tokens[0].start_pos
+    assert 0 == sentence.tokens[0].start_position
     assert "I" == sentence.tokens[0].text
-    assert 2 == sentence.tokens[1].start_pos
+    assert 2 == sentence.tokens[1].start_position
     assert "love" == sentence.tokens[1].text
-    assert 7 == sentence.tokens[2].start_pos
+    assert 7 == sentence.tokens[2].start_position
     assert "Berlin" == sentence.tokens[2].text
-    assert 13 == sentence.tokens[3].start_pos
+    assert 13 == sentence.tokens[3].start_position
     assert "." == sentence.tokens[3].text
 
 
@@ -135,7 +135,7 @@ def test_create_sentence_with_segtok():
 def test_create_sentence_with_custom_tokenizer():
     sentence: Sentence = Sentence("I love Berlin.", use_tokenizer=TokenizerWrapper(no_op_tokenizer))
     assert 1 == len(sentence.tokens)
-    assert 0 == sentence.tokens[0].start_pos
+    assert 0 == sentence.tokens[0].start_position
     assert "I love Berlin." == sentence.tokens[0].text
 
 
@@ -144,13 +144,13 @@ def test_create_sentence_with_spacy_tokenizer():
     sentence: Sentence = Sentence("I love Berlin.", use_tokenizer=SpacyTokenizer("en_core_sci_sm"))
 
     assert 4 == len(sentence.tokens)
-    assert 0 == sentence.tokens[0].start_pos
+    assert 0 == sentence.tokens[0].start_position
     assert "I" == sentence.tokens[0].text
-    assert 2 == sentence.tokens[1].start_pos
+    assert 2 == sentence.tokens[1].start_position
     assert "love" == sentence.tokens[1].text
-    assert 7 == sentence.tokens[2].start_pos
+    assert 7 == sentence.tokens[2].start_position
     assert "Berlin" == sentence.tokens[2].text
-    assert 13 == sentence.tokens[3].start_pos
+    assert 13 == sentence.tokens[3].start_position
     assert "." == sentence.tokens[3].text
 
 
@@ -187,19 +187,19 @@ def test_create_sentence_using_scispacy_tokenizer():
     assert "motor" == sentence.tokens[11].text
     assert "neuron" == sentence.tokens[12].text
 
-    assert 0 == sentence.tokens[0].start_pos
-    assert 7 == sentence.tokens[1].start_pos
-    assert 11 == sentence.tokens[2].start_pos
-    assert 18 == sentence.tokens[3].start_pos
-    assert 27 == sentence.tokens[4].start_pos
-    assert 35 == sentence.tokens[5].start_pos
-    assert 36 == sentence.tokens[6].start_pos
-    assert 40 == sentence.tokens[7].start_pos
-    assert 42 == sentence.tokens[8].start_pos
-    assert 45 == sentence.tokens[9].start_pos
-    assert 48 == sentence.tokens[10].start_pos
-    assert 58 == sentence.tokens[11].start_pos
-    assert 64 == sentence.tokens[12].start_pos
+    assert 0 == sentence.tokens[0].start_position
+    assert 7 == sentence.tokens[1].start_position
+    assert 11 == sentence.tokens[2].start_position
+    assert 18 == sentence.tokens[3].start_position
+    assert 27 == sentence.tokens[4].start_position
+    assert 35 == sentence.tokens[5].start_position
+    assert 36 == sentence.tokens[6].start_position
+    assert 40 == sentence.tokens[7].start_position
+    assert 42 == sentence.tokens[8].start_position
+    assert 45 == sentence.tokens[9].start_position
+    assert 48 == sentence.tokens[10].start_position
+    assert 58 == sentence.tokens[11].start_position
+    assert 64 == sentence.tokens[12].start_position
 
     assert sentence.tokens[4].whitespace_after == 1
     assert sentence.tokens[5].whitespace_after != 1


### PR DESCRIPTION
This PR refactors the Token and Sentence positional properties inherited from the DataPoint to replace the `self.start_pos` and `self.end_pos` attributes.

For the Sentence, both variants of accessing positional information behaved differently, resulting in inconsistent results where they appropriately should have been aliases. These are the inconsistencies:

1. Initializing the Sentence with `str`, i.e. untokenized input.
    - We allow the user to set an offset `start_position` in the init but this is not respected in the `start_position` property. It always returns zero. The inconsistency is also that in `start_pos` the start position offset is included. 
    **Suggestion**: Only use and expose the property inherited from the DataPoint. Having multiple attributes doing the same thing with different names may get confusing.

2. Initializing the Sentence with `List[str]`, i.e. pre-tokenized input.
    - Same concern as in (1)
    - Added to (1), `end_pos` and `end_position` actually do not behave the same. 
      ```python
      from flair.data import Sentence
      s = Sentence(['This', 'is', 'an', 'example', '.'])
      print(s.end_position)  # Prints 17 -> Corresponding to the character-level end position
      print(s.end_pos)  # Prints 5 -> Corresponding to the token-level end position
      ```
      **Suggestion:** Always use the character-level end position since the token-level end position is accessible with `len(s)`.
    - The token start and end positions were incorrect.
      ```python
      from flair.data import Sentence
      sentence = Sentence(["This", "is", "a", "sentence", "."])
      print([(token.start_position, token.end_position) for token in sentence])  
      # Prints [(0, 4), (5, 7), (7, 8), (8, 16), (16, 17)] but expected [(0, 4), (5, 7), (8, 9), (10, 18), (19, 20)]
      ```
      **Suggestion:** Do not use two separate methods to construct the tokens. Instead, convert the case of initializing the Sentence with `List[str]` to the case of initializing the `str`.

Please see the commits as isolated corresponding to the suggestions.
