### PR TITLE
Add stacklevel to log_line in order to display correct file and line number (backwards compatible)

### DIFF
--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import sys
 from collections import defaultdict
 from enum import Enum
 from functools import reduce
@@ -352,7 +353,10 @@ def convert_labels_to_one_hot(label_list: List[List[str]], label_dict: Dictionar
 
 
 def log_line(log):
-    log.info("-" * 100, stacklevel=3)
+    if sys.version_info >= (3, 8):
+        log.info("-" * 100, stacklevel=3)
+    else:
+        log.info("-" * 100)
 
 
 def add_file_handler(log, output_file):


### PR DESCRIPTION
Same as GH-3170, but checks if the python version is >= 3.8 first.