### PR TITLE
ZELDA candidate lists in EntityLinker

### DIFF
--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -17,13 +17,11 @@ class CandidateGenerator:
     """
 
     def __init__(self, candidates: Union[str, Dict], lower_case: bool = True):
-
         # internal candidate lists of generator
         self.mention_to_candidates_map: Dict = {}
 
         # load Zelda candidates if so passed
         if isinstance(candidates, str) and candidates.lower() == "zelda":
-
             zelda_path: str = "https://flair.informatik.hu-berlin.de/resources/datasets/zelda"
             zelda_candidates = cached_path(f"{zelda_path}/zelda_mention_entities_counter.pickle", cache_dir="datasets")
             import pickle
@@ -45,13 +43,11 @@ class CandidateGenerator:
         # if lower casing is enabled, create candidate lists of lower cased versions
         self.lower_case = lower_case
         if self.lower_case:
-
             # create a new dictionary for lower cased mentions
             lowercased_mention_to_candidates_map: Dict = {}
 
             # go through each mention and its candidates
             for mention, candidates in self.mention_to_candidates_map.items():
-
                 # check if lowercased mention already seen. If so, add candidates. Else, create new entry.
                 if mention.lower() in lowercased_mention_to_candidates_map:
                     current_candidates = lowercased_mention_to_candidates_map[mention.lower()]
@@ -200,7 +196,6 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
         return self._label_type
 
     def _mask_scores(self, scores: torch.Tensor, data_points: List[Span]):
-
         if not self.candidates:
             return scores
 

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -207,7 +207,12 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
         masked_scores = -torch.inf * torch.ones(scores.size(), requires_grad=True, device=flair.device)
 
         for idx, span in enumerate(data_points):
+            # get the candidates
             candidate_set = self.candidates.get_candidates(span.text)
+            # during training, add the gold value as candidate
+            if self.training:
+                candidate_set.add(span.get_label(self.label_type).value)
+            #candidate_set.add("<unk>")
             indices_of_candidates = [self.label_dictionary.get_idx_for_item(candidate) for candidate in candidate_set]
             masked_scores[idx, indices_of_candidates] = scores[idx, indices_of_candidates]
 

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -212,7 +212,7 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
             # during training, add the gold value as candidate
             if self.training:
                 candidate_set.add(span.get_label(self.label_type).value)
-            #candidate_set.add("<unk>")
+            candidate_set.add("<unk>")
             indices_of_candidates = [self.label_dictionary.get_idx_for_item(candidate) for candidate in candidate_set]
             masked_scores[idx, indices_of_candidates] = scores[idx, indices_of_candidates]
 

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -702,7 +702,6 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
         return data_point_tensor
 
     def _mask_scores(self, scores, data_points):
-        print("maskmask")
         return scores
 
     def forward_loss(self, sentences: List[DT]) -> Tuple[torch.Tensor, int]:

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -701,6 +701,10 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
 
         return data_point_tensor
 
+    def _mask_scores(self, scores, data_points):
+        print("maskmask")
+        return scores
+
     def forward_loss(self, sentences: List[DT]) -> Tuple[torch.Tensor, int]:
         # make a forward pass to produce embedded data points and labels
         sentences = [sentence for sentence in sentences if self._filter_data_point(sentence)]
@@ -720,6 +724,9 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
 
         # decode
         scores = self.decoder(data_point_tensor)
+
+        # an optional masking step (no masking in most cases)
+        scores = self._mask_scores(scores, data_points)
 
         # calculate the loss
         return self._calculate_loss(scores, label_tensor)
@@ -812,6 +819,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
                 # pass data points through network and decode
                 data_point_tensor = self._encode_data_points(batch, data_points)
                 scores = self.decoder(data_point_tensor)
+                scores = self._mask_scores(scores, data_points)
 
                 # if anything could possibly be predicted
                 if len(data_points) > 0:


### PR DESCRIPTION
Entity Linking has been shown to profit from candidate lists that contain for a mention a list of possible disambiguation targets. 

This PR integrates candidate lists as loss masking into the EntityLinker. It also integrates the ZELDA candidate lists for convenience. 

Example for initializing the ZELDA candidate lists and retrieving candidates for a string.
```python
generator = CandidateGenerator(candidates="zelda", lower_case=False)
print(generator.get_candidates("Pence"))
```

Example for initializing an EntityLinker with a candidate generator:
```python
linker = EntityLinker(
    embeddings,
    label_dictionary=tag_dictionary,
    pooling_operation="first",
    candidates=CandidateGenerator("zelda") 
)
```
