### PR TITLE
Add stacklevel to log_line in order to display correct file and line number

### DIFF
--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -352,7 +352,7 @@ def convert_labels_to_one_hot(label_list: List[List[str]], label_dict: Dictionar
 
 
 def log_line(log):
-    log.info("-" * 100)
+    log.info("-" * 100, stacklevel=3)
 
 
 def add_file_handler(log, output_file):


### PR DESCRIPTION
Probably not relevant in most use cases, but if the flair log is used with a format containing the file, line number, or function name, the resulting line of log_line refers to the `log_line` function itself. Instead, it should refer to the place in the code where `log_line` is called. This can be fixed using `stacklevel`.

The following code demonstrates the stacklevel behavior (stacklevel <= 1 is in the logging module and will be ignored, stacklevel=2 refers to the log_line function, stacklevel=3 refers to the correct caller).


```python
import logging


def log_line(stacklevel):
    logging.info("Stacklevel=%d", stacklevel, stacklevel=stacklevel)


def actual_caller(stacklevel):
    log_line(stacklevel)


if __name__ == "__main__":
    logging.basicConfig(
        format="%(levelname)-8s %(filename)s:%(lineno)d [%(funcName)s] %(message)s", level=logging.INFO
    )

    for i in range(1, 5):
        actual_caller(stacklevel=i)
```

Output:

```
INFO     main.py:5 [log_line] Stacklevel=1
INFO     main.py:5 [log_line] Stacklevel=2
INFO     main.py:9 [actual_caller] Stacklevel=3
INFO     main.py:18 [<module>] Stacklevel=4
```