### PR TITLE
Update required version of transformers library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.2.7
 boto3
-transformers[sentencepiece]>=4.0.0
+transformers[sentencepiece]>=4.18.0
 bpemb>=0.3.2
 regex
 tabulate


### PR DESCRIPTION
`flair/embeddings/transformer.py` has the import statement `from transformers.utils import PaddingStrategy`. That is only available from version 4.18.0 of the transformers library. Up until version 4.17.0 it is called `transformers.file_utils.PaddingStrategy`.