### PR TITLE
github: bug report description should be textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
-  - type: input
+  - type: textarea
     id: description
     attributes:
       label: Describe the bug
@@ -32,7 +32,7 @@ body:
   - type: textarea
     id: expectation
     attributes:
-      label: Expected behaivor
+      label: Expected behavior
       description: A clear and concise description of what you expected to happen.
     validations:
       required: true


### PR DESCRIPTION
Hi,

for the current description of a bug report, only one line of text is currently possible:

![image](https://user-images.githubusercontent.com/20651387/229479666-afa20a47-4e44-4d2e-8259-63b8850c60b3.png)

This is very short, so this PR changes the input text to a text area.