### PR TITLE
Call `super().__setstate__()` in Embeddings

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -426,7 +426,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
             self.eval()
 
         else:
-            self.__dict__ = d
+            super().__setstate__(d)
 
 
 class DocumentLMEmbeddings(DocumentEmbeddings):

--- a/flair/embeddings/legacy.py
+++ b/flair/embeddings/legacy.py
@@ -691,7 +691,7 @@ class CamembertEmbeddings(TokenEmbeddings):
         return state
 
     def __setstate__(self, d):
-        self.__dict__ = d
+        super().__setstate__(d)
 
         # 1-camembert-base -> camembert-base
         if any(char.isdigit() for char in self.name):
@@ -763,7 +763,7 @@ class XLMRobertaEmbeddings(TokenEmbeddings):
         return state
 
     def __setstate__(self, d):
-        self.__dict__ = d
+        super().__setstate__(d)
 
         # 1-xlm-roberta-large -> xlm-roberta-large
         self.tokenizer = self.tokenizer = XLMRobertaTokenizer.from_pretrained("-".join(self.name.split("-")[1:]))

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -904,7 +904,7 @@ class PooledFlairEmbeddings(TokenEmbeddings):
         return [self.name, self.context_embeddings.name]
 
     def __setstate__(self, d):
-        self.__dict__ = d
+        super().__setstate__(d)
 
         if flair.device != "cpu":
             for key in self.word_embeddings:
@@ -1448,7 +1448,7 @@ class ELMoEmbeddings(TokenEmbeddings):
         return self.name
 
     def __setstate__(self, state):
-        self.__dict__ = state
+        super().__setstate__(state)
 
         if re.fullmatch(r"cuda:[0-9]+", str(flair.device)):
             cuda_device = int(str(flair.device).split(":")[-1])


### PR DESCRIPTION
When loading a model that was trained with an older torch version, it is possible that an `AttributeError` occurs. This can happen if new attributes were added to `torch.nn.Module`.

For backwards compatibility, they implemented their `__setstate__` to add these attributes if they are not present (https://github.com/pytorch/pytorch/blob/ae4ec7de1e6f60aa7dcf4d5187c720f2f40543c3/torch/nn/modules/module.py#L1564).

In oder to be independent from these changes and increase backwards compatibility, it would be good, if the super-method would be called when unpickling Embeddings instead of setting `__dict__`.