### PR TITLE
Removed a name that is undefined

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -424,7 +424,6 @@ __all__ = [
     "WSD_TRAINOMATIC",
     "WSD_UFSAC",
     "WSD_WORDNET_GLOSS_TAGGED",
-    "EntityLinkingCorpus",
     "RE_ENGLISH_CONLL04",
     "RE_ENGLISH_DRUGPROT",
     "RE_ENGLISH_SEMEVAL2010",


### PR DESCRIPTION
In file: init.py, the list named __all__ contains an undefined name which can result in errors when this module is imported. We removed the undefined name from the list.

This is similar to a previous PR (https://github.com/flairNLP/flair/pull/3054).
