### PR TITLE
fix comment parsing for conllu datasets

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -693,7 +693,7 @@ class ColumnDataset(FlairDataset):
             # to set the metadata "domain" to "de-orcas"
             for comment_row in comment.split("\t"):
                 if "=" in comment_row:
-                    key, value = comment_row.split("=", 2)
+                    key, value = comment_row.split("=", 1)
                     sentence.add_metadata(key, value)
 
         if len(sentence) > 0:

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -661,7 +661,7 @@ class FlairEmbeddings(TokenEmbeddings):
             "am-forward": f"{am_path}/best-lm.pt",
             # Ukrainian
             "uk-forward": "https://huggingface.co/dchaplinsky/flair-uk-forward/resolve/main/best-lm.pt",
-            "uk-backward": "https://huggingface.co/dchaplinsky/flair-uk-backward/resolve/main/best-lm.pt"
+            "uk-backward": "https://huggingface.co/dchaplinsky/flair-uk-backward/resolve/main/best-lm.pt",
         }
 
         if isinstance(model, str):

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -664,7 +664,7 @@ class FlairEmbeddings(TokenEmbeddings):
             "uk-backward": "https://huggingface.co/dchaplinsky/flair-uk-backward/resolve/main/best-lm.pt"
         }
 
-        if type(model) == str:
+        if isinstance(model, str):
 
             # load model if in pretrained model map
             if model.lower() in self.PRETRAINED_MODEL_ARCHIVE_MAP:

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -665,7 +665,6 @@ class FlairEmbeddings(TokenEmbeddings):
         }
 
         if isinstance(model, str):
-
             # load model if in pretrained model map
             if model.lower() in self.PRETRAINED_MODEL_ARCHIVE_MAP:
                 base_path = self.PRETRAINED_MODEL_ARCHIVE_MAP[model.lower()]

--- a/tests/models/test_entity_linker.py
+++ b/tests/models/test_entity_linker.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flair.data import Sentence
-from flair.datasets import NEL_ENGLISH_AQUAINT
+from flair.datasets import NEL_ENGLISH_AIDA
 from flair.embeddings import TransformerWordEmbeddings
 from flair.models import EntityLinker
 from tests.model_test_utils import BaseModelTest
@@ -18,7 +18,7 @@ class TestEntityLinker(BaseModelTest):
 
     @pytest.fixture
     def corpus(self, tasks_base_path):
-        yield NEL_ENGLISH_AQUAINT().downsample(0.05)
+        yield NEL_ENGLISH_AIDA().downsample(0.05)
 
     @pytest.fixture
     def train_test_sentence(self):


### PR DESCRIPTION
regarding https://github.com/flairNLP/flair/issues/3018

`str.split(text, s)` creates a lsit with up to s+1 entries,
hence to have 2 entries, s needs to be 1.


Besides that, I suppose that the entry doesn't contain valid metadata if it starts with "#"
