### PR TITLE
HunFlair: Fix links to datasets that are no longer available

### DIFF
--- a/flair/datasets/biomedical.py
+++ b/flair/datasets/biomedical.py
@@ -1273,7 +1273,7 @@ class KaewphanCorpusHelper:
 
     @staticmethod
     def download_cll_dataset(data_folder: Path):
-        data_url = "http://bionlp-www.utu.fi/cell-lines/CLL_corpus.tar.gz"
+        data_url = "https://github.com/hu-ner/hunflair-corpora/raw/main/cll/CLL_corpus.tar.gz"
         data_path = cached_path(data_url, data_folder)
         unpack_file(data_path, data_folder)
 
@@ -1320,7 +1320,7 @@ class KaewphanCorpusHelper:
 
     @staticmethod
     def download_gellus_dataset(data_folder: Path):
-        data_url = "http://bionlp-www.utu.fi/cell-lines/Gellus_corpus.tar.gz"
+        data_url = "https://github.com/hu-ner/hunflair-corpora/raw/main/gellus/Gellus_corpus.tar.gz"
         data_path = cached_path(data_url, data_folder)
         unpack_file(data_path, data_folder)
 
@@ -2116,7 +2116,7 @@ class VARIOME(ColumnCorpus):
 
     @staticmethod
     def download_dataset(data_dir: Path):
-        data_url = "http://corpora.informatik.hu-berlin.de/corpora/brat2bioc/hvp_bioc.xml.zip"
+        data_url = "https://github.com/hu-ner/hunflair-corpora/raw/main/variome/hvp_bioc.xml.zip"
         data_path = cached_path(data_url, data_dir)
         unpack_file(data_path, data_dir)
 


### PR DESCRIPTION
This PR fixes links to datasets that are no longer available at their original location. Instead the links now target the newly created hunflair-corpora repository.