### PR TITLE
Enable uniform label noise generation

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -212,7 +212,7 @@ class Label:
 
     def set_value(self, value: str, score: float = 1.0):
         self._value = value
-        self.score = score
+        self._score = score
 
     @property
     def value(self) -> str:
@@ -221,10 +221,6 @@ class Label:
     @property
     def score(self) -> float:
         return self._score
-
-    @score.setter
-    def score(self, score):
-        self._score = score
 
     def to_dict(self):
         return {"value": self.value, "confidence": self.score}

--- a/flair/data.py
+++ b/flair/data.py
@@ -211,19 +211,12 @@ class Label:
         super().__init__()
 
     def set_value(self, value: str, score: float = 1.0):
-        self.value = value
+        self._value = value
         self.score = score
 
     @property
     def value(self) -> str:
         return self._value
-
-    @value.setter
-    def value(self, value):
-        if not value and value != "":
-            raise ValueError("Incorrect label value provided. Label value needs to be set.")
-        else:
-            self._value = value
 
     @property
     def score(self) -> float:
@@ -1531,7 +1524,7 @@ class Corpus(typing.Generic[T_co]):
                 # sample randomly from a label distribution according to the probabilities defined by the desired noise share
                 new_label = np.random.choice(a=labels, p=prob_dist)
                 # replace the old label with the new one
-                label.value = new_label
+                label.data_point.set_label(label_type, new_label)
                 # keep track of the old (clean) label using another label type category
                 label.data_point.add_label(label_type + "_clean", orig_label)
                 # keep track of how many labels in total are flipped
@@ -1692,30 +1685,6 @@ def iob2(tags):
         else:  # conversion IOB1 to IOB2
             tags[i].value = "B" + tag.value[1:]
     return True
-
-
-def iob_iobes(tags):
-    """
-    IOB -> IOBES
-    """
-    for i, tag in enumerate(tags):
-        if tag.value == "O" or tag.value == "":
-            tag.value = "O"
-            continue
-        t, label = tag.value.split("-", 1)
-        if len(tags) == i + 1 or tags[i + 1].value == "O":
-            next_same = False
-        else:
-            nt, next_label = tags[i + 1].value.split("-", 1)
-            next_same = nt == "I" and next_label == label
-        if t == "B":
-            if not next_same:
-                tag.value = tag.value.replace("B-", "S-")
-        elif t == "I":
-            if not next_same:
-                tag.value = tag.value.replace("I-", "E-")
-        else:
-            raise Exception("Invalid IOB format!")
 
 
 def randomly_split_into_two_datasets(dataset, length_of_first):

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -530,7 +530,7 @@ class TARSTagger(FewshotClassifier):
                         overall_count += loss_and_count[1]
 
                         for predicted in tars_sentence.get_labels(label_name):
-                            predicted.value = label
+                            predicted.set_value(label, predicted.score)
                             all_detected[predicted] = predicted.score
 
                     if most_probable_first:

--- a/tests/test_corpus_dictionary.py
+++ b/tests/test_corpus_dictionary.py
@@ -132,7 +132,7 @@ def test_label_set_confidence():
     assert 3.2 == label.score
     assert "class_1" == label.value
 
-    label.score = 0.2
+    label._score = 0.2
 
     assert 0.2 == label.score
 


### PR DESCRIPTION
This PR enables uniform label noise simulation in any dataset available in Flair via an additional method in the Corpus class.