### PR TITLE
get_spans_from_bio: Start new span for previous S- if class also changed

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1769,7 +1769,7 @@ def get_spans_from_bio(bioes_tags: List[str], bioes_scores=None) -> List[typing.
     # return complex list
     found_spans = []
     # internal variables
-    current_tag_weights: Dict[str, float] = defaultdict(lambda: 0.0)
+    current_tag_weights: Dict[str, float] = {}
     previous_tag = "O-"
     current_span: List[int] = []
     current_span_scores: List[float] = []
@@ -1785,7 +1785,7 @@ def get_spans_from_bio(bioes_tags: List[str], bioes_scores=None) -> List[typing.
         starts_new_span = False
 
         # begin and single tags start new spans
-        if bioes_tag[0:2] in ["B-", "S-"]:
+        if bioes_tag[0:2] in {"B-", "S-"}:
             starts_new_span = True
 
         # in IOB format, an I tag starts a span if it follows an O or is a different span
@@ -1793,7 +1793,10 @@ def get_spans_from_bio(bioes_tags: List[str], bioes_scores=None) -> List[typing.
             starts_new_span = True
 
         # single tags that change prediction start new spans
-        if bioes_tag[0:2] in ["S-"] and previous_tag[2:] != bioes_tag[2:]:
+        if bioes_tag[0:2] == "S-" and previous_tag[2:] != bioes_tag[2:]:
+            starts_new_span = True
+
+        if previous_tag[0:2] == "S-" and previous_tag[2:] != bioes_tag[2:] and in_span:
             starts_new_span = True
 
         # if an existing span is ended (either by reaching O or starting a new span)
@@ -1808,13 +1811,13 @@ def get_spans_from_bio(bioes_tags: List[str], bioes_scores=None) -> List[typing.
             # reset for-loop variables for new span
             current_span = []
             current_span_scores = []
-            current_tag_weights = defaultdict(lambda: 0.0)
+            current_tag_weights = {}
 
         if in_span:
             current_span.append(idx)
             current_span_scores.append(bioes_scores[idx] if bioes_scores else 1.0)
             weight = 1.1 if starts_new_span else 1.0
-            current_tag_weights[bioes_tag[2:]] += weight
+            current_tag_weights[bioes_tag[2:]] = current_tag_weights.setdefault(bioes_tag[2:], 0.0) + weight
 
         # remember previous tag
         previous_tag = bioes_tag

--- a/flair/data.py
+++ b/flair/data.py
@@ -1779,25 +1779,18 @@ def get_spans_from_bio(bioes_tags: List[str], bioes_scores=None) -> List[typing.
             bioes_tag = "O-"
 
         # anything that is not OUT is IN
-        in_span = False if bioes_tag == "O-" else True
+        in_span = bioes_tag != "O-"
 
         # does this prediction start a new span?
         starts_new_span = False
 
         # begin and single tags start new spans
-        if bioes_tag[0:2] in {"B-", "S-"}:
+        if bioes_tag[:2] in {"B-", "S-"}:
             starts_new_span = True
-
-        # in IOB format, an I tag starts a span if it follows an O or is a different span
-        if bioes_tag[0:2] == "I-" and previous_tag[2:] != bioes_tag[2:]:
-            starts_new_span = True
-
-        # single tags that change prediction start new spans
-        if bioes_tag[0:2] == "S-" and previous_tag[2:] != bioes_tag[2:]:
-            starts_new_span = True
-
-        if previous_tag[0:2] == "S-" and previous_tag[2:] != bioes_tag[2:] and in_span:
-            starts_new_span = True
+        elif in_span and previous_tag[2:] != bioes_tag[2:]:  # predicted class changed
+            # If the current tag is I- or the previous tag was S-, we start a new span
+            if bioes_tag[:2] == "I-" or previous_tag[2:] == "S-":
+                starts_new_span = True
 
         # if an existing span is ended (either by reaching O or starting a new span)
         if (starts_new_span or not in_span) and len(current_span) > 0:


### PR DESCRIPTION
In previous flair versions (e.g. 0.10) get_span_from_bio would start a new span if the previous tag was a "S-" token of a different class than the current token, see:
https://github.com/flairNLP/flair/blob/v0.10/flair/data.py#L698

 It happens that our production model semi-frequently produces these kinds of (invalid BIOES) prediction, and that the new span extraction performs worse on our data.
This adds back this special check for previous tag "S-", making span calculation more similar to what it was in 0.10, and remaining the same for all 100% valid BIOES tagging.

Also included are some minor code tweaks to the function to make it prettier.