### PR TITLE
Fix text pair classifier

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1133,6 +1133,9 @@ class DataPair(DataPoint, typing.Generic[DT, DT2]):
     def text(self):
         return self.first.text + " || " + self.second.text
 
+    def to_original_text(self):
+        return self.text
+
 
 TextPair = DataPair[Sentence, Sentence]
 


### PR DESCRIPTION
The forward method in TextPairClassifier was recently removed and this produced an error. I fixed it by overriding `_encode_data_points()` from DefaultClassifier. Two sentences have to be embedded together by adding a separator token in between and this needs different handling than in DefaultClassifier. The model now works the same as in previous version.


Here’s how to fine-tune a transformer for Textual Entailment task:

```python3
from flair.datasets import GLUE_RTE
from flair.embeddings import TransformerDocumentEmbeddings
from flair.models import TextPairClassifier
from flair.trainers import ModelTrainer

# Step 1: Load RTE (Recognizing Textual Entailment) corpus
corpus = GLUE_RTE()

label_type = 'entailment'

label_dictionary = corpus.make_label_dictionary(label_type=label_type)

# Step 2: Pick a transformer model
embeddings = TransformerDocumentEmbeddings('google/electra-small-discriminator', fine_tune=True)

# Step 3: Use text pair classification model
classifier = TextPairClassifier(embeddings=embeddings,
                                label_type=label_type,
                                label_dictionary=label_dictionary,
                                embed_separately=False,
                                )

# Step 4: Initialize trainer and fine-tune transformer embeddings
trainer = ModelTrainer(classifier, corpus)

trainer.fine_tune(base_path='resources/sentence-pair-test',
                  learning_rate=2e-5,
                  mini_batch_size=16,
                  max_epochs=10,
                  )
```
