### PR TITLE
Removed a name that is undefined

### DIFF
--- a/flair/embeddings/__init__.py
+++ b/flair/embeddings/__init__.py
@@ -90,7 +90,6 @@ __all__ = [
     "OpenAIGPT2Embeddings",
     "OpenAIGPTEmbeddings",
     "RoBERTaEmbeddings",
-    "TransformerXLEmbeddings",
     "XLMEmbeddings",
     "XLMRobertaEmbeddings",
     "XLNetEmbeddings",


### PR DESCRIPTION
In file: __init__.py, the list named __all__ contains an undefined name which can result in errors when this module is imported. We removed the undefined name from the list. 

This is following the best practices of importing fields from a package (https://docs.python.org/3/tutorial/modules.html#importing-from-a-package).