### PR TITLE
Fix transformer smaller training vocab

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -384,513 +384,515 @@ class ModelTrainer:
 
             train_data = self.corpus.train
 
-        # if training also uses dev/train data, include in training set
-        if train_with_dev or train_with_test:
-            parts = [self.corpus.train]
-            if train_with_dev and self.corpus.dev:
-                parts.append(self.corpus.dev)
-            if train_with_test and self.corpus.test:
-                parts.append(self.corpus.test)
+            # if training also uses dev/train data, include in training set
+            if train_with_dev or train_with_test:
+                parts = [self.corpus.train]
+                if train_with_dev and self.corpus.dev:
+                    parts.append(self.corpus.dev)
+                if train_with_test and self.corpus.test:
+                    parts.append(self.corpus.test)
 
-            train_data = ConcatDataset(parts)
+                train_data = ConcatDataset(parts)
 
-        # initialize sampler if provided
-        if sampler is not None:
-            # init with default values if only class is provided
-            if inspect.isclass(sampler):
-                sampler = sampler()
-            # set dataset to sample from
-            sampler.set_dataset(train_data)
-            shuffle = False
+            # initialize sampler if provided
+            if sampler is not None:
+                # init with default values if only class is provided
+                if inspect.isclass(sampler):
+                    sampler = sampler()
+                # set dataset to sample from
+                sampler.set_dataset(train_data)
+                shuffle = False
 
-        dev_score_history = []
-        dev_loss_history = []
-        train_loss_history = []
+            dev_score_history = []
+            dev_loss_history = []
+            train_loss_history = []
 
-        micro_batch_size = mini_batch_chunk_size
+            micro_batch_size = mini_batch_chunk_size
 
-        # this field stores the names of all dynamic embeddings in the model (determined after first forward pass)
-        dynamic_embeddings = None
+            # this field stores the names of all dynamic embeddings in the model (determined after first forward pass)
+            dynamic_embeddings = None
 
-        # At any point you can hit Ctrl + C to break out of training early.
-        try:
-            if create_file_logs:
-                log_handler = add_file_handler(log, base_path / "training.log")
-            else:
-                log_handler = None
+            # At any point you can hit Ctrl + C to break out of training early.
+            try:
+                if create_file_logs:
+                    log_handler = add_file_handler(log, base_path / "training.log")
+                else:
+                    log_handler = None
 
-            lr_info = ",".join([f"{lr:.6f}" for lr in current_learning_rate])
+                lr_info = ",".join([f"{lr:.6f}" for lr in current_learning_rate])
 
-            log_line(log)
-            log.info(f'Model: "{self.model}"')
-            log_line(log)
-            log.info(f'Corpus: "{self.corpus}"')
-            log_line(log)
-            log.info("Parameters:")
-            log.info(f' - learning_rate: "{lr_info}"')
-            log.info(f' - mini_batch_size: "{mini_batch_size}"')
-            log.info(f' - patience: "{patience}"')
-            log.info(f' - anneal_factor: "{anneal_factor}"')
-            log.info(f' - max_epochs: "{max_epochs}"')
-            log.info(f' - shuffle: "{shuffle}"')
-            log.info(f' - train_with_dev: "{train_with_dev}"')
-            log.info(f' - batch_growth_annealing: "{batch_growth_annealing}"')
-            log_line(log)
-            log.info(f'Model training base path: "{base_path}"')
-            log_line(log)
-            log.info(f"Device: {flair.device}")
-            log_line(log)
-            log.info(f"Embeddings storage mode: {embeddings_storage_mode}")
-
-            previous_learning_rate = current_learning_rate
-
-            momentum = [group["momentum"] if "momentum" in group else 0 for group in optimizer_instance.param_groups]
-
-            for epoch in range(epoch + 1, max_epochs + 1):
                 log_line(log)
-
-                # update epoch in model card
-                model_card["training_parameters"]["epoch"] = epoch
-
-                if anneal_with_prestarts:
-                    last_epoch_model_state_dict = copy.deepcopy(self.model.state_dict())
-
-                if eval_on_train_shuffle:
-                    train_part_indices = list(range(_len_dataset(self.corpus.train)))
-                    random.shuffle(train_part_indices)
-                    train_part_indices = train_part_indices[:train_part_size]
-                    train_part = torch.utils.data.dataset.Subset(self.corpus.train, train_part_indices)
-
-                # get new learning rate
-                current_learning_rate = [group["lr"] for group in optimizer_instance.param_groups]
-
-                lr_changed = any([lr != prev_lr for lr, prev_lr in zip(current_learning_rate, previous_learning_rate)])
-
-                if lr_changed and batch_growth_annealing:
-                    mini_batch_size *= 2
-
-                # reload last best model if annealing with restarts is enabled
-                if (
-                    (anneal_with_restarts or anneal_with_prestarts)
-                    and lr_changed
-                    and os.path.exists(base_path / "best-model.pt")
-                ):
-                    if anneal_with_restarts:
-                        log.info("resetting to best model")
-                        self.model.load_state_dict(self.model.load(base_path / "best-model.pt").state_dict())
-                    if anneal_with_prestarts:
-                        log.info("resetting to pre-best model")
-                        self.model.load_state_dict(self.model.load(base_path / "pre-best-model.pt").state_dict())
+                log.info(f'Model: "{self.model}"')
+                log_line(log)
+                log.info(f'Corpus: "{self.corpus}"')
+                log_line(log)
+                log.info("Parameters:")
+                log.info(f' - learning_rate: "{lr_info}"')
+                log.info(f' - mini_batch_size: "{mini_batch_size}"')
+                log.info(f' - patience: "{patience}"')
+                log.info(f' - anneal_factor: "{anneal_factor}"')
+                log.info(f' - max_epochs: "{max_epochs}"')
+                log.info(f' - shuffle: "{shuffle}"')
+                log.info(f' - train_with_dev: "{train_with_dev}"')
+                log.info(f' - batch_growth_annealing: "{batch_growth_annealing}"')
+                log_line(log)
+                log.info(f'Model training base path: "{base_path}"')
+                log_line(log)
+                log.info(f"Device: {flair.device}")
+                log_line(log)
+                log.info(f"Embeddings storage mode: {embeddings_storage_mode}")
 
                 previous_learning_rate = current_learning_rate
-                if use_tensorboard:
-                    if len(current_learning_rate) == 1:
-                        writer.add_scalar("learning_rate", current_learning_rate[0], epoch)
-                    else:
-                        for i, lr in enumerate(current_learning_rate):
-                            writer.add_scalar(f"learning_rate_{i}", lr, epoch)
 
-                all_lrs_too_small = all([lr < min_lr for lr, min_lr in zip(current_learning_rate, min_learning_rate)])
+                momentum = [group["momentum"] if "momentum" in group else 0 for group in optimizer_instance.param_groups]
 
-                # stop training if learning rate becomes too small
-                if not isinstance(scheduler, (OneCycleLR, LinearSchedulerWithWarmup)) and all_lrs_too_small:
+                for epoch in range(epoch + 1, max_epochs + 1):
                     log_line(log)
-                    log.info("learning rate too small - quitting training!")
-                    log_line(log)
-                    break
 
-                start_time = time.time()
-
-                # if shuffle_first_epoch==False, the first epoch is not shuffled
-                shuffle_data_this_epoch = shuffle
-                if not shuffle_first_epoch and epoch == 1:
-                    shuffle_data_this_epoch = False
-
-                batch_loader = DataLoader(
-                    train_data,
-                    batch_size=mini_batch_size,
-                    shuffle=shuffle_data_this_epoch,
-                    num_workers=0 if num_workers is None else num_workers,
-                    sampler=sampler,
-                )
-
-                self.model.train()
-
-                train_loss: float = 0
-
-                seen_batches = 0
-                total_number_of_batches = len(batch_loader)
-
-                modulo = max(1, int(total_number_of_batches / 10))
-
-                # process mini-batches
-                average_over = 0
-                for batch_no, batch in enumerate(batch_loader):
-                    # zero the gradients on the model and optimizer
-                    self.model.zero_grad()
-                    optimizer_instance.zero_grad()
-
-                    # if necessary, make batch_steps
-                    batch_steps = [batch]
-                    if len(batch) > micro_batch_size:
-                        batch_steps = [batch[x : x + micro_batch_size] for x in range(0, len(batch), micro_batch_size)]
-
-                    # forward and backward for batch
-                    for batch_step in batch_steps:
-                        # forward pass
-                        loss, datapoint_count = self.model.forward_loss(batch_step)
-                        average_over += datapoint_count
-                        # Backward
-                        if use_amp:
-                            with amp.scale_loss(loss, optimizer_instance) as scaled_loss:
-                                scaled_loss.backward()
-                        else:
-                            loss.backward()
-                        train_loss += loss.item()
-
-                        # identify dynamic embeddings (always deleted) on first sentence
-
-                        if dynamic_embeddings is None:
-                            dynamic_embeddings = identify_dynamic_embeddings(batch)
-
-                        # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                        store_embeddings(batch, embeddings_storage_mode, dynamic_embeddings)
-
-                    # do the optimizer step
-                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
-                    optimizer_instance.step()
-
-                    # do the scheduler step if one-cycle or linear decay
-                    if isinstance(scheduler, (OneCycleLR, LinearSchedulerWithWarmup)):
-                        scheduler.step()
-                        # get new learning rate
-                        current_learning_rate = [group["lr"] for group in optimizer_instance.param_groups]
-
-                        momentum = [
-                            group["betas"][0] if "betas" in group else group.get("momentum", 0)
-                            for group in optimizer_instance.param_groups
-                        ]
-
-                    seen_batches += 1
-
-                    if seen_batches % modulo == 0:
-                        momentum_info = ""
-                        if cycle_momentum:
-                            momentum_info = " - momentum:" + ",".join([f"{m:.4f}" for m in momentum])
-
-                        lr_info = ",".join([f"{lr:.6f}" for lr in current_learning_rate])
-
-                        intermittent_loss = train_loss / average_over if average_over > 0 else train_loss / seen_batches
-                        end_time = time.time()
-                        log.info(
-                            f"epoch {epoch}"
-                            f" - iter {seen_batches}/{total_number_of_batches}"
-                            f" - loss {intermittent_loss:.8f}"
-                            f" - time (sec): {end_time - start_time:.2f}"
-                            f" - samples/sec: {average_over / (end_time - start_time):.2f}"
-                            f" - lr: {lr_info}{momentum_info}"
-                        )
-                        iteration = epoch * total_number_of_batches + batch_no
-                        if not param_selection_mode and write_weights:
-                            weight_extractor.extract_weights(self.model.state_dict(), iteration)
-
-                if average_over != 0:
-                    train_loss /= average_over
-
-                self.model.eval()
-
-                if save_model_each_k_epochs > 0 and epoch % save_model_each_k_epochs == 0:
-                    log.info("saving model of current epoch")
-                    model_name = "model_epoch_" + str(epoch) + ".pt"
-                    self.model.save(base_path / model_name, checkpoint=save_optimizer_state)
-
-                log_line(log)
-                log.info(f"EPOCH {epoch} done: loss {train_loss:.4f} - lr {lr_info}")
-
-                if use_tensorboard:
-                    writer.add_scalar("train_loss", train_loss, epoch)
-
-                # evaluate on train / dev / test split depending on training settings
-                result_line: str = ""
-
-                if log_train:
-                    train_eval_result = self.model.evaluate(
-                        self.corpus.train,
-                        gold_label_type=self.model.label_type,
-                        mini_batch_size=eval_batch_size,
-                        num_workers=num_workers,
-                        embedding_storage_mode=embeddings_storage_mode,
-                        main_evaluation_metric=main_evaluation_metric,
-                        gold_label_dictionary=gold_label_dictionary_for_eval,
-                        exclude_labels=exclude_labels,
-                    )
-                    result_line += f"\t{train_eval_result.loss}\t{train_eval_result.log_line}"
-                    log.info(
-                        f"TRAIN : loss {train_eval_result.loss} -"
-                        f" {main_evaluation_metric[1]}"
-                        f" ({main_evaluation_metric[0]}) "
-                        f" {round(train_eval_result.main_score, 4)}"
-                    )
-                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(self.corpus.train, embeddings_storage_mode, dynamic_embeddings)
-
-                if log_train_part:
-                    train_part_eval_result = self.model.evaluate(
-                        train_part,
-                        gold_label_type=self.model.label_type,
-                        mini_batch_size=eval_batch_size,
-                        num_workers=num_workers,
-                        embedding_storage_mode=embeddings_storage_mode,
-                        main_evaluation_metric=main_evaluation_metric,
-                        gold_label_dictionary=gold_label_dictionary_for_eval,
-                        exclude_labels=exclude_labels,
-                    )
-                    result_line += f"\t{train_part_eval_result.loss}" f"\t{train_part_eval_result.log_line}"
-                    log.info(
-                        f"TRAIN_SPLIT : loss {train_part_eval_result.loss}"
-                        f" - {main_evaluation_metric[1]}"
-                        f" ({main_evaluation_metric[0]})"
-                        f" {round(train_part_eval_result.main_score, 4)}"
-                    )
-                    if use_tensorboard:
-                        for metric_class_avg_type, metric_type in metrics_for_tensorboard:
-                            writer.add_scalar(
-                                f"train_{metric_class_avg_type}_{metric_type}",
-                                train_part_eval_result.classification_report[metric_class_avg_type][metric_type],
-                                epoch,
-                            )
-
-                if log_dev:
-                    assert self.corpus.dev
-                    dev_eval_result = self.model.evaluate(
-                        self.corpus.dev,
-                        gold_label_type=self.model.label_type,
-                        mini_batch_size=eval_batch_size,
-                        num_workers=num_workers,
-                        out_path=base_path / "dev.tsv",
-                        embedding_storage_mode=embeddings_storage_mode,
-                        main_evaluation_metric=main_evaluation_metric,
-                        gold_label_dictionary=gold_label_dictionary_for_eval,
-                        exclude_labels=exclude_labels,
-                    )
-                    result_line += f"\t{dev_eval_result.loss}\t{dev_eval_result.log_line}"
-                    log.info(
-                        f"DEV : loss {dev_eval_result.loss}"
-                        f" - {main_evaluation_metric[1]}"
-                        f" ({main_evaluation_metric[0]})"
-                        f"  {round(dev_eval_result.main_score, 4)}"
-                    )
-                    # calculate scores using dev data if available
-                    # append dev score to score history
-                    dev_score_history.append(dev_eval_result.main_score)
-                    dev_loss_history.append(dev_eval_result.loss)
-
-                    dev_score = dev_eval_result.main_score
-
-                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(self.corpus.dev, embeddings_storage_mode, dynamic_embeddings)
-
-                    if use_tensorboard:
-                        writer.add_scalar("dev_loss", dev_eval_result.loss, epoch)
-                        writer.add_scalar("dev_score", dev_eval_result.main_score, epoch)
-                        for (
-                            metric_class_avg_type,
-                            metric_type,
-                        ) in metrics_for_tensorboard:
-                            writer.add_scalar(
-                                f"dev_{metric_class_avg_type}_{metric_type}",
-                                dev_eval_result.classification_report[metric_class_avg_type][metric_type],
-                                epoch,
-                            )
-
-                if log_test:
-                    assert self.corpus.test
-                    test_eval_result = self.model.evaluate(
-                        self.corpus.test,
-                        gold_label_type=self.model.label_type,
-                        mini_batch_size=eval_batch_size,
-                        num_workers=num_workers,
-                        out_path=base_path / "test.tsv",
-                        embedding_storage_mode=embeddings_storage_mode,
-                        main_evaluation_metric=main_evaluation_metric,
-                        gold_label_dictionary=gold_label_dictionary_for_eval,
-                        exclude_labels=exclude_labels,
-                    )
-                    result_line += f"\t{test_eval_result.loss}\t{test_eval_result.log_line}"
-                    log.info(
-                        f"TEST : loss {test_eval_result.loss} -"
-                        f" {main_evaluation_metric[1]}"
-                        f" ({main_evaluation_metric[0]}) "
-                        f" {round(test_eval_result.main_score, 4)}"
-                    )
-
-                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(self.corpus.test, embeddings_storage_mode, dynamic_embeddings)
-
-                    if use_tensorboard:
-                        writer.add_scalar("test_loss", test_eval_result.loss, epoch)
-                        writer.add_scalar("test_score", test_eval_result.main_score, epoch)
-                        for (
-                            metric_class_avg_type,
-                            metric_type,
-                        ) in metrics_for_tensorboard:
-                            writer.add_scalar(
-                                f"test_{metric_class_avg_type}_{metric_type}",
-                                test_eval_result.classification_report[metric_class_avg_type][metric_type],
-                                epoch,
-                            )
-
-                # determine if this is the best model or if we need to anneal
-                current_epoch_has_best_model_so_far = False
-                # default mode: anneal against dev score
-                if not train_with_dev and not anneal_against_dev_loss and self.corpus.dev is not None:
-                    if dev_score > best_validation_score:
-                        current_epoch_has_best_model_so_far = True
-                        best_validation_score = dev_score
-
-                    if isinstance(scheduler, AnnealOnPlateau):
-                        scheduler.step(dev_score, dev_eval_result.loss)
-
-                # alternative: anneal against dev loss
-                if not train_with_dev and anneal_against_dev_loss and self.corpus.dev is not None:
-                    if dev_eval_result.loss < best_validation_score:
-                        current_epoch_has_best_model_so_far = True
-                        best_validation_score = dev_eval_result.loss
-
-                    if isinstance(scheduler, AnnealOnPlateau):
-                        scheduler.step(dev_eval_result.loss)
-
-                # alternative: anneal against train loss
-                if train_with_dev:
-                    if train_loss < best_validation_score:
-                        current_epoch_has_best_model_so_far = True
-                        best_validation_score = train_loss
-
-                    if isinstance(scheduler, AnnealOnPlateau):
-                        scheduler.step(train_loss)
-
-                train_loss_history.append(train_loss)
-
-                # determine bad epoch number
-                try:
-                    bad_epochs = scheduler.num_bad_epochs
-                except AttributeError:
-                    bad_epochs = 0
-
-                new_learning_rate = [group["lr"] for group in optimizer_instance.param_groups]
-
-                if any([new_lr != prev_lr for new_lr, prev_lr in zip(new_learning_rate, previous_learning_rate)]):
-                    bad_epochs = patience + 1
-
-                    # lr unchanged
-                    if all(
-                        [
-                            prev_lr == initial_lr
-                            for prev_lr, initial_lr in zip(previous_learning_rate, initial_learning_rate)
-                        ]
-                    ):
-                        bad_epochs += initial_extra_patience
-
-                # log bad epochs
-                if log_bad_epochs:
-                    log.info(f"BAD EPOCHS (no improvement): {bad_epochs}")
-
-                if loss_txt is not None:
-                    # output log file
-                    with open(loss_txt, "a") as f:
-                        # make headers on first epoch
-                        if epoch == 1:
-                            bad_epoch_header = "BAD_EPOCHS\t" if log_bad_epochs else ""
-                            f.write(f"EPOCH\tTIMESTAMP\t{bad_epoch_header}LEARNING_RATE\tTRAIN_LOSS")
-
-                            if log_train:
-                                f.write("\tTRAIN_" + "\tTRAIN_".join(train_eval_result.log_header.split("\t")))
-
-                            if log_train_part:
-                                f.write(
-                                    "\tTRAIN_PART_LOSS\tTRAIN_PART_"
-                                    + "\tTRAIN_PART_".join(train_part_eval_result.log_header.split("\t"))
-                                )
-
-                            if log_dev:
-                                f.write("\tDEV_LOSS\tDEV_" + "\tDEV_".join(dev_eval_result.log_header.split("\t")))
-
-                            if log_test:
-                                f.write("\tTEST_LOSS\tTEST_" + "\tTEST_".join(test_eval_result.log_header.split("\t")))
-
-                        lr_info = ",".join([f"{lr:.4f}" for lr in current_learning_rate])
-
-                        bad_epoch_info = "\t" + str(bad_epochs) if log_bad_epochs else ""
-                        f.write(
-                            f"\n{epoch}\t{datetime.datetime.now():%H:%M:%S}"
-                            f"{bad_epoch_info}"
-                            f"\t{lr_info}\t{train_loss}"
-                        )
-                        f.write(result_line)
-
-                # if checkpoint is enabled, save model at each epoch
-                if checkpoint and not param_selection_mode:
-                    self.model.save(base_path / "checkpoint.pt", checkpoint=True)
-
-                # Check whether to save best model
-                if (
-                    (not train_with_dev or anneal_with_restarts or anneal_with_prestarts)
-                    and not param_selection_mode
-                    and current_epoch_has_best_model_so_far
-                    and not use_final_model_for_eval
-                ):
-                    log.info("saving best model")
-                    self.model.save(base_path / "best-model.pt", checkpoint=save_optimizer_state)
+                    # update epoch in model card
+                    model_card["training_parameters"]["epoch"] = epoch
 
                     if anneal_with_prestarts:
-                        current_state_dict = self.model.state_dict()
-                        self.model.load_state_dict(last_epoch_model_state_dict)
-                        self.model.save(base_path / "pre-best-model.pt")
-                        self.model.load_state_dict(current_state_dict)
+                        last_epoch_model_state_dict = copy.deepcopy(self.model.state_dict())
 
-            if use_swa:
-                import torchcontrib
+                    if eval_on_train_shuffle:
+                        train_part_indices = list(range(_len_dataset(self.corpus.train)))
+                        random.shuffle(train_part_indices)
+                        train_part_indices = train_part_indices[:train_part_size]
+                        train_part = torch.utils.data.dataset.Subset(self.corpus.train, train_part_indices)
 
-                cast(torchcontrib.optim.SWA, optimizer_instance).swap_swa_sgd()
+                    # get new learning rate
+                    current_learning_rate = [group["lr"] for group in optimizer_instance.param_groups]
 
-            # if we do not use dev data for model selection, save final model
-            if save_final_model and not param_selection_mode:
-                self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
+                    lr_changed = any([lr != prev_lr for lr, prev_lr in zip(current_learning_rate, previous_learning_rate)])
 
-        except KeyboardInterrupt:
-            log_line(log)
-            log.info("Exiting from training early.")
+                    if lr_changed and batch_growth_annealing:
+                        mini_batch_size *= 2
 
-            if not param_selection_mode:
-                log.info("Saving model ...")
-                self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
-                log.info("Done.")
-        except Exception:
-            if create_file_logs:
-                log_handler.close()
-                log.removeHandler(log_handler)
-            raise
-        finally:
-            if use_tensorboard:
-                writer.close()
-        optimizer_instance.zero_grad(set_to_none=True)
-        del optimizer_instance
+                    # reload last best model if annealing with restarts is enabled
+                    if (
+                        (anneal_with_restarts or anneal_with_prestarts)
+                        and lr_changed
+                        and os.path.exists(base_path / "best-model.pt")
+                    ):
+                        if anneal_with_restarts:
+                            log.info("resetting to best model")
+                            self.model.load_state_dict(self.model.load(base_path / "best-model.pt").state_dict())
+                        if anneal_with_prestarts:
+                            log.info("resetting to pre-best model")
+                            self.model.load_state_dict(self.model.load(base_path / "pre-best-model.pt").state_dict())
 
-        # test best model if test data is present
-        if self.corpus.test and not train_with_test:
-            final_score = self.final_test(
-                base_path=base_path,
-                eval_mini_batch_size=eval_batch_size,
-                num_workers=num_workers,
-                main_evaluation_metric=main_evaluation_metric,
-                gold_label_dictionary_for_eval=gold_label_dictionary_for_eval,
-                exclude_labels=exclude_labels,
-            )
-        else:
-            final_score = 0
-            log.info("Test data not provided setting final score to 0")
+                    previous_learning_rate = current_learning_rate
+                    if use_tensorboard:
+                        if len(current_learning_rate) == 1:
+                            writer.add_scalar("learning_rate", current_learning_rate[0], epoch)
+                        else:
+                            for i, lr in enumerate(current_learning_rate):
+                                writer.add_scalar(f"learning_rate_{i}", lr, epoch)
+
+                    all_lrs_too_small = all([lr < min_lr for lr, min_lr in zip(current_learning_rate, min_learning_rate)])
+
+                    # stop training if learning rate becomes too small
+                    if not isinstance(scheduler, (OneCycleLR, LinearSchedulerWithWarmup)) and all_lrs_too_small:
+                        log_line(log)
+                        log.info("learning rate too small - quitting training!")
+                        log_line(log)
+                        break
+
+                    start_time = time.time()
+
+                    # if shuffle_first_epoch==False, the first epoch is not shuffled
+                    shuffle_data_this_epoch = shuffle
+                    if not shuffle_first_epoch and epoch == 1:
+                        shuffle_data_this_epoch = False
+
+                    batch_loader = DataLoader(
+                        train_data,
+                        batch_size=mini_batch_size,
+                        shuffle=shuffle_data_this_epoch,
+                        num_workers=0 if num_workers is None else num_workers,
+                        sampler=sampler,
+                    )
+
+                    self.model.train()
+
+                    train_loss: float = 0
+
+                    seen_batches = 0
+                    total_number_of_batches = len(batch_loader)
+
+                    modulo = max(1, int(total_number_of_batches / 10))
+
+                    # process mini-batches
+                    average_over = 0
+                    for batch_no, batch in enumerate(batch_loader):
+                        # zero the gradients on the model and optimizer
+                        self.model.zero_grad()
+                        optimizer_instance.zero_grad()
+
+                        # if necessary, make batch_steps
+                        batch_steps = [batch]
+                        if len(batch) > micro_batch_size:
+                            batch_steps = [batch[x : x + micro_batch_size] for x in range(0, len(batch), micro_batch_size)]
+
+                        # forward and backward for batch
+                        for batch_step in batch_steps:
+                            # forward pass
+                            loss, datapoint_count = self.model.forward_loss(batch_step)
+                            average_over += datapoint_count
+                            # Backward
+                            if use_amp:
+                                with amp.scale_loss(loss, optimizer_instance) as scaled_loss:
+                                    scaled_loss.backward()
+                            else:
+                                loss.backward()
+                            train_loss += loss.item()
+
+                            # identify dynamic embeddings (always deleted) on first sentence
+
+                            if dynamic_embeddings is None:
+                                dynamic_embeddings = identify_dynamic_embeddings(batch)
+
+                            # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                            store_embeddings(batch, embeddings_storage_mode, dynamic_embeddings)
+
+                        # do the optimizer step
+                        torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
+                        optimizer_instance.step()
+
+                        # do the scheduler step if one-cycle or linear decay
+                        if isinstance(scheduler, (OneCycleLR, LinearSchedulerWithWarmup)):
+                            scheduler.step()
+                            # get new learning rate
+                            current_learning_rate = [group["lr"] for group in optimizer_instance.param_groups]
+
+                            momentum = [
+                                group["betas"][0] if "betas" in group else group.get("momentum", 0)
+                                for group in optimizer_instance.param_groups
+                            ]
+
+                        seen_batches += 1
+
+                        if seen_batches % modulo == 0:
+                            momentum_info = ""
+                            if cycle_momentum:
+                                momentum_info = " - momentum:" + ",".join([f"{m:.4f}" for m in momentum])
+
+                            lr_info = ",".join([f"{lr:.6f}" for lr in current_learning_rate])
+
+                            intermittent_loss = train_loss / average_over if average_over > 0 else train_loss / seen_batches
+                            end_time = time.time()
+                            log.info(
+                                f"epoch {epoch}"
+                                f" - iter {seen_batches}/{total_number_of_batches}"
+                                f" - loss {intermittent_loss:.8f}"
+                                f" - time (sec): {end_time - start_time:.2f}"
+                                f" - samples/sec: {average_over / (end_time - start_time):.2f}"
+                                f" - lr: {lr_info}{momentum_info}"
+                            )
+                            iteration = epoch * total_number_of_batches + batch_no
+                            if not param_selection_mode and write_weights:
+                                weight_extractor.extract_weights(self.model.state_dict(), iteration)
+
+                    if average_over != 0:
+                        train_loss /= average_over
+
+                    self.model.eval()
+
+                    if save_model_each_k_epochs > 0 and epoch % save_model_each_k_epochs == 0:
+                        log.info("saving model of current epoch")
+                        model_name = "model_epoch_" + str(epoch) + ".pt"
+                        self.model.save(base_path / model_name, checkpoint=save_optimizer_state)
+
+                    log_line(log)
+                    log.info(f"EPOCH {epoch} done: loss {train_loss:.4f} - lr {lr_info}")
+
+                    if use_tensorboard:
+                        writer.add_scalar("train_loss", train_loss, epoch)
+
+                    # evaluate on train / dev / test split depending on training settings
+                    result_line: str = ""
+
+                    if log_train:
+                        train_eval_result = self.model.evaluate(
+                            self.corpus.train,
+                            gold_label_type=self.model.label_type,
+                            mini_batch_size=eval_batch_size,
+                            num_workers=num_workers,
+                            embedding_storage_mode=embeddings_storage_mode,
+                            main_evaluation_metric=main_evaluation_metric,
+                            gold_label_dictionary=gold_label_dictionary_for_eval,
+                            exclude_labels=exclude_labels,
+                        )
+                        result_line += f"\t{train_eval_result.loss}\t{train_eval_result.log_line}"
+                        log.info(
+                            f"TRAIN : loss {train_eval_result.loss} -"
+                            f" {main_evaluation_metric[1]}"
+                            f" ({main_evaluation_metric[0]}) "
+                            f" {round(train_eval_result.main_score, 4)}"
+                        )
+                        # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                        store_embeddings(self.corpus.train, embeddings_storage_mode, dynamic_embeddings)
+
+                    if log_train_part:
+                        train_part_eval_result = self.model.evaluate(
+                            train_part,
+                            gold_label_type=self.model.label_type,
+                            mini_batch_size=eval_batch_size,
+                            num_workers=num_workers,
+                            embedding_storage_mode=embeddings_storage_mode,
+                            main_evaluation_metric=main_evaluation_metric,
+                            gold_label_dictionary=gold_label_dictionary_for_eval,
+                            exclude_labels=exclude_labels,
+                        )
+                        result_line += f"\t{train_part_eval_result.loss}" f"\t{train_part_eval_result.log_line}"
+                        log.info(
+                            f"TRAIN_SPLIT : loss {train_part_eval_result.loss}"
+                            f" - {main_evaluation_metric[1]}"
+                            f" ({main_evaluation_metric[0]})"
+                            f" {round(train_part_eval_result.main_score, 4)}"
+                        )
+                        if use_tensorboard:
+                            for metric_class_avg_type, metric_type in metrics_for_tensorboard:
+                                writer.add_scalar(
+                                    f"train_{metric_class_avg_type}_{metric_type}",
+                                    train_part_eval_result.classification_report[metric_class_avg_type][metric_type],
+                                    epoch,
+                                )
+
+                    if log_dev:
+                        assert self.corpus.dev
+                        dev_eval_result = self.model.evaluate(
+                            self.corpus.dev,
+                            gold_label_type=self.model.label_type,
+                            mini_batch_size=eval_batch_size,
+                            num_workers=num_workers,
+                            out_path=base_path / "dev.tsv",
+                            embedding_storage_mode=embeddings_storage_mode,
+                            main_evaluation_metric=main_evaluation_metric,
+                            gold_label_dictionary=gold_label_dictionary_for_eval,
+                            exclude_labels=exclude_labels,
+                        )
+                        result_line += f"\t{dev_eval_result.loss}\t{dev_eval_result.log_line}"
+                        log.info(
+                            f"DEV : loss {dev_eval_result.loss}"
+                            f" - {main_evaluation_metric[1]}"
+                            f" ({main_evaluation_metric[0]})"
+                            f"  {round(dev_eval_result.main_score, 4)}"
+                        )
+                        # calculate scores using dev data if available
+                        # append dev score to score history
+                        dev_score_history.append(dev_eval_result.main_score)
+                        dev_loss_history.append(dev_eval_result.loss)
+
+                        dev_score = dev_eval_result.main_score
+
+                        # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                        store_embeddings(self.corpus.dev, embeddings_storage_mode, dynamic_embeddings)
+
+                        if use_tensorboard:
+                            writer.add_scalar("dev_loss", dev_eval_result.loss, epoch)
+                            writer.add_scalar("dev_score", dev_eval_result.main_score, epoch)
+                            for (
+                                metric_class_avg_type,
+                                metric_type,
+                            ) in metrics_for_tensorboard:
+                                writer.add_scalar(
+                                    f"dev_{metric_class_avg_type}_{metric_type}",
+                                    dev_eval_result.classification_report[metric_class_avg_type][metric_type],
+                                    epoch,
+                                )
+
+                    if log_test:
+                        assert self.corpus.test
+                        test_eval_result = self.model.evaluate(
+                            self.corpus.test,
+                            gold_label_type=self.model.label_type,
+                            mini_batch_size=eval_batch_size,
+                            num_workers=num_workers,
+                            out_path=base_path / "test.tsv",
+                            embedding_storage_mode=embeddings_storage_mode,
+                            main_evaluation_metric=main_evaluation_metric,
+                            gold_label_dictionary=gold_label_dictionary_for_eval,
+                            exclude_labels=exclude_labels,
+                        )
+                        result_line += f"\t{test_eval_result.loss}\t{test_eval_result.log_line}"
+                        log.info(
+                            f"TEST : loss {test_eval_result.loss} -"
+                            f" {main_evaluation_metric[1]}"
+                            f" ({main_evaluation_metric[0]}) "
+                            f" {round(test_eval_result.main_score, 4)}"
+                        )
+
+                        # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                        store_embeddings(self.corpus.test, embeddings_storage_mode, dynamic_embeddings)
+
+                        if use_tensorboard:
+                            writer.add_scalar("test_loss", test_eval_result.loss, epoch)
+                            writer.add_scalar("test_score", test_eval_result.main_score, epoch)
+                            for (
+                                metric_class_avg_type,
+                                metric_type,
+                            ) in metrics_for_tensorboard:
+                                writer.add_scalar(
+                                    f"test_{metric_class_avg_type}_{metric_type}",
+                                    test_eval_result.classification_report[metric_class_avg_type][metric_type],
+                                    epoch,
+                                )
+
+                    # determine if this is the best model or if we need to anneal
+                    current_epoch_has_best_model_so_far = False
+                    # default mode: anneal against dev score
+                    if not train_with_dev and not anneal_against_dev_loss and self.corpus.dev is not None:
+                        if dev_score > best_validation_score:
+                            current_epoch_has_best_model_so_far = True
+                            best_validation_score = dev_score
+
+                        if isinstance(scheduler, AnnealOnPlateau):
+                            scheduler.step(dev_score, dev_eval_result.loss)
+
+                    # alternative: anneal against dev loss
+                    if not train_with_dev and anneal_against_dev_loss and self.corpus.dev is not None:
+                        if dev_eval_result.loss < best_validation_score:
+                            current_epoch_has_best_model_so_far = True
+                            best_validation_score = dev_eval_result.loss
+
+                        if isinstance(scheduler, AnnealOnPlateau):
+                            scheduler.step(dev_eval_result.loss)
+
+                    # alternative: anneal against train loss
+                    if train_with_dev:
+                        if train_loss < best_validation_score:
+                            current_epoch_has_best_model_so_far = True
+                            best_validation_score = train_loss
+
+                        if isinstance(scheduler, AnnealOnPlateau):
+                            scheduler.step(train_loss)
+
+                    train_loss_history.append(train_loss)
+
+                    # determine bad epoch number
+                    try:
+                        bad_epochs = scheduler.num_bad_epochs
+                    except AttributeError:
+                        bad_epochs = 0
+
+                    new_learning_rate = [group["lr"] for group in optimizer_instance.param_groups]
+
+                    if any([new_lr != prev_lr for new_lr, prev_lr in zip(new_learning_rate, previous_learning_rate)]):
+                        bad_epochs = patience + 1
+
+                        # lr unchanged
+                        if all(
+                            [
+                                prev_lr == initial_lr
+                                for prev_lr, initial_lr in zip(previous_learning_rate, initial_learning_rate)
+                            ]
+                        ):
+                            bad_epochs += initial_extra_patience
+
+                    # log bad epochs
+                    if log_bad_epochs:
+                        log.info(f"BAD EPOCHS (no improvement): {bad_epochs}")
+
+                    if loss_txt is not None:
+                        # output log file
+                        with open(loss_txt, "a") as f:
+                            # make headers on first epoch
+                            if epoch == 1:
+                                bad_epoch_header = "BAD_EPOCHS\t" if log_bad_epochs else ""
+                                f.write(f"EPOCH\tTIMESTAMP\t{bad_epoch_header}LEARNING_RATE\tTRAIN_LOSS")
+
+                                if log_train:
+                                    f.write("\tTRAIN_" + "\tTRAIN_".join(train_eval_result.log_header.split("\t")))
+
+                                if log_train_part:
+                                    f.write(
+                                        "\tTRAIN_PART_LOSS\tTRAIN_PART_"
+                                        + "\tTRAIN_PART_".join(train_part_eval_result.log_header.split("\t"))
+                                    )
+
+                                if log_dev:
+                                    f.write("\tDEV_LOSS\tDEV_" + "\tDEV_".join(dev_eval_result.log_header.split("\t")))
+
+                                if log_test:
+                                    f.write("\tTEST_LOSS\tTEST_" + "\tTEST_".join(test_eval_result.log_header.split("\t")))
+
+                            lr_info = ",".join([f"{lr:.4f}" for lr in current_learning_rate])
+
+                            bad_epoch_info = "\t" + str(bad_epochs) if log_bad_epochs else ""
+                            f.write(
+                                f"\n{epoch}\t{datetime.datetime.now():%H:%M:%S}"
+                                f"{bad_epoch_info}"
+                                f"\t{lr_info}\t{train_loss}"
+                            )
+                            f.write(result_line)
+
+                    # if checkpoint is enabled, save model at each epoch
+                    if checkpoint and not param_selection_mode:
+                        self.model.save(base_path / "checkpoint.pt", checkpoint=True)
+
+                    # Check whether to save best model
+                    if (
+                        (not train_with_dev or anneal_with_restarts or anneal_with_prestarts)
+                        and not param_selection_mode
+                        and current_epoch_has_best_model_so_far
+                        and not use_final_model_for_eval
+                    ):
+                        log.info("saving best model")
+                        self.model.save(base_path / "best-model.pt", checkpoint=save_optimizer_state)
+
+                        if anneal_with_prestarts:
+                            current_state_dict = self.model.state_dict()
+                            self.model.load_state_dict(last_epoch_model_state_dict)
+                            self.model.save(base_path / "pre-best-model.pt")
+                            self.model.load_state_dict(current_state_dict)
+
+                if use_swa:
+                    import torchcontrib
+
+                    cast(torchcontrib.optim.SWA, optimizer_instance).swap_swa_sgd()
+
+                # if we do not use dev data for model selection, save final model
+                if save_final_model and not param_selection_mode:
+                    self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
+
+            except KeyboardInterrupt:
+                log_line(log)
+                log.info("Exiting from training early.")
+
+                if not param_selection_mode:
+                    log.info("Saving model ...")
+                    self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
+                    log.info("Done.")
+            except Exception:
+                if create_file_logs:
+                    log_handler.close()
+                    log.removeHandler(log_handler)
+                raise
+            finally:
+                if use_tensorboard:
+                    writer.close()
+            optimizer_instance.zero_grad(set_to_none=True)
+            del optimizer_instance
+
+            # test best model if test data is present
+            if self.corpus.test and not train_with_test:
+                final_score = self.final_test(
+                    base_path=base_path,
+                    eval_mini_batch_size=eval_batch_size,
+                    num_workers=num_workers,
+                    main_evaluation_metric=main_evaluation_metric,
+                    gold_label_dictionary_for_eval=gold_label_dictionary_for_eval,
+                    exclude_labels=exclude_labels,
+                )
+            else:
+                final_score = 0
+                log.info("Test data not provided setting final score to 0")
         if reduce_transformer_vocab:
-            if save_final_model and not param_selection_mode:
+            if (base_path / "best-model.pt").exists():
+                self.model.save(base_path / "best-model.pt")
+            elif save_final_model and not param_selection_mode:
                 self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
 
         if create_file_logs:

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -444,7 +444,9 @@ class ModelTrainer:
 
                 previous_learning_rate = current_learning_rate
 
-                momentum = [group["momentum"] if "momentum" in group else 0 for group in optimizer_instance.param_groups]
+                momentum = [
+                    group["momentum"] if "momentum" in group else 0 for group in optimizer_instance.param_groups
+                ]
 
                 for epoch in range(epoch + 1, max_epochs + 1):
                     log_line(log)
@@ -464,7 +466,9 @@ class ModelTrainer:
                     # get new learning rate
                     current_learning_rate = [group["lr"] for group in optimizer_instance.param_groups]
 
-                    lr_changed = any([lr != prev_lr for lr, prev_lr in zip(current_learning_rate, previous_learning_rate)])
+                    lr_changed = any(
+                        [lr != prev_lr for lr, prev_lr in zip(current_learning_rate, previous_learning_rate)]
+                    )
 
                     if lr_changed and batch_growth_annealing:
                         mini_batch_size *= 2
@@ -490,7 +494,9 @@ class ModelTrainer:
                             for i, lr in enumerate(current_learning_rate):
                                 writer.add_scalar(f"learning_rate_{i}", lr, epoch)
 
-                    all_lrs_too_small = all([lr < min_lr for lr, min_lr in zip(current_learning_rate, min_learning_rate)])
+                    all_lrs_too_small = all(
+                        [lr < min_lr for lr, min_lr in zip(current_learning_rate, min_learning_rate)]
+                    )
 
                     # stop training if learning rate becomes too small
                     if not isinstance(scheduler, (OneCycleLR, LinearSchedulerWithWarmup)) and all_lrs_too_small:
@@ -533,7 +539,9 @@ class ModelTrainer:
                         # if necessary, make batch_steps
                         batch_steps = [batch]
                         if len(batch) > micro_batch_size:
-                            batch_steps = [batch[x : x + micro_batch_size] for x in range(0, len(batch), micro_batch_size)]
+                            batch_steps = [
+                                batch[x : x + micro_batch_size] for x in range(0, len(batch), micro_batch_size)
+                            ]
 
                         # forward and backward for batch
                         for batch_step in batch_steps:
@@ -580,7 +588,9 @@ class ModelTrainer:
 
                             lr_info = ",".join([f"{lr:.6f}" for lr in current_learning_rate])
 
-                            intermittent_loss = train_loss / average_over if average_over > 0 else train_loss / seen_batches
+                            intermittent_loss = (
+                                train_loss / average_over if average_over > 0 else train_loss / seen_batches
+                            )
                             end_time = time.time()
                             log.info(
                                 f"epoch {epoch}"
@@ -816,7 +826,9 @@ class ModelTrainer:
                                     f.write("\tDEV_LOSS\tDEV_" + "\tDEV_".join(dev_eval_result.log_header.split("\t")))
 
                                 if log_test:
-                                    f.write("\tTEST_LOSS\tTEST_" + "\tTEST_".join(test_eval_result.log_header.split("\t")))
+                                    f.write(
+                                        "\tTEST_LOSS\tTEST_" + "\tTEST_".join(test_eval_result.log_header.split("\t"))
+                                    )
 
                             lr_info = ",".join([f"{lr:.4f}" for lr in current_learning_rate])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ more-itertools
 wikipedia-api
 pptree
 pytorch_revgrad
-transformer-smaller-training-vocab>=0.2.0
+transformer-smaller-training-vocab>=0.2.1

--- a/resources/docs/TUTORIAL_TRAINING_MORE.md
+++ b/resources/docs/TUTORIAL_TRAINING_MORE.md
@@ -118,3 +118,10 @@ can have one of three values:
    CUDA memory is often limited so large datasets will not fit into CUDA memory. However, if the dataset fits into CUDA
    memory, this option is the fastest one.
 
+### Reducing the memory food-print when using Transformers
+
+Especially when you use multilingual transformer embeddings such as [xlm-roberta-large](https://huggingface.co/xlm-roberta-large) or [xlm-v-base](facebook/xlm-v-base),
+you will notice, that those models contain plenty of tokens that are not contained in your training dataset.
+[transformer-smaller-training-vocab](https://github.com/helpmefindaname/transformer-smaller-training-vocab) is a library that temporarily reduces the vocabulary during training,
+and inserts the removed vocabulary again afterwards for consistent inference. Having the reduced vocabulary leads to less requirements in GPU-memory and it can lead to a faster training.
+The `ModelTrainer` integrates this library, all you need to do is to set the `reduce_transformer_vocab` parameter of the `train()` method to `True`


### PR DESCRIPTION
this PR fixes the usage of the transformer smaller training vocab and improves documentation:

* fix that transformer smaller training vocab are actually used for training and not just temporarily reduce the vocab size before the training starts.
* enforce using a newer version of the library. There are 2 changes:
  * embedding-parameters that are not trainable, but present in the optimizer, will now be rightfully kept not trainable. Hence, running `embeddings.model.embeddings.word_embeddings.requires_grad_(False)` before training will work with `reduce=True`.
  * The config rightfully sets the vocab size and therefore reduced models can be saved and later loaded as such.
* the transformer smaller training vocab is now documented in the tutorials
* the onnx tutorial is now slightly improved to fit the newer structure