### PR TITLE
Add return types to Model and Classifier

### DIFF
--- a/flair/models/__init__.py
+++ b/flair/models/__init__.py
@@ -7,7 +7,7 @@ from .pairwise_classification_model import TextPairClassifier
 from .regexp_tagger import RegexpTagger
 from .relation_classifier_model import RelationClassifier
 from .relation_extractor_model import RelationExtractor
-from .sequence_tagger_model import MultiTagger, SequenceTagger
+from .sequence_tagger_model import SequenceTagger
 from .tars_model import FewshotClassifier, TARSClassifier, TARSTagger
 from .text_classification_model import TextClassifier
 from .text_regression_model import TextRegressor
@@ -21,7 +21,6 @@ __all__ = [
     "RelationClassifier",
     "RelationExtractor",
     "RegexpTagger",
-    "MultiTagger",
     "SequenceTagger",
     "WordTagger",
     "FewshotClassifier",

--- a/flair/models/entity_linker_model.py
+++ b/flair/models/entity_linker_model.py
@@ -1,7 +1,8 @@
 import logging
 import re
 from functools import lru_cache
-from typing import Callable, Dict, List, Optional, Set, Union
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 from unicodedata import category
 
 import torch
@@ -222,3 +223,9 @@ class EntityLinker(flair.nn.DefaultClassifier[Sentence, Span]):
             masked_scores[idx, indices_of_candidates] = scores[idx, indices_of_candidates]
 
         return masked_scores
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "EntityLinker":
+        from typing import cast
+
+        return cast("EntityLinker", super().load(model_path=model_path))

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -263,3 +263,9 @@ class MultitaskModel(flair.nn.Classifier):
             model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
 
         return model_name
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "MultitaskModel":
+        from typing import cast
+
+        return cast("MultitaskModel", super().load(model_path=model_path))

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -7,6 +7,7 @@ import torch
 
 import flair.nn
 from flair.data import DT, Dictionary, Sentence
+from flair.file_utils import cached_path
 from flair.nn import Classifier
 from flair.training_utils import Result
 
@@ -246,3 +247,19 @@ class MultitaskModel(flair.nn.Classifier):
     @property
     def label_type(self):
         return self._label_type
+
+    @staticmethod
+    def _fetch_model(model_name) -> str:
+        model_map = {}
+        hu_path: str = "https://nlp.informatik.hu-berlin.de/resources/models"
+
+        # biomedical models
+        model_map["bioner"] = "/".join([hu_path, "bioner", "hunflair.pt"])
+        model_map["hunflair"] = "/".join([hu_path, "bioner", "hunflair.pt"])
+        model_map["hunflair-paper"] = "/".join([hu_path, "bioner", "hunflair-paper.pt"])
+
+        cache_dir = Path("models")
+        if model_name in model_map:
+            model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
+
+        return model_name

--- a/flair/models/relation_classifier_model.py
+++ b/flair/models/relation_classifier_model.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -705,3 +706,9 @@ class RelationClassifier(flair.nn.DefaultClassifier[EncodedSentence, EncodedSent
     @property
     def allow_unk_tag(self) -> bool:
         return self._allow_unk_tag
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "RelationClassifier":
+        from typing import cast
+
+        return cast("RelationClassifier", super().load(model_path=model_path))

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 
@@ -168,3 +168,9 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
             model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
 
         return model_name
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "RelationExtractor":
+        from typing import cast
+
+        return cast("RelationExtractor", super().load(model_path=model_path))

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -685,6 +685,8 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         }
 
         hu_path: str = "https://nlp.informatik.hu-berlin.de/resources/models"
+        hunflair_paper_path = hu_path + "/hunflair_smallish_models"
+        hunflair_main_path = hu_path + "/hunflair_allcorpus_models"
 
         hu_model_map = {
             # English NER models
@@ -743,79 +745,16 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             "keyphrase": "/".join([hu_path, "keyphrase", "keyphrase-en-scibert.pt"]),
             "negation-speculation": "/".join([hu_path, "negation-speculation", "negation-speculation-model.pt"]),
             # Biomedical models
-            "hunflair-paper-cellline": "/".join(
-                [
-                    hu_path,
-                    "hunflair_smallish_models",
-                    "cellline",
-                    "hunflair-celline-v1.0.pt",
-                ]
-            ),
-            "hunflair-paper-chemical": "/".join(
-                [
-                    hu_path,
-                    "hunflair_smallish_models",
-                    "chemical",
-                    "hunflair-chemical-v1.0.pt",
-                ]
-            ),
-            "hunflair-paper-disease": "/".join(
-                [
-                    hu_path,
-                    "hunflair_smallish_models",
-                    "disease",
-                    "hunflair-disease-v1.0.pt",
-                ]
-            ),
-            "hunflair-paper-gene": "/".join([hu_path, "hunflair_smallish_models", "gene", "hunflair-gene-v1.0.pt"]),
-            "hunflair-paper-species": "/".join(
-                [
-                    hu_path,
-                    "hunflair_smallish_models",
-                    "species",
-                    "hunflair-species-v1.0.pt",
-                ]
-            ),
-            "hunflair-cellline": "/".join(
-                [
-                    hu_path,
-                    "hunflair_smallish_models",
-                    "cellline",
-                    "hunflair-celline-v1.0.pt",
-                ]
-            ),
-            "hunflair-chemical": "/".join(
-                [
-                    hu_path,
-                    "hunflair_allcorpus_models",
-                    "huner-chemical",
-                    "hunflair-chemical-full-v1.0.pt",
-                ]
-            ),
-            "hunflair-disease": "/".join(
-                [
-                    hu_path,
-                    "hunflair_allcorpus_models",
-                    "huner-disease",
-                    "hunflair-disease-full-v1.0.pt",
-                ]
-            ),
-            "hunflair-gene": "/".join(
-                [
-                    hu_path,
-                    "hunflair_allcorpus_models",
-                    "huner-gene",
-                    "hunflair-gene-full-v1.0.pt",
-                ]
-            ),
-            "hunflair-species": "/".join(
-                [
-                    hu_path,
-                    "hunflair_allcorpus_models",
-                    "huner-species",
-                    "hunflair-species-full-v1.1.pt",
-                ]
-            ),
+            "hunflair-paper-cellline": "/".join([hunflair_paper_path, "cellline", "hunflair-celline-v1.0.pt"]),
+            "hunflair-paper-chemical": "/".join([hunflair_paper_path, "chemical", "hunflair-chemical-v1.0.pt"]),
+            "hunflair-paper-disease": "/".join([hunflair_paper_path, "disease", "hunflair-disease-v1.0.pt"]),
+            "hunflair-paper-gene": "/".join([hunflair_paper_path, "gene", "hunflair-gene-v1.0.pt"]),
+            "hunflair-paper-species": "/".join([hunflair_paper_path, "species", "hunflair-species-v1.0.pt"]),
+            "hunflair-cellline": "/".join([hunflair_main_path, "cellline", "hunflair-celline-v1.0.pt"]),
+            "hunflair-chemical": "/".join([hunflair_main_path, "huner-chemical", "hunflair-chemical-full-v1.0.pt"]),
+            "hunflair-disease": "/".join([hunflair_main_path, "huner-disease", "hunflair-disease-full-v1.0.pt"]),
+            "hunflair-gene": "/".join([hunflair_main_path, "huner-gene", "hunflair-gene-full-v1.0.pt"]),
+            "hunflair-species": "/".join([hunflair_main_path, "huner-species", "hunflair-species-full-v1.1.pt"]),
         }
 
         cache_dir = Path("models")
@@ -1088,128 +1027,3 @@ for entity in sentence.get_spans('ner'):
                     lines.append(eval_line)
                 lines.append("\n")
         return lines
-
-
-class MultiTagger:
-    def __init__(self, name_to_tagger: Dict[str, SequenceTagger]):
-        super().__init__()
-        self.name_to_tagger = name_to_tagger
-
-    def predict(
-        self,
-        sentences: Union[List[Sentence], Sentence],
-        return_loss: bool = False,
-        mini_batch_size: int = 32,
-    ):
-        """
-        Predict sequence tags for Named Entity Recognition task
-        :param sentences: a Sentence or a List of Sentence
-        :param mini_batch_size: size of the minibatch, usually bigger is more rapid but consume more memory,
-        up to a point when it has no more effect.
-        :param all_tag_prob: True to compute the score for each tag on each token,
-        otherwise only the score of the best tag is returned
-        :param verbose: set to True to display a progress bar
-        :param return_loss: set to True to return loss
-        """
-        if any(["hunflair" in name for name in self.name_to_tagger.keys()]):
-            if "spacy" not in sys.modules:
-                logging.warning(
-                    "We recommend to use SciSpaCy for tokenization and sentence splitting "
-                    "if HunFlair is applied to biomedical text, e.g.\n\n"
-                    "from flair.tokenization import SciSpacySentenceSplitter\n"
-                    "sentence = Sentence('Your biomed text', use_tokenizer=SciSpacySentenceSplitter())\n"
-                )
-
-        if isinstance(sentences, Sentence):
-            sentences = [sentences]
-        for name, tagger in self.name_to_tagger.items():
-            tagger.predict(
-                sentences=sentences,
-                label_name=name,
-                return_loss=return_loss,
-                embedding_storage_mode="cpu",
-                mini_batch_size=mini_batch_size,
-            )
-
-        # clear embeddings after predicting
-        for sentence in sentences:
-            sentence.clear_embeddings()
-
-    @classmethod
-    def load(cls, model_names: Union[List[str], str]):
-        if model_names == "hunflair-paper":
-            model_names = [
-                "hunflair-paper-cellline",
-                "hunflair-paper-chemical",
-                "hunflair-paper-disease",
-                "hunflair-paper-gene",
-                "hunflair-paper-species",
-            ]
-        elif model_names == "hunflair" or model_names == "bioner":
-            model_names = [
-                "hunflair-cellline",
-                "hunflair-chemical",
-                "hunflair-disease",
-                "hunflair-gene",
-                "hunflair-species",
-            ]
-        elif isinstance(model_names, str):
-            model_names = [model_names]
-
-        taggers = {}
-        models: List[SequenceTagger] = []
-
-        # load each model
-        for model_name in model_names:
-            model = SequenceTagger.load(model_name)
-
-            # check if the same embeddings were already loaded previously
-            # if the model uses StackedEmbedding, make a new stack with previous objects
-            if type(model.embeddings) == StackedEmbeddings:
-                # sort embeddings by key alphabetically
-                new_stack = []
-                d = model.embeddings.get_named_embeddings_dict()
-                import collections
-
-                od = collections.OrderedDict(sorted(d.items()))
-
-                for k, embedding in od.items():
-                    # check previous embeddings and add if found
-                    embedding_found = False
-                    for previous_model in models:
-                        # only re-use static embeddings
-                        if not embedding.static_embeddings:
-                            continue
-
-                        if embedding.name in previous_model.embeddings.get_named_embeddings_dict():
-                            previous_embedding = previous_model.embeddings.get_named_embeddings_dict()[embedding.name]
-                            previous_embedding.name = previous_embedding.name[2:]
-                            new_stack.append(previous_embedding)
-                            embedding_found = True
-                            break
-
-                    # if not found, use existing embedding
-                    if not embedding_found:
-                        embedding.name = embedding.name[2:]
-                        new_stack.append(embedding)
-
-                # initialize new stack
-                model.embeddings = None
-                model.embeddings = StackedEmbeddings(new_stack)
-
-            else:
-                # of the model uses regular embedding, re-load if previous version found
-                if not model.embeddings.static_embeddings:
-                    for previous_model in models:
-                        if model.embeddings.name in previous_model.embeddings.get_named_embeddings_dict():
-                            previous_embedding = previous_model.embeddings.get_named_embeddings_dict()[
-                                model.embeddings.name
-                            ]
-                            if not previous_embedding.static_embeddings:
-                                model.embeddings = previous_embedding
-                                break
-
-            taggers[model_name] = model
-            models.append(model)
-
-        return cls(taggers)

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from urllib.error import HTTPError
 
 import torch
@@ -1027,3 +1027,9 @@ for entity in sentence.get_spans('ner'):
                     lines.append(eval_line)
                 lines.append("\n")
         return lines
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "SequenceTagger":
+        from typing import cast
+
+        return cast("SequenceTagger", super().load(model_path=model_path))

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 import flair.nn
 from flair.data import Dictionary, Label, Sentence, Span, get_spans_from_bio
 from flair.datasets import DataLoader, FlairDatapointDataset
-from flair.embeddings import StackedEmbeddings, TokenEmbeddings
+from flair.embeddings import TokenEmbeddings
 from flair.file_utils import cached_path, unzip_file
 from flair.models.sequence_tagger_utils.crf import CRF
 from flair.models.sequence_tagger_utils.viterbi import ViterbiDecoder, ViterbiLoss

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC
 from collections import OrderedDict
 from pathlib import Path
-from typing import List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import torch
@@ -308,6 +308,12 @@ class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
 
         return
 
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "FewshotClassifier":
+        from typing import cast
+
+        return cast("FewshotClassifier", super().load(model_path=model_path))
+
 
 class TARSTagger(FewshotClassifier):
     """
@@ -612,6 +618,12 @@ class TARSTagger(FewshotClassifier):
                 lines.append("\n")
         return lines
 
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TARSTagger":
+        from typing import cast
+
+        return cast("TARSTagger", super().load(model_path=model_path))
+
 
 class TARSClassifier(FewshotClassifier):
     """
@@ -900,3 +912,9 @@ class TARSClassifier(FewshotClassifier):
 
         if return_loss:
             return overall_loss, overall_count
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TARSClassifier":
+        from typing import cast
+
+        return cast("TARSClassifier", super().load(model_path=model_path))

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List, Union
 
 import torch
 
@@ -129,3 +129,9 @@ class TextClassifier(flair.nn.DefaultClassifier[Sentence, Sentence]):
     @property
     def label_type(self):
         return self._label_type
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TextClassifier":
+        from typing import cast
+
+        return cast("TextClassifier", super().load(model_path=model_path))

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -228,3 +228,9 @@ class TextRegressor(flair.nn.Model[Sentence]):
         if len(sentences) != len(filtered_sentences):
             log.warning("Ignore {} sentence(s) with no tokens.".format(len(sentences) - len(filtered_sentences)))
         return filtered_sentences
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TextRegressor":
+        from typing import cast
+
+        return cast("TextRegressor", super().load(model_path=model_path))

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -1,5 +1,6 @@
 import logging
-from typing import List
+from pathlib import Path
+from typing import Any, Dict, List, Union
 
 import torch
 
@@ -85,3 +86,9 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
                 lines.append(eval_line)
             lines.append("\n")
         return lines
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "WordTagger":
+        from typing import cast
+
+        return cast("WordTagger", super().load(model_path=model_path))

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -924,6 +924,12 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
 
         return state
 
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "DefaultClassifier":
+        from typing import cast
+
+        return cast("DefaultClassifier", super().load(model_path=model_path))
+
 
 def get_non_abstract_subclasses(cls):
     all_subclasses = []

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -140,7 +140,7 @@ class Model(torch.nn.Module, typing.Generic[DT], ABC):
                 self.model_card["training_parameters"]["scheduler"] = scheduler
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]):
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "Model":
         """
         Loads the model from the given file.
         :param model_path: the model file or the already loaded state dict
@@ -541,6 +541,12 @@ class Classifier(Model[DT], typing.Generic[DT], ABC):
             )
             lines.append(eval_line)
         return lines
+
+    @classmethod
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "Classifier":
+        from typing import cast
+
+        return cast("Classifier", super().load(model_path=model_path))
 
 
 class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):


### PR DESCRIPTION
Add return types to `load()` function so that type hints become possible when loading models: 

```python
from flair.nn import Classifier

model = Classifier.load('ner')
```

It also changes the internal packaging of the hunflair bio NER taggers to use the general `MultitaskModel`. They can now be loaded like all other models with: 

```python
from flair.nn import Classifier

model = Classifier.load('bioner')
```

The `MultiTagger` class, specifically created for the hunflair tagger, is removed.