### PR TITLE
Bump python requirement to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   - BOTO_CONFIG=/dev/null
 python:
-  - "3.6"
+  - "3.7"
 install:
   - python setup.py develop -q
 before_script: cd tests

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ types-tabulate = "*"
 types-requests = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ on the [__🤗 HuggingFace model hub__](https://huggingface.co/models?library=fl
 
 ### Requirements and Installation
 
-The project is based on PyTorch 1.5+ and Python 3.6+, because method signatures and type hints are beautiful.
-If you do not have Python 3.6, install it first. [Here is how for Ubuntu 16.04](https://vsupalov.com/developing-with-python3-6-on-ubuntu-16-04/).
-Then, in your favorite virtual environment, simply do:
+In your favorite virtual environment, simply do:
 
 ```
 pip install flair
 ```
+
+Flair requires Python 3.7+. 
 
 ### Example Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37']
+target-version = ['py37']
 exclude = '''
 (
   /(

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     license="MIT",
     install_requires=required,
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
As python 3.6 is no longer supported, we are increasing minimal python version for flair to 3.7.