### PR TITLE
Improved Tars Context

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -713,6 +713,7 @@ class Sentence(DataPoint):
 
         # internal variables to denote position inside dataset
         self._previous_sentence: Optional[Sentence] = None
+        self._has_context: bool = False
         self._next_sentence: Optional[Sentence] = None
         self._position_in_dataset: Optional[typing.Tuple[Dataset, int]] = None
 
@@ -1064,7 +1065,25 @@ class Sentence(DataPoint):
         Return True or False depending on whether context is set (for instance in dataloader or elsewhere)
         :return: True if context is set, else False
         """
-        return self._previous_sentence is not None or self._position_in_dataset is not None
+        return self._has_context or self._previous_sentence is not None or self._position_in_dataset is not None
+
+    def copy_context_from_sentence(self, sentence: "Sentence") -> None:
+        self._previous_sentence = sentence._previous_sentence
+        self._next_sentence = sentence._next_sentence
+        self._position_in_dataset = sentence._position_in_dataset
+
+    @classmethod
+    def set_context_for_sentences(cls, sentences: List["Sentence"]) -> None:
+        previous_sentence = None
+        for sentence in sentences:
+            if sentence.is_context_set():
+                continue
+            sentence._previous_sentence = previous_sentence
+            sentence._next_sentence = None
+            sentence._has_context = True
+            if previous_sentence is not None:
+                previous_sentence._next_sentence = sentence
+            previous_sentence = sentence
 
     def get_labels(self, label_type: str = None):
 

--- a/flair/data.py
+++ b/flair/data.py
@@ -1065,7 +1065,12 @@ class Sentence(DataPoint):
         Return True or False depending on whether context is set (for instance in dataloader or elsewhere)
         :return: True if context is set, else False
         """
-        return self._has_context or self._previous_sentence is not None or self._position_in_dataset is not None
+        return (
+            self._has_context
+            or self._previous_sentence is not None
+            or self._next_sentence is not None
+            or self._position_in_dataset is not None
+        )
 
     def copy_context_from_sentence(self, sentence: "Sentence") -> None:
         self._previous_sentence = sentence._previous_sentence

--- a/flair/datasets/ocr.py
+++ b/flair/datasets/ocr.py
@@ -117,6 +117,7 @@ class OcrJsonDataset(FlairDataset):
             sentence = self._load_example(self.file_names[index])
 
             # set sentence context using partials TODO: pointer to dataset is really inefficient
+            sentence._has_context = True
             sentence._position_in_dataset = (self, index)
 
         return sentence

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -789,6 +789,7 @@ class ColumnDataset(FlairDataset):
             )
 
             # set sentence context using partials TODO: pointer to dataset is really inefficient
+            sentence._has_context = True
             sentence._position_in_dataset = (self, index)
 
         return sentence

--- a/flair/models/lemmatizer_model.py
+++ b/flair/models/lemmatizer_model.py
@@ -425,6 +425,8 @@ class Lemmatizer(flair.nn.Classifier[Sentence]):
         if isinstance(sentences, Sentence):
             sentences = [sentences]
 
+        Sentence.set_context_for_sentences(sentences)
+
         # filter empty sentences
         sentences = [sentence for sentence in sentences if len(sentence) > 0]
         if len(sentences) == 0:

--- a/flair/models/relation_classifier_model.py
+++ b/flair/models/relation_classifier_model.py
@@ -452,7 +452,7 @@ class RelationClassifier(flair.nn.DefaultClassifier[EncodedSentence, EncodedSent
             # Using the sentence label instead of annotating a separate `Relation` object is easier to manage since,
             # during prediction, the forward pass does not need any knowledge about the entities in the sentence.
             encoded_sentence.add_label(typename=self.label_type, value=gold_label, score=1.0)
-
+        encoded_sentence.copy_context_from_sentence(original_sentence)
         return encoded_sentence
 
     def _encode_sentence_for_inference(
@@ -639,7 +639,7 @@ class RelationClassifier(flair.nn.DefaultClassifier[EncodedSentence, EncodedSent
 
         elif all(not isinstance(sentence, EncodedSentence) for sentence in sentences):
             # Deal with the case where all sentences are standard (non-encoded) sentences
-
+            Sentence.set_context_for_sentences(cast(List[Sentence], sentences))
             sentences_with_relation_reference: List[Tuple[EncodedSentence, Relation]] = list(
                 itertools.chain.from_iterable(self._encode_sentence_for_inference(sentence) for sentence in sentences)
             )

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, cast
 from urllib.error import HTTPError
 
 import torch
@@ -441,7 +441,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         Predicts labels for current batch with CRF or Softmax.
         :param sentences: List of sentences in batch
         :param mini_batch_size: batch size for test data
-        :param return_probabilities_for_all_classes: Whether to return probabilites for all classes
+        :param return_probabilities_for_all_classes: Whether to return probabilities for all classes
         :param verbose: whether to use progress bar
         :param label_name: which label to predict
         :param return_loss: whether to return loss value
@@ -454,9 +454,11 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             if not sentences:
                 return sentences
 
-            # make sure its a list
+            # make sure it's a list
             if not isinstance(sentences, list) and not isinstance(sentences, flair.data.Dataset):
                 sentences = [sentences]
+
+            Sentence.set_context_for_sentences(cast(List[Sentence], sentences))
 
             # filter empty sentences
             sentences = [sentence for sentence in sentences if len(sentence) > 0]

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -207,7 +207,7 @@ class FewshotClassifier(flair.nn.Classifier[Sentence]):
             for tag in label_dictionary:
                 if tag == "<unk>" or tag == "O":
                     continue
-                if tag[1] == "-":
+                if len(tag) > 1 and tag[1] == "-":
                     tag = tag[2:]
                     tag_dictionary.add_item(tag)
                 else:
@@ -406,7 +406,7 @@ class TARSTagger(FewshotClassifier):
                     [tars_sentence.get_token(token.idx + label_length) for token in entity_label.data_point]
                 )
                 new_span.add_label(self.static_label_type, value="entity")
-
+        tars_sentence.copy_context_from_sentence(sentence)
         return tars_sentence
 
     def _get_state_dict(self):
@@ -491,6 +491,8 @@ class TARSTagger(FewshotClassifier):
 
         if not isinstance(sentences, list):
             sentences = [sentences]
+
+        Sentence.set_context_for_sentences(sentences)
 
         reordered_sentences = sorted(sentences, key=lambda s: len(s), reverse=True)
 
@@ -719,7 +721,7 @@ class TARSClassifier(FewshotClassifier):
         tars_label = self.LABEL_MATCH if label in sentence_labels else self.LABEL_NO_MATCH
 
         tars_sentence = Sentence(label_text_pair, use_tokenizer=False).add_label(self.static_label_type, tars_label)
-
+        tars_sentence.copy_context_from_sentence(sentence)
         return tars_sentence
 
     def _get_state_dict(self):
@@ -829,16 +831,7 @@ class TARSClassifier(FewshotClassifier):
         if isinstance(sentences, Sentence):
             sentences = [sentences]
 
-        # set context if not set already
-        previous_sentence = None
-        for sentence in sentences:
-            if sentence.is_context_set():
-                continue
-            sentence._previous_sentence = previous_sentence
-            sentence._next_sentence = None
-            if previous_sentence:
-                previous_sentence._next_sentence = sentence
-            previous_sentence = sentence
+        Sentence.set_context_for_sentences(sentences)
 
         reordered_sentences = sorted(sentences, key=lambda s: len(s), reverse=True)
 

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -89,6 +89,8 @@ class TextRegressor(flair.nn.Model[Sentence]):
 
             if not sentences:
                 return sentences
+
+            Sentence.set_context_for_sentences(sentences)
             filtered_sentences = self._filter_empty_sentences(sentences)
             reordered_sentences = sorted(filtered_sentences, key=lambda s: len(s), reverse=True)
 

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -731,6 +731,9 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2]):
             if not isinstance(sentences, list):
                 sentences = [sentences]
 
+            if isinstance(sentences[0], Sentence):
+                Sentence.set_context_for_sentences(typing.cast(List[Sentence], sentences))
+
             reordered_sentences = self._sort_data(sentences)
 
             if len(reordered_sentences) == 0:

--- a/tests/model_test_utils.py
+++ b/tests/model_test_utils.py
@@ -124,7 +124,7 @@ class BaseModelTest:
 
     @pytest.mark.integration
     def test_train_load_use_model_multi_corpus(
-            self, results_base_path, multi_corpus, embeddings, example_sentence, train_test_sentence
+        self, results_base_path, multi_corpus, embeddings, example_sentence, train_test_sentence
     ):
         flair.set_seed(123)
         label_dict = multi_corpus.make_label_dictionary(label_type=self.train_label_type)
@@ -158,7 +158,7 @@ class BaseModelTest:
 
     @pytest.mark.integration
     def test_train_resume_classifier(
-            self, results_base_path, corpus, embeddings, example_sentence, train_test_sentence
+        self, results_base_path, corpus, embeddings, example_sentence, train_test_sentence
     ):
         flair.set_seed(123)
         label_dict = corpus.make_label_dictionary(label_type=self.train_label_type)
@@ -201,7 +201,7 @@ class BaseModelTest:
         del loaded_pretrained_model
 
     def test_train_load_use_model_multi_label(
-            self, results_base_path, multi_class_corpus, embeddings, example_sentence, multiclass_train_test_sentence
+        self, results_base_path, multi_class_corpus, embeddings, example_sentence, multiclass_train_test_sentence
     ):
         flair.set_seed(123)
         label_dict = multi_class_corpus.make_label_dictionary(label_type=self.train_label_type)


### PR DESCRIPTION

This PR is fixing https://github.com/flairNLP/flair/issues/3024 and adds the following changes while doing so:

* tars models (classifcation & ner) won't fail on labels with only 1 character.
* models that predict on modified sentences (`TARSClassifier`, `TARSTagger` and `RelationClassifier`) now also make use of the context and therefore can be trained and tested in a flert manner.
* Empty sentences will not be discarded in the context chain, however they won't change the context as they are empty.
* it is possible to disable context, by setting `sentence._has_context = True` without setting `sentence._next_sentence` or `sentence._previous_sentence`. That way, batch prediction on context independent sentences will work.
* context is considered to be set if only "_next_sentence" is set. So every first sentence won't be reset again