### PR TITLE
unpin gdown dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ langdetect
 lxml
 ftfy
 janome
-gdown==4.4.0
+gdown>=4.4.0
 huggingface-hub>=0.10.0
 conllu>=4.0
 more-itertools


### PR DESCRIPTION
I don't thing there is a reason why gdown is pinned to a specific version, however the version 4.4.0 imports `pkg_resources` which leads to a deprecation warning.