### PR TITLE
gather dev and test labels if the dataset is available

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1446,6 +1446,12 @@ class Corpus(typing.Generic[T_co]):
         assert self.train
         datasets = [self.train]
 
+        if self.dev is not None:
+            datasets.append(self.dev)
+
+        if self.test is not None:
+            datasets.append(self.test)
+
         data: ConcatDataset = ConcatDataset(datasets)
 
         log.info("Computing label dictionary. Progress:")


### PR DESCRIPTION
training a model on a dataset where some classes have low examples can lead to errors if a class is only available in the test or dev set but not the training test