### PR TITLE
Load Ukrainian embeddings and taggers

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -659,6 +659,9 @@ class FlairEmbeddings(TokenEmbeddings):
             "fr-impresso-hipe-v1-backward": f"{clef_hipe_path}/fr-hipe-flair-v1-backward/best-lm.pt",
             # Amharic
             "am-forward": f"{am_path}/best-lm.pt",
+            # Ukrainian
+            "uk-forward": "https://huggingface.co/dchaplinsky/flair-uk-forward/resolve/main/best-lm.pt",
+            "uk-backward": "https://huggingface.co/dchaplinsky/flair-uk-backward/resolve/main/best-lm.pt"
         }
 
         if type(model) == str:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -685,6 +685,9 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             "de-ner-legal": "flair/ner-german-legal",
             "fr-ner": "flair/ner-french",
             "nl-ner": "flair/ner-dutch",
+            "ner-ukrainian": "dchaplinsky/flair-uk-ner",
+            # Language-specific POS models
+            "pos-ukrainian": "dchaplinsky/flair-uk-pos",
         }
 
         hu_path: str = "https://nlp.informatik.hu-berlin.de/resources/models"

--- a/resources/docs/TUTORIAL_2_TAGGING.md
+++ b/resources/docs/TUTORIAL_2_TAGGING.md
@@ -243,6 +243,8 @@ You can pass text in any of these languages to the model. In particular, the NER
 | 'ml-pos' | POS-tagging | Malayalam | 30000 Malayalam sentences  | **83** | [sabiqueqb](https://github.com/sabiqueqb) |
 | 'ml-upos' | POS-tagging | Malayalam | 30000 Malayalam sentences | **87** | [sabiqueqb](https://github.com/sabiqueqb) |
 | 'pt-pos-clinical' | POS-tagging | Portuguese | [PUCPR](https://github.com/HAILab-PUCPR/portuguese-clinical-pos-tagger) | **92.39** | [LucasFerroHAILab](https://github.com/LucasFerroHAILab) for clinical texts |
+| '[ner-ukrainian](https://huggingface.co/dchaplinsky/flair-uk-ner)' | NER (4-class) | Ukrainian |  [NER-UK dataset](https://github.com/lang-uk/ner-uk)  | **86.05** (F1)  | [dchaplinsky](https://github.com/dchaplinsky) |
+| '[pos-ukrainian](https://huggingface.co/dchaplinsky/flair-uk-pos)' | POS-tagging | Ukrainian |  [Ukrainian UD](https://universaldependencies.org/treebanks/uk_iu/index.html)  | **97.93** (F1)  | [dchaplinsky](https://github.com/dchaplinsky) |
 
 
 ### Tagging a German sentence

--- a/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
+++ b/resources/docs/embeddings/FLAIR_EMBEDDINGS.md
@@ -71,6 +71,7 @@ Currently, the following contextual string embeddings are provided (note: replac
 | 'en-impresso-hipe-v1-X' | English (historical) | In-domain data (Chronicling America material) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020). More information on the shared task can be found in [this paper](https://zenodo.org/record/3752679#.XqgzxXUzZzU) |
 | 'fr-impresso-hipe-v1-X' | French (historical)  | In-domain data (Swiss and Luxembourgish newspapers) for [CLEF HIPE Shared task](https://impresso.github.io/CLEF-HIPE-2020). More information on the shared task can be found in [this paper](https://zenodo.org/record/3752679#.XqgzxXUzZzU) |
 | 'am-X' | Amharic  | Based on 6.5m Amharic text corpus crawled from different sources. See [this paper](https://www.mdpi.com/1999-5903/13/11/275) and the official [GitHub Repository](https://github.com/uhh-lt/amharicmodels) for more information. |
+| 'uk-X' | Ukrainian | Added by [@dchaplinsky](https://github.com/dchaplinsky): Trained with [UberText](https://lang.org.ua/en/corpora/) corpus. |
 
 So, if you want to load embeddings from the German forward LM model, instantiate the method as follows:
 


### PR DESCRIPTION
Added links for Ukrainian forward and backward Flair embeddings:
```python3
# Load Ukrainian Flair embeddings
from flair.embeddings import FlairEmbeddings

flair_uk_forward = FlairEmbeddings('uk-forward')
flair_uk_backward = FlairEmbeddings('uk-backward')
```

and two taggers: NER and POS

```python3
# Load Ukrainian NER and POS taggers
from flair.models import SequenceTagger

ner_tagger = SequenceTagger.load('ner-ukrainian')
pos_tagger = SequenceTagger.load('pos-ukrainian')

# Tag a sentence
from flair.data import Sentence
sentence = Sentence("Сьогодні в Знам’янці проживають нащадки поета — родина Шкоди.")

ner_tagger.predict(sentence)
pos_tagger.predict(sentence)

print(sentence)
# ”Сьогодні в Знам’янці проживають нащадки поета — родина Шкоди." → 
# [“Сьогодні"/ADV, "в"/ADP, "Знам’янці"/LOC, "Знам’янці"/PROPN, "проживають”/VERB, "нащадки"/NOUN, "поета"/NOUN, "—"/PUNCT, "родина"/NOUN, "Шкоди”/PERS, "Шкоди"/PROPN, "."/PUNCT]
```
