### PR TITLE
unpin huggingface-hub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ filterwarnings = [
     'ignore:The `device` argument is deprecated and will be removed in v5 of Transformers.',  # hf layoutlmv3 calls deprecated hf.
     "ignore:the imp module is deprecated:DeprecationWarning:past",  # ignore DeprecationWarning from hyperopt dependency
     "ignore:.*imp module.*:DeprecationWarning",  # ignore DeprecationWarnings that involve imp module
+    "ignore:The class LayoutLMv3FeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please use LayoutLMv3ImageProcessor instead.",  # huggingface layoutlmv3 has deprecated calls.
 ]
 markers = [
     "integration",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ lxml
 ftfy
 janome
 gdown==4.4.0
-huggingface-hub==0.10.0
+huggingface-hub>=0.10.0
 conllu>=4.0
 more-itertools
 wikipedia-api


### PR DESCRIPTION
Simply moving from == to >= for `huggingface-hub`, since this is creating problems for me to install newer versions of `transformers` that require a minimum `huggingface-hub` version.

Some warnings appear for newer versions, so had to add some config to ignore warnings for `LayoutLMv3FeatureExtractor`, similarly as what was prev done for v2