### PR TITLE
Release optimizer memory and fix legacy tokenization

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -221,6 +221,8 @@ def _reconstruct_word_ids_from_subtokens(embedding, tokens: List[str], subtokens
         special_tokens.append(embedding.tokenizer.bos_token)
     if embedding.tokenizer._cls_token:
         special_tokens.append(embedding.tokenizer.cls_token)
+    if embedding.tokenizer._sep_token:
+        special_tokens.append(embedding.tokenizer.sep_token)
 
     # iterate over subtokens and reconstruct tokens
     for subtoken_id, subtoken in enumerate(subtokens):
@@ -243,7 +245,6 @@ def _reconstruct_word_ids_from_subtokens(embedding, tokens: List[str], subtokens
         subtoken_count += 1
 
         reconstructed_token = reconstructed_token + subtoken
-        print(reconstructed_token)
 
         if reconstructed_token.lower() == token_text:
             # we cannot handle unk_tokens perfectly, so let's assume that one unk_token corresponds to one token.

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -844,6 +844,8 @@ class ModelTrainer:
         finally:
             if use_tensorboard:
                 writer.close()
+        optimizer.zero_grad(set_to_none=True)
+        del optimizer
 
         # test best model if test data is present
         if self.corpus.test and not train_with_test:


### PR DESCRIPTION
This PR does 2 little things:

* it makes it easier to clean up the gpu memory, by cleaning gradients and deleting the reference of the optimzier. Hence `torch.cuda.empty_cache()` will be able to clean up more parameters. 
* some (slow) tokenizers like RobertaTokenizer seem to add a [SEP] token at the end, breaking the legacy subword token mapping, which is fixed by allowing that specific token