### PR TITLE
Use to_plain_string instead of to_original_text for the property text of a Sentence

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -865,7 +865,7 @@ class Sentence(DataPoint):
 
     @property
     def text(self):
-        return self.to_original_text()
+        return self.to_plain_string()
 
     def to_tokenized_string(self) -> str:
         if self.tokenized is None:


### PR DESCRIPTION
When splitting a huge document into several flair Sentence objects and thus keeping trace of the token indexes from the document, the method `Sentence.to_original_text()`, used to defined the `Sentence.text` property, will store string sentences with a lot of useless whitespaces corresponding to the `start_position` of the first token of each Sentence. A simple fix is to replace `.to_original_text()` by `.to_plain_string()` for the `text` property.

For example for the following text which is split in two Sentence objects in my application:
`text = "Amaury et Valentin mangent au 77 boulevard  Perreire.\n\n\n\n Paul  a modifié le tokenizer."`

It gives before the fix:
```python
[Sentence[9]: "Amaury et Valentin mangent au 77 boulevard  Perreire.",
 Sentence[6]: "                                                          Paul  a modifié le tokenizer."]
```

And after the fix:
```python
[Sentence[9]: "Amaury et Valentin mangent au 77 boulevard  Perreire.",
 Sentence[6]: "Paul  a modifié le tokenizer."]
```