### PR TITLE
Modify Sentence.to_original_text() to take into account Sentence.start_position for whitespace calculation

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -917,7 +917,9 @@ class Sentence(DataPoint):
         if len(self) == 0:
             return ""
         # otherwise, return concatenation of tokens with the correct offsets
-        return self[0].start_position * " " + "".join([t.text + t.whitespace_after * " " for t in self.tokens]).strip()
+        return (self[0].start_position - self.start_position) * " " + "".join(
+            [t.text + t.whitespace_after * " " for t in self.tokens]
+        ).strip()
 
     def to_dict(self, tag_type: str = None):
         labels = []


### PR DESCRIPTION
Related to https://github.com/flairNLP/flair/pull/3142. This solution, by taking the difference between the first token start index and the sentence start index, keep the initial whitespace for some special cases while not printing a lot of useless whitespaces because we store the index of the token from a bigger document.

For example for the following text which is split in two Sentence objects in my application:
```python
text = "Amaury et Valentin mangent au 77 boulevard  Perreire.\n\n\n\n Paul  a modifié le tokenizer."
```
It gives before the fix:
```python
[Sentence[9]: "Amaury et Valentin mangent au 77 boulevard  Perreire.",
 Sentence[6]: "                                                          Paul  a modifié le tokenizer."]
```
And after the fix:
```python
[Sentence[9]: "Amaury et Valentin mangent au 77 boulevard  Perreire.",
 Sentence[6]: "Paul  a modifié le tokenizer."]
```
And a sentence that begins with a whitespace
```python
sentence = Sentence(" ... and then?")

print(sentence)
```
still got it in the printout:
```python
Sentence[4]: " ... and then?"
```