### PR TITLE
Explicit context boundaries in Transformer embeddings

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -515,7 +515,7 @@ class Token(_PartOfSentence):
         if isinstance(self._internal_index, int):
             return self._internal_index
         else:
-            raise ValueError
+            return -1
 
     @property
     def text(self) -> str:

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -37,6 +37,8 @@ from flair.embeddings.base import (
     register_embeddings,
 )
 
+SENTENCE_BOUNDARY_TAG: str = "[SATZ]"
+
 
 @torch.jit.script_if_tracing
 def pad_sequence_embeddings(all_hidden_states: List[torch.Tensor]) -> torch.Tensor:
@@ -628,8 +630,8 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
             right_context = sentence.right_context(self.context_length, self.respect_document_boundaries)
 
             if self.use_context_separator:
-                left_context = left_context + [Token("[KONTEXT]")]
-                right_context = [Token("[KONTEXT]")] + right_context
+                left_context = left_context + [Token(SENTENCE_BOUNDARY_TAG)]
+                right_context = [Token(SENTENCE_BOUNDARY_TAG)] + right_context
 
         expanded_sentence = left_context + sentence.tokens + right_context
 
@@ -1050,7 +1052,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         # If we use a context separator, add a new special token
         self.use_context_separator = use_context_separator
         if use_context_separator:
-            self.tokenizer.add_special_tokens({"additional_special_tokens": ["[KONTEXT]"]})
+            self.tokenizer.add_special_tokens({"additional_special_tokens": [SENTENCE_BOUNDARY_TAG]})
             transformer_model.resize_token_embeddings(len(self.tokenizer))
 
         super().__init__(**self.to_args())

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -295,6 +295,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         force_max_length: bool = False,
         feature_extractor: Optional[FeatureExtractionMixin] = None,
         needs_manual_ocr: Optional[bool] = None,
+        use_context_separator: bool = True,
     ):
         self.name = name
         super().__init__()
@@ -313,6 +314,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         self.fine_tune = fine_tune
         self.force_max_length = force_max_length
         self.feature_extractor = feature_extractor
+        self.use_context_separator = use_context_separator
 
         tokenizer_params = list(inspect.signature(self.tokenizer.__call__).parameters.keys())
         self.tokenizer_needs_ocr_boxes = "boxes" in tokenizer_params
@@ -345,6 +347,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
             "use_lang_emb": self.use_lang_emb,
             "force_max_length": self.force_max_length,
             "feature_extractor": self.feature_extractor,
+            "use_context_separator": self.use_context_separator,
         }
         if hasattr(self, "needs_manual_ocr"):
             args["needs_manual_ocr"] = self.needs_manual_ocr
@@ -612,7 +615,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
             lengths.append(len(sentence))
         return sentence_tokens, offsets, lengths
 
-    def __expand_sentence_with_context(self, sentence) -> Tuple[List[Token], int]:
+    def _expand_sentence_with_context(self, sentence) -> Tuple[List[Token], int]:
         expand_context = self.context_length > 0 and (
             not self.training or random.randint(1, 100) > (self.context_dropout * 100)
         )
@@ -623,6 +626,10 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         if expand_context:
             left_context = sentence.left_context(self.context_length, self.respect_document_boundaries)
             right_context = sentence.right_context(self.context_length, self.respect_document_boundaries)
+
+            if self.use_context_separator:
+                left_context = left_context + [Token(self.tokenizer.sep_token)]
+                right_context = [Token(self.tokenizer.sep_token)] + right_context
 
         expanded_sentence = left_context + sentence.tokens + right_context
 
@@ -926,6 +933,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         name: Optional[str] = None,
         force_max_length: bool = False,
         needs_manual_ocr: Optional[bool] = None,
+        use_context_separator: bool = True,
         **kwargs,
     ):
         self.instance_parameters = self.get_instance_parameters(locals=locals())
@@ -1038,6 +1046,8 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         self.embedding_length_internal = self._calculate_embedding_length(transformer_model)
         if needs_manual_ocr is not None:
             self.needs_manual_ocr = needs_manual_ocr
+        if use_context_separator is not None:
+            self.use_context_separator = use_context_separator
 
         super().__init__(**self.to_args())
 

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -628,8 +628,8 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
             right_context = sentence.right_context(self.context_length, self.respect_document_boundaries)
 
             if self.use_context_separator:
-                left_context = left_context + [Token(self.use_context_separator)]
-                right_context = [Token(self.use_context_separator)] + right_context
+                left_context = left_context + [Token("[KONTEXT]")]
+                right_context = [Token("[KONTEXT]")] + right_context
 
         expanded_sentence = left_context + sentence.tokens + right_context
 

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -609,7 +609,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         sentence_tokens = []
         for sentence in sentences:
             # flair specific pre-tokenization
-            tokens, offset = self.__expand_sentence_with_context(sentence)
+            tokens, offset = self._expand_sentence_with_context(sentence)
             sentence_tokens.append(tokens)
             offsets.append(offset)
             lengths.append(len(sentence))

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -1047,15 +1047,11 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         if needs_manual_ocr is not None:
             self.needs_manual_ocr = needs_manual_ocr
 
-        # add special context
-        self.use_context_separator = False
-        if use_context_separator is not None:
-            if use_context_separator is True:
-                self.use_context_separator = self.tokenizer.sep_token
-            if type(use_context_separator) == str:
-                self.use_context_separator = use_context_separator
-                self.tokenizer.add_special_tokens({"additional_special_tokens": [use_context_separator]})
-                transformer_model.resize_token_embeddings(len(self.tokenizer))
+        # If we use a context separator, add a new special token
+        self.use_context_separator = use_context_separator
+        if use_context_separator:
+            self.tokenizer.add_special_tokens({"additional_special_tokens": ["[KONTEXT]"]})
+            transformer_model.resize_token_embeddings(len(self.tokenizer))
 
         super().__init__(**self.to_args())
 
@@ -1121,6 +1117,10 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         if "layer_indexes" in state:
             layer_indexes = state.pop("layer_indexes")
             state["layers"] = ",".join(map(str, layer_indexes))
+
+        if "use_context_separator" not in state:
+            # legacy Flair <= 0.12
+            state["use_context_separator"] = False
 
         if "use_scalar_mix" in state:
             # legacy Flair <= 0.7


### PR DESCRIPTION
This PR adds the option of setting a "context separator" to Transformer embeddings.  If set, a new special token is added to the transformer tokenizer dictionary. This token is at the beginning and end of a Sentence to separate it from context. 

To use the example from #3063: 

Assume the current sentence is `Peter Blackburn` and the previous sentence ends with `to boycott British lamb .`, while the next sentence starts with `BRUSSELS 1996-08-22 The European Commission`. 

In this case,
1. if `use_context_separator=False`, the embedding is produced from this string: `to boycott British lamb . Peter Blackburn BRUSSELS 1996-08-22 The European Commission` 
2. if `use_context_separator=True`, the embedding is produced from this string `to boycott British lamb . [KONTEXT] Peter Blackburn [KONTEXT] BRUSSELS 1996-08-22 The European Commission`

Option 1 is how it was before. Option 2 is the new standard and explicitly marks up the boundaries of the current sentence using the [KONTEXT] token. 

To evaluate, we trained FLERT models on CoNLL-03 for two transformers and different context markers. Each setup is trained for 7 different seeds: reported test F1 is averaged over all 7 runs, with standard deviation:

| Transformer   |      Context-Marker      |  CoNLL-03 Test F1 |
|----------|:-------------:|------:|
| bert-base-uncased |  _none_ | 91.52 +- 0.16  |
|   |      [SEP]    | 91.38 +- 0.18 |
|   |  [KONTEXT] |  **91.56 +- 0.17** |
| xlm-roberta-large | _none_ | 93.73 +- 0.2  |
|   |      [SEP]    | 93.76 +- 0.13 |
|   |  [KONTEXT] |  **93.92 +- 0.14** |

The context marker generally does not seem to hurt F1 score and it will potentially enable us to address the context issue described in #3063.
