### PR TITLE
GH-3090: fix pre-commit bug by upgrading to isort 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
               tests/resources/.*\.(tsv|txt|testa|testb|train|conllu|json)
           )$
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
closes gh-3090. see reference [here](https://github.com/home-assistant/core/issues/86892).