### PR TITLE
GH-3166: add comments and one-sided dropout

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -620,7 +620,6 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         return sentence_tokens, offsets, lengths
 
     def _expand_sentence_with_context(self, sentence) -> Tuple[List[Token], int]:
-
         # fields to store left and right context
         left_context = []
         right_context = []


### PR DESCRIPTION
This PR makes slight modifications to the behavior of context dropout in context expansion in TransformerEmbeddings: 
- the` [FLERT]` token is now always added, even when context is dropped
- context dropout is applied to left and right context independently
- more comments in the code