### PR TITLE
Restructure Tokenizer and Splitter modules

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -16,6 +16,7 @@ from torch.utils.data.dataset import ConcatDataset, Subset
 
 import flair
 from flair.file_utils import Tqdm
+from flair.tokenization import SegtokTokenizer, SpaceTokenizer, Tokenizer
 
 T_co = typing.TypeVar("T_co", covariant=True)
 
@@ -661,25 +662,6 @@ class Relation(_PartOfSentence):
         pass
 
 
-class Tokenizer(ABC):
-    r"""An abstract class representing a :class:`Tokenizer`.
-
-    Tokenizers are used to represent algorithms and models to split plain text into
-    individual tokens / words. All subclasses should overwrite :meth:`tokenize`, which
-    splits the given plain text into tokens. Moreover, subclasses may overwrite
-    :meth:`name`, returning a unique identifier representing the tokenizer's
-    configuration.
-    """
-
-    @abstractmethod
-    def tokenize(self, text: str) -> List[str]:
-        raise NotImplementedError()
-
-    @property
-    def name(self) -> str:
-        return self.__class__.__name__
-
-
 class Sentence(DataPoint):
     """
     A Sentence is a list of tokens and is used to represent a sentence or text fragment.
@@ -719,8 +701,6 @@ class Sentence(DataPoint):
             tokenizer = use_tokenizer
 
         elif type(use_tokenizer) == bool:
-            from flair.tokenization import SegtokTokenizer, SpaceTokenizer
-
             tokenizer = SegtokTokenizer() if use_tokenizer else SpaceTokenizer()
 
         else:

--- a/flair/datasets/biomedical.py
+++ b/flair/datasets/biomedical.py
@@ -30,15 +30,14 @@ import flair
 from flair.data import MultiCorpus, Tokenizer
 from flair.datasets.sequence_labeling import ColumnCorpus, ColumnDataset
 from flair.file_utils import Tqdm, cached_path, unpack_file
-from flair.tokenization import (
+from flair.splitter import (
     NewlineSentenceSplitter,
     NoSentenceSplitter,
     SciSpacySentenceSplitter,
-    SciSpacyTokenizer,
     SentenceSplitter,
-    SpaceTokenizer,
     TagSentenceSplitter,
 )
+from flair.tokenization import SciSpacyTokenizer, SpaceTokenizer
 
 DISEASE_TAG = "Disease"
 CHEMICAL_TAG = "Chemical"

--- a/flair/datasets/entity_linking.py
+++ b/flair/datasets/entity_linking.py
@@ -10,7 +10,7 @@ import flair
 from flair.data import Corpus, MultiCorpus, Sentence
 from flair.datasets.sequence_labeling import ColumnCorpus
 from flair.file_utils import cached_path, unpack_file
-from flair.tokenization import SegtokSentenceSplitter, SentenceSplitter
+from flair.splitter import SegtokSentenceSplitter, SentenceSplitter
 
 log = logging.getLogger("flair")
 

--- a/flair/datasets/relation_extraction.py
+++ b/flair/datasets/relation_extraction.py
@@ -16,7 +16,7 @@ import flair
 from flair.data import Sentence
 from flair.datasets.sequence_labeling import ColumnCorpus
 from flair.file_utils import cached_path
-from flair.tokenization import SegtokSentenceSplitter, SentenceSplitter
+from flair.splitter import SegtokSentenceSplitter, SentenceSplitter
 
 log = logging.getLogger("flair")
 

--- a/flair/splitter.py
+++ b/flair/splitter.py
@@ -1,0 +1,253 @@
+from abc import ABC, abstractmethod
+from typing import Any, List, Union
+
+from segtok.segmenter import split_multi
+
+from flair.data import Sentence
+from flair.tokenization import (
+    SciSpacyTokenizer,
+    SegtokTokenizer,
+    SpacyTokenizer,
+    Tokenizer,
+)
+
+
+class SentenceSplitter(ABC):
+    r"""An abstract class representing a :class:`SentenceSplitter`.
+
+    Sentence splitters are used to represent algorithms and models to split plain text into
+    sentences and individual tokens / words. All subclasses should overwrite :meth:`splits`,
+    which splits the given plain text into a sequence of sentences (:class:`Sentence`). The
+    individual sentences are in turn subdivided into tokens / words. In most cases, this can
+    be controlled by passing custom implementation of :class:`Tokenizer`.
+
+    Moreover, subclasses may overwrite :meth:`name`, returning a unique identifier representing
+    the sentence splitter's configuration.
+    """
+
+    @abstractmethod
+    def split(self, text: str) -> List[Sentence]:
+        raise NotImplementedError()
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    @property
+    def tokenizer(self) -> Tokenizer:
+        raise NotImplementedError()
+
+    @tokenizer.setter
+    def tokenizer(self, value: Tokenizer):
+        raise NotImplementedError()
+
+
+class SegtokSentenceSplitter(SentenceSplitter):
+    """
+    Implementation of :class:`SentenceSplitter` using the SegTok library.
+
+    For further details see: https://github.com/fnl/segtok
+    """
+
+    def __init__(self, tokenizer: Tokenizer = SegtokTokenizer()):
+        super(SegtokSentenceSplitter, self).__init__()
+        self._tokenizer = tokenizer
+
+    def split(self, text: str) -> List[Sentence]:
+        plain_sentences: List[str] = split_multi(text)
+        sentence_offset = 0
+
+        sentences: List[Sentence] = []
+        for sentence in plain_sentences:
+            try:
+                sentence_offset = text.index(sentence, sentence_offset)
+            except ValueError as error:
+                raise AssertionError(
+                    f"Can't find the sentence offset for sentence {repr(sentence)} "
+                    f"starting from position {repr(sentence_offset)}"
+                ) from error
+            sentences.append(
+                Sentence(
+                    text=sentence,
+                    use_tokenizer=self._tokenizer,
+                    start_position=sentence_offset,
+                )
+            )
+
+            sentence_offset += len(sentence)
+
+        return sentences
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    @property
+    def tokenizer(self) -> Tokenizer:
+        return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: Tokenizer):
+        self._tokenizer = value
+
+
+class SpacySentenceSplitter(SentenceSplitter):
+    """
+    Implementation of :class:`SentenceSplitter`, using models from Spacy.
+
+    :param model Spacy V2 model or the name of the model to load.
+    :param tokenizer Custom tokenizer to use (default :class:`SpacyTokenizer`)
+    """
+
+    def __init__(self, model: Union[Any, str], tokenizer: Tokenizer = None):
+        super(SpacySentenceSplitter, self).__init__()
+
+        try:
+            import spacy
+            from spacy.language import Language
+        except ImportError:
+            raise ImportError(
+                "Please install spacy v2.3.2 or higher before using the SpacySentenceSplitter, "
+                "otherwise you can use SegtokSentenceSplitter as alternative implementation."
+            )
+
+        if isinstance(model, Language):
+            self.model: Language = model
+        else:
+            assert isinstance(model, str)
+            self.model = spacy.load(model)
+
+        if tokenizer is None:
+            self._tokenizer: Tokenizer = SpacyTokenizer("en_core_sci_sm")
+        else:
+            self._tokenizer = tokenizer
+
+    def split(self, text: str) -> List[Sentence]:
+        document = self.model(text)
+
+        sentences = [
+            Sentence(
+                text=str(spacy_sent),
+                use_tokenizer=self._tokenizer,
+                start_position=spacy_sent.start_char,
+            )
+            for spacy_sent in document.sents
+            if len(str(spacy_sent)) > 0
+        ]
+
+        return sentences
+
+    @property
+    def tokenizer(self) -> Tokenizer:
+        return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: Tokenizer):
+        self._tokenizer = value
+
+    @property
+    def name(self) -> str:
+        return (
+            self.__class__.__name__
+            + "_"
+            + self.model.meta["name"]
+            + "_"
+            + self.model.meta["version"]
+            + "_"
+            + self._tokenizer.name
+        )
+
+
+class SciSpacySentenceSplitter(SpacySentenceSplitter):
+    """
+    Convenience class to instantiate :class:`SpacySentenceSplitter` with Spacy model `en_core_sci_sm`
+    for sentence splitting and :class:`SciSpacyTokenizer` as tokenizer.
+    """
+
+    def __init__(self):
+        super(SciSpacySentenceSplitter, self).__init__("en_core_sci_sm", SciSpacyTokenizer())
+
+
+class TagSentenceSplitter(SentenceSplitter):
+    """
+    Implementation of :class:`SentenceSplitter` which assumes that there is a special tag within
+    the text that is used to mark sentence boundaries.
+    """
+
+    def __init__(self, tag: str, tokenizer: Tokenizer = SegtokTokenizer()):
+        super(TagSentenceSplitter, self).__init__()
+        self._tokenizer = tokenizer
+        self.tag = tag
+
+    def split(self, text: str) -> List[Sentence]:
+        plain_sentences = text.split(self.tag)
+
+        sentences = []
+        last_offset = 0
+
+        for sentence in plain_sentences:
+            if len(sentence.strip()) == 0:
+                continue
+
+            sentences += [
+                Sentence(
+                    text=sentence,
+                    use_tokenizer=self._tokenizer,
+                    start_position=last_offset,
+                )
+            ]
+
+            last_offset += len(sentence) + len(self.tag)
+
+        return sentences
+
+    @property
+    def tokenizer(self) -> Tokenizer:
+        return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: Tokenizer):
+        self._tokenizer = value
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__ + "_" + self.tag + "_" + self._tokenizer.name
+
+
+class NewlineSentenceSplitter(TagSentenceSplitter):
+    """
+    Convenience class to instantiate :class:`SentenceTagSplitter` with newline ("\n") as
+    sentence boundary marker.
+    """
+
+    def __init__(self, tokenizer: Tokenizer = SegtokTokenizer()):
+        super(NewlineSentenceSplitter, self).__init__(tag="\n", tokenizer=tokenizer)
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__ + "_" + self._tokenizer.name
+
+
+class NoSentenceSplitter(SentenceSplitter):
+    """
+    Implementation of :class:`SentenceSplitter` which treats the complete text as one sentence.
+    """
+
+    def __init__(self, tokenizer: Tokenizer = SegtokTokenizer()):
+        super(NoSentenceSplitter, self).__init__()
+        self._tokenizer = tokenizer
+
+    def split(self, text: str) -> List[Sentence]:
+        return [Sentence(text=text, use_tokenizer=self._tokenizer, start_position=0)]
+
+    @property
+    def tokenizer(self) -> Tokenizer:
+        return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: Tokenizer):
+        self._tokenizer = value
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__ + "_" + self._tokenizer.name

--- a/flair/tokenization.py
+++ b/flair/tokenization.py
@@ -1,13 +1,30 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List, Union
+from typing import Callable, List
 
-from segtok.segmenter import split_multi, split_single
+from segtok.segmenter import split_single
 from segtok.tokenizer import split_contractions, word_tokenizer
 
-from flair.data import Sentence, Tokenizer
-
 log = logging.getLogger("flair")
+
+
+class Tokenizer(ABC):
+    r"""An abstract class representing a :class:`Tokenizer`.
+
+    Tokenizers are used to represent algorithms and models to split plain text into
+    individual tokens / words. All subclasses should overwrite :meth:`tokenize`, which
+    splits the given plain text into tokens. Moreover, subclasses may overwrite
+    :meth:`name`, returning a unique identifier representing the tokenizer's
+    configuration.
+    """
+
+    @abstractmethod
+    def tokenize(self, text: str) -> List[str]:
+        raise NotImplementedError()
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
 
 
 class SpacyTokenizer(Tokenizer):
@@ -262,244 +279,3 @@ class SciSpacyTokenizer(Tokenizer):
     @property
     def name(self) -> str:
         return self.__class__.__name__ + "_" + self.model.meta["name"] + "_" + self.model.meta["version"]
-
-
-class SentenceSplitter(ABC):
-    r"""An abstract class representing a :class:`SentenceSplitter`.
-
-    Sentence splitters are used to represent algorithms and models to split plain text into
-    sentences and individual tokens / words. All subclasses should overwrite :meth:`splits`,
-    which splits the given plain text into a sequence of sentences (:class:`Sentence`). The
-    individual sentences are in turn subdivided into tokens / words. In most cases, this can
-    be controlled by passing custom implementation of :class:`Tokenizer`.
-
-    Moreover, subclasses may overwrite :meth:`name`, returning a unique identifier representing
-    the sentence splitter's configuration.
-    """
-
-    @abstractmethod
-    def split(self, text: str) -> List[Sentence]:
-        raise NotImplementedError()
-
-    @property
-    def name(self) -> str:
-        return self.__class__.__name__
-
-    @property
-    def tokenizer(self) -> Tokenizer:
-        raise NotImplementedError()
-
-    @tokenizer.setter
-    def tokenizer(self, value: Tokenizer):
-        raise NotImplementedError()
-
-
-class SegtokSentenceSplitter(SentenceSplitter):
-    """
-    Implementation of :class:`SentenceSplitter` using the SegTok library.
-
-    For further details see: https://github.com/fnl/segtok
-    """
-
-    def __init__(self, tokenizer: Tokenizer = SegtokTokenizer()):
-        super(SegtokSentenceSplitter, self).__init__()
-        self._tokenizer = tokenizer
-
-    def split(self, text: str) -> List[Sentence]:
-        plain_sentences: List[str] = split_multi(text)
-        sentence_offset = 0
-
-        sentences: List[Sentence] = []
-        for sentence in plain_sentences:
-            try:
-                sentence_offset = text.index(sentence, sentence_offset)
-            except ValueError as error:
-                raise AssertionError(
-                    f"Can't find the sentence offset for sentence {repr(sentence)} "
-                    f"starting from position {repr(sentence_offset)}"
-                ) from error
-            sentences.append(
-                Sentence(
-                    text=sentence,
-                    use_tokenizer=self._tokenizer,
-                    start_position=sentence_offset,
-                )
-            )
-
-            sentence_offset += len(sentence)
-
-        return sentences
-
-    @property
-    def name(self) -> str:
-        return self.__class__.__name__
-
-    @property
-    def tokenizer(self) -> Tokenizer:
-        return self._tokenizer
-
-    @tokenizer.setter
-    def tokenizer(self, value: Tokenizer):
-        self._tokenizer = value
-
-
-class SpacySentenceSplitter(SentenceSplitter):
-    """
-    Implementation of :class:`SentenceSplitter`, using models from Spacy.
-
-    :param model Spacy V2 model or the name of the model to load.
-    :param tokenizer Custom tokenizer to use (default :class:`SpacyTokenizer`)
-    """
-
-    def __init__(self, model: Union[Any, str], tokenizer: Tokenizer = None):
-        super(SpacySentenceSplitter, self).__init__()
-
-        try:
-            import spacy
-            from spacy.language import Language
-        except ImportError:
-            raise ImportError(
-                "Please install spacy v2.3.2 or higher before using the SpacySentenceSplitter, "
-                "otherwise you can use SegtokSentenceSplitter as alternative implementation."
-            )
-
-        if isinstance(model, Language):
-            self.model: Language = model
-        else:
-            assert isinstance(model, str)
-            self.model = spacy.load(model)
-
-        if tokenizer is None:
-            self._tokenizer: Tokenizer = SpacyTokenizer("en_core_sci_sm")
-        else:
-            self._tokenizer = tokenizer
-
-    def split(self, text: str) -> List[Sentence]:
-        document = self.model(text)
-
-        sentences = [
-            Sentence(
-                text=str(spacy_sent),
-                use_tokenizer=self._tokenizer,
-                start_position=spacy_sent.start_char,
-            )
-            for spacy_sent in document.sents
-            if len(str(spacy_sent)) > 0
-        ]
-
-        return sentences
-
-    @property
-    def tokenizer(self) -> Tokenizer:
-        return self._tokenizer
-
-    @tokenizer.setter
-    def tokenizer(self, value: Tokenizer):
-        self._tokenizer = value
-
-    @property
-    def name(self) -> str:
-        return (
-            self.__class__.__name__
-            + "_"
-            + self.model.meta["name"]
-            + "_"
-            + self.model.meta["version"]
-            + "_"
-            + self._tokenizer.name
-        )
-
-
-class SciSpacySentenceSplitter(SpacySentenceSplitter):
-    """
-    Convenience class to instantiate :class:`SpacySentenceSplitter` with Spacy model `en_core_sci_sm`
-    for sentence splitting and :class:`SciSpacyTokenizer` as tokenizer.
-    """
-
-    def __init__(self):
-        super(SciSpacySentenceSplitter, self).__init__("en_core_sci_sm", SciSpacyTokenizer())
-
-
-class TagSentenceSplitter(SentenceSplitter):
-    """
-    Implementation of :class:`SentenceSplitter` which assumes that there is a special tag within
-    the text that is used to mark sentence boundaries.
-    """
-
-    def __init__(self, tag: str, tokenizer: Tokenizer = SegtokTokenizer()):
-        super(TagSentenceSplitter, self).__init__()
-        self._tokenizer = tokenizer
-        self.tag = tag
-
-    def split(self, text: str) -> List[Sentence]:
-        plain_sentences = text.split(self.tag)
-
-        sentences = []
-        last_offset = 0
-
-        for sentence in plain_sentences:
-            if len(sentence.strip()) == 0:
-                continue
-
-            sentences += [
-                Sentence(
-                    text=sentence,
-                    use_tokenizer=self._tokenizer,
-                    start_position=last_offset,
-                )
-            ]
-
-            last_offset += len(sentence) + len(self.tag)
-
-        return sentences
-
-    @property
-    def tokenizer(self) -> Tokenizer:
-        return self._tokenizer
-
-    @tokenizer.setter
-    def tokenizer(self, value: Tokenizer):
-        self._tokenizer = value
-
-    @property
-    def name(self) -> str:
-        return self.__class__.__name__ + "_" + self.tag + "_" + self._tokenizer.name
-
-
-class NewlineSentenceSplitter(TagSentenceSplitter):
-    """
-    Convenience class to instantiate :class:`SentenceTagSplitter` with newline ("\n") as
-    sentence boundary marker.
-    """
-
-    def __init__(self, tokenizer: Tokenizer = SegtokTokenizer()):
-        super(NewlineSentenceSplitter, self).__init__(tag="\n", tokenizer=tokenizer)
-
-    @property
-    def name(self) -> str:
-        return self.__class__.__name__ + "_" + self._tokenizer.name
-
-
-class NoSentenceSplitter(SentenceSplitter):
-    """
-    Implementation of :class:`SentenceSplitter` which treats the complete text as one sentence.
-    """
-
-    def __init__(self, tokenizer: Tokenizer = SegtokTokenizer()):
-        super(NoSentenceSplitter, self).__init__()
-        self._tokenizer = tokenizer
-
-    def split(self, text: str) -> List[Sentence]:
-        return [Sentence(text=text, use_tokenizer=self._tokenizer, start_position=0)]
-
-    @property
-    def tokenizer(self) -> Tokenizer:
-        return self._tokenizer
-
-    @tokenizer.setter
-    def tokenizer(self, value: Tokenizer):
-        self._tokenizer = value
-
-    @property
-    def name(self) -> str:
-        return self.__class__.__name__ + "_" + self._tokenizer.name

--- a/tests/test_datasets_biomedical.py
+++ b/tests/test_datasets_biomedical.py
@@ -19,7 +19,8 @@ from flair.datasets.biomedical import (
     InternalBioNerDataset,
     filter_nested_entities,
 )
-from flair.tokenization import NoSentenceSplitter, SentenceSplitter, SpaceTokenizer
+from flair.splitter import NoSentenceSplitter, SentenceSplitter
+from flair.tokenization import SpaceTokenizer
 
 
 def has_balanced_parantheses(text: str) -> bool:

--- a/tests/test_tokenize_sentence.py
+++ b/tests/test_tokenize_sentence.py
@@ -4,18 +4,20 @@ import pytest
 
 import flair
 from flair.data import Sentence, Token
-from flair.tokenization import (
-    JapaneseTokenizer,
+from flair.splitter import (
     NewlineSentenceSplitter,
     NoSentenceSplitter,
     SciSpacySentenceSplitter,
-    SciSpacyTokenizer,
     SegtokSentenceSplitter,
+    SpacySentenceSplitter,
+    TagSentenceSplitter,
+)
+from flair.tokenization import (
+    JapaneseTokenizer,
+    SciSpacyTokenizer,
     SegtokTokenizer,
     SpaceTokenizer,
-    SpacySentenceSplitter,
     SpacyTokenizer,
-    TagSentenceSplitter,
     TokenizerWrapper,
 )
 


### PR DESCRIPTION
When initializing a `Sentence` object, with `use_tokenizer=True` (set by default), it triggered an import of the `SegtokTokenizer` in the Sentence constructor. According to [this thread](https://stackoverflow.com/questions/29504313/python-what-is-the-cost-of-re-importing-modules), there is a cost of re-importing modules and since we often create large numbers of `Sentence` objects, this is unnecessary overhead. 

This PR makes the import global. To do this, it splits up the `flair.tokenization` module into tokenization (for all tokenizers) and splitter (for all sentence splitters). This way, there is no longer an import of `flair.data` in `flair.tokenization`.