### PR TITLE
gh-3097: fix multitask model training

### DIFF
--- a/flair/embeddings/base.py
+++ b/flair/embeddings/base.py
@@ -45,7 +45,7 @@ class Embeddings(torch.nn.Module, Generic[DT]):
         if not isinstance(data_points, list):
             data_points = [data_points]
 
-        if not self._everything_embedded(data_points) or not self.static_embeddings:
+        if not self._everything_embedded(data_points):
             self._add_embeddings_internal(data_points)
 
         return data_points

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -28,6 +28,7 @@ class MultitaskModel(flair.nn.Classifier):
         models: List[flair.nn.Classifier],
         task_ids: Optional[List[str]] = None,
         loss_factors: Optional[List[float]] = None,
+        use_all_tasks: bool = False,
     ):
         """
         :param models: Key (Task ID) - Value (flair.nn.Model) Pairs to stack model
@@ -38,6 +39,7 @@ class MultitaskModel(flair.nn.Classifier):
 
         self.tasks: Dict[str, flair.nn.Classifier] = {}
         self.loss_factors: Dict[str, float] = {}
+        self.use_all_tasks = use_all_tasks
 
         if not loss_factors:
             loss_factors = [1.0] * len(models)
@@ -64,7 +66,7 @@ class MultitaskModel(flair.nn.Classifier):
         :param sentences: batch of sentences
         :return: loss
         """
-        batch_split = self.split_batch_to_task_ids(sentences)
+        batch_split = self.split_batch_to_task_ids(sentences, all_tasks=self.use_all_tasks)
         loss = torch.tensor(0.0, device=flair.device)
         count = 0
         for task_id, split in batch_split.items():
@@ -82,20 +84,25 @@ class MultitaskModel(flair.nn.Classifier):
             task.predict(sentences, **predictargs)
 
     @staticmethod
-    def split_batch_to_task_ids(sentences: Union[List[Sentence], Sentence]) -> Dict:
+    def split_batch_to_task_ids(sentences: Union[List[Sentence], Sentence], all_tasks: bool = False) -> Dict:
         """
         Splits a batch of sentences to its respective model. If single sentence is assigned to several tasks
         (i.e. same corpus but different tasks), then the model assignment for this batch is randomly choosen.
         :param sentences: batch of sentences
+        :param all_tasks: use all tasks of each sentence. If deactivated, a random task will be sampled
         :return: Key-value pairs as (task_id, list of sentences ids in batch)
         """
         batch_to_task_mapping: Dict[str, List[int]] = {}
         for sentence_id, sentence in enumerate(sentences):
-            multitask_id = random.choice(sentence.get_labels("multitask_id"))
-            if multitask_id.value in batch_to_task_mapping:
-                batch_to_task_mapping[multitask_id.value].append(sentence_id)
-            elif multitask_id.value not in batch_to_task_mapping:
-                batch_to_task_mapping[multitask_id.value] = [sentence_id]
+            if all_tasks:
+                multitask_ids = sentence.get_labels("multitask_id")
+            else:
+                multitask_ids = [random.choice(sentence.get_labels("multitask_id"))]
+            for multitask_id in multitask_ids:
+                if multitask_id.value in batch_to_task_mapping:
+                    batch_to_task_mapping[multitask_id.value].append(sentence_id)
+                elif multitask_id.value not in batch_to_task_mapping:
+                    batch_to_task_mapping[multitask_id.value] = [sentence_id]
         return batch_to_task_mapping
 
     def evaluate(
@@ -110,6 +117,7 @@ class MultitaskModel(flair.nn.Classifier):
         exclude_labels: List[str] = [],
         gold_label_dictionary: Optional[Dictionary] = None,
         return_loss: bool = True,
+        evaluate_all: bool = True,
         **evalargs,
     ) -> Result:
         """
@@ -118,10 +126,35 @@ class MultitaskModel(flair.nn.Classifier):
             'cpu' (embeddings are stored on CPU) or 'gpu' (embeddings are stored on GPU)
         :param mini_batch_size: size of batches
         :param num_workers: number of workers for DataLoader class
+        :param evaluate_all: choose if all tasks should be evaluated, or a single one, depending on gold_label_type
         :return: Tuple of Result object and loss value (float)
         """
 
-        batch_split = self.split_batch_to_task_ids(data_points)
+        if not evaluate_all:
+            if gold_label_type not in self.tasks:
+                raise ValueError(
+                    "evaluating a single task on a multitask model requires 'gold_label_type' to be a valid task."
+                )
+            data = [
+                dp
+                for dp in data_points
+                if any(label.value == gold_label_type for label in dp.get_labels("multitask_id"))
+            ]
+            return self.tasks[gold_label_type].evaluate(
+                data,
+                gold_label_type=self.tasks[gold_label_type].label_type,
+                out_path=out_path,
+                embedding_storage_mode=embedding_storage_mode,
+                mini_batch_size=mini_batch_size,
+                num_workers=num_workers,
+                main_evaluation_metric=main_evaluation_metric,
+                exclude_labels=exclude_labels,
+                gold_label_dictionary=gold_label_dictionary,
+                return_loss=return_loss,
+                **evalargs,
+            )
+
+        batch_split = self.split_batch_to_task_ids(data_points, all_tasks=True)
 
         loss = torch.tensor(0.0, device=flair.device)
         main_score = 0.0
@@ -132,7 +165,7 @@ class MultitaskModel(flair.nn.Classifier):
             result = self.tasks[task_id].evaluate(
                 data_points=[data_points[i] for i in split],
                 gold_label_type=gold_label_type[task_id],
-                out_path=f"{out_path}_{task_id}.txt",
+                out_path=f"{out_path}_{task_id}.txt" if out_path is not None else None,
                 embedding_storage_mode=embedding_storage_mode,
                 mini_batch_size=mini_batch_size,
                 num_workers=mini_batch_size,
@@ -183,6 +216,7 @@ class MultitaskModel(flair.nn.Classifier):
             **initial_model_state,
             "model_states": {task: model._get_state_dict() for task, model in self.tasks.items()},
             "loss_factors": [self.loss_factors[task] for task in self.tasks.keys()],
+            "use_all_tasks": self.use_all_tasks,
         }
 
         return model_state
@@ -200,7 +234,13 @@ class MultitaskModel(flair.nn.Classifier):
             models.append(Classifier.load(task_state))
             tasks.append(task)
 
-        model = cls(models=models, task_ids=tasks, loss_factors=loss_factors, **kwargs)
+        model = cls(
+            models=models,
+            task_ids=tasks,
+            loss_factors=loss_factors,
+            use_all_tasks=state.get("use_all_tasks", False),
+            **kwargs,
+        )
         return model
 
     @property

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -164,7 +164,7 @@ class MultitaskModel(flair.nn.Classifier):
         for task_id, split in batch_split.items():
             result = self.tasks[task_id].evaluate(
                 data_points=[data_points[i] for i in split],
-                gold_label_type=gold_label_type[task_id],
+                gold_label_type=self.tasks[task_id].label_type,
                 out_path=f"{out_path}_{task_id}.txt" if out_path is not None else None,
                 embedding_storage_mode=embedding_storage_mode,
                 mini_batch_size=mini_batch_size,
@@ -190,7 +190,7 @@ class MultitaskModel(flair.nn.Classifier):
                 + task_id
                 + " - "
                 + "Label type: "
-                + self.label_type.get(task_id)
+                + self.tasks[task_id].label_type
                 + "\n\n"
                 + result.detailed_results
             )

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -518,7 +518,6 @@ class ModelTrainer:
                         # forward pass
                         loss, datapoint_count = self.model.forward_loss(batch_step)
                         average_over += datapoint_count
-
                         # Backward
                         if use_amp:
                             with amp.scale_loss(loss, optimizer) as scaled_loss:
@@ -528,8 +527,9 @@ class ModelTrainer:
                         train_loss += loss.item()
 
                         # identify dynamic embeddings (always deleted) on first sentence
-                        if not dynamic_embeddings:
-                            dynamic_embeddings = identify_dynamic_embeddings(batch[0])
+
+                        if dynamic_embeddings is None:
+                            dynamic_embeddings = identify_dynamic_embeddings(batch)
 
                         # depending on memory mode, embeddings are moved to CPU, GPU or deleted
                         store_embeddings(batch, embeddings_storage_mode, dynamic_embeddings)

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -409,4 +409,4 @@ def identify_dynamic_embeddings(data_points: List[DataPoint]):
             return dynamic_embeddings
     if not all_embeddings:
         return None
-    return dynamic_embeddings
+    return list(set(dynamic_embeddings))

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -13,7 +13,7 @@ from torch.optim import Optimizer
 from torch.utils.data import Dataset
 
 import flair
-from flair.data import DT, DataPoint, Dictionary, Sentence, _iter_dataset
+from flair.data import DT, Dictionary, Sentence, _iter_dataset
 
 log = logging.getLogger("flair")
 
@@ -390,7 +390,7 @@ def store_embeddings(
             data_point.to("cpu", pin_memory=pin_memory)
 
 
-def identify_dynamic_embeddings(data_points: List[DataPoint]):
+def identify_dynamic_embeddings(data_points: List[DT]):
     dynamic_embeddings = []
     all_embeddings = []
     for data_point in data_points:

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -376,8 +376,8 @@ def store_embeddings(
         dynamic_embeddings = None
 
     # if dynamic embedding keys not passed, identify them automatically
-    elif not dynamic_embeddings:
-        dynamic_embeddings = identify_dynamic_embeddings(data_points[0])
+    elif dynamic_embeddings is None:
+        dynamic_embeddings = identify_dynamic_embeddings(data_points)
 
     # always delete dynamic embeddings
     for data_point in data_points:
@@ -390,15 +390,23 @@ def store_embeddings(
             data_point.to("cpu", pin_memory=pin_memory)
 
 
-def identify_dynamic_embeddings(data_point: DataPoint):
+def identify_dynamic_embeddings(data_points: List[DataPoint]):
     dynamic_embeddings = []
-    if isinstance(data_point, Sentence):
-        first_token = data_point[0]
-        for name, vector in first_token._embeddings.items():
+    all_embeddings = []
+    for data_point in data_points:
+        if isinstance(data_point, Sentence):
+            first_token = data_point[0]
+            for name, vector in first_token._embeddings.items():
+                if vector.requires_grad:
+                    dynamic_embeddings.append(name)
+                all_embeddings.append(name)
+
+        for name, vector in data_point._embeddings.items():
             if vector.requires_grad:
                 dynamic_embeddings.append(name)
-
-    for name, vector in data_point._embeddings.items():
-        if vector.requires_grad:
-            dynamic_embeddings.append(name)
+            all_embeddings.append(name)
+        if dynamic_embeddings:
+            return dynamic_embeddings
+    if not all_embeddings:
+        return None
     return dynamic_embeddings


### PR DESCRIPTION
This PR fixes https://github.com/flairNLP/flair/issues/3097 by introducing an `evaluate_all` parameter. That way, users can use `multitask_model.evaluate(corpus.test, gold_label_type="Task_0", evaluate_all=False)` to evaluate the first task. If `evaluate_all` is set to true, the value of `gold_label_type` will be ignored and every task will be evaluated on their respective label type.

While doing this implementation I also noticed, that the evaluation currently evaluates sentences that have multiple tasks annotated to be evaluated for only one random task. -> now the evaluation uses all sentences for all tasks they are assigned to as it should be expected.

I also added the possibilities to compute the loss of a sentence on all assigned tasks during training. Hence Training Knowledge Graph Construction (NER + Relation Extraction + NEL) with a shared transformer embedding, would lead to only slightly increased training time compared to NER only, while leaveraging information of all 3 tasks at any time.


I found a bug where the embeddigns where not embedded right, as the `identify_dynamic_embeddings` only looks at the first sentence of the batch which could be unenbedded (e.g. for relation extraction or NEL but has no NER labels). Now the logic searches the whole batch and continues searching until it finds a batch that contains ANY embedding.
