### PR TITLE
Allow users to use no scheduler and use a custom scheduling plugin

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -188,6 +188,7 @@ class ModelTrainer(Pluggable):
             "min_learning_rate",
             "initial_extra_patience",
             "anneal_with_restarts",
+            "attach_default_scheduler",
             "kwargs",
         ]:
             local_variables.pop(var)

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -160,21 +160,24 @@ class ModelTrainer(Pluggable):
         write_weights: bool = False,
         # plugins
         plugins: List[TrainerPlugin] = None,
+        attach_default_scheduler: bool = True,
         **kwargs,
     ):
-        # activate annealing plugin
         if plugins is None:
             plugins = []
-        plugins.append(
-            AnnealingPlugin(
-                base_path=base_path,
-                anneal_factor=anneal_factor,
-                patience=patience,
-                min_learning_rate=min_learning_rate,
-                initial_extra_patience=initial_extra_patience,
-                anneal_with_restarts=anneal_with_restarts,
+
+        if attach_default_scheduler:
+            # activate annealing plugin
+            plugins.append(
+                AnnealingPlugin(
+                    base_path=base_path,
+                    anneal_factor=anneal_factor,
+                    patience=patience,
+                    min_learning_rate=min_learning_rate,
+                    initial_extra_patience=initial_extra_patience,
+                    anneal_with_restarts=anneal_with_restarts,
+                )
             )
-        )
 
         # call self.train_custom with all parameters (minus the ones specific to the AnnealingPlugin)
         local_variables = locals()
@@ -228,12 +231,15 @@ class ModelTrainer(Pluggable):
         write_weights: bool = False,
         # plugins
         plugins: List[TrainerPlugin] = None,
+        attach_default_scheduler: bool = True,
         **kwargs,
     ):
         # annealing logic
         if plugins is None:
             plugins = []
-        plugins.append(LinearSchedulerPlugin(warmup_fraction=warmup_fraction))
+
+        if attach_default_scheduler:
+            plugins.append(LinearSchedulerPlugin(warmup_fraction=warmup_fraction))
 
         return self.train_custom(
             base_path=base_path,


### PR DESCRIPTION
This PR introduces a flag (`attach_default_scheduler`) in the methods `fine_tune` and `train` of the trainer in order to allow the user to

1. use no scheduler when training or finetuning, and
2. use a custom scheduler plugin (at the moment, a passed scheduling plugin would be added on top of the default scheduler),

while still using the other defaults of these functions.