### PR TITLE
TokenClassifier model

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -127,6 +127,14 @@ class Dictionary:
         self.add_item("<START>")
         self.add_item("<STOP>")
 
+    def is_span_prediction_problem(self) -> bool:
+        if self.span_labels:
+            return True
+        for item in self.get_items():
+            if item.startswith("B-") or item.startswith("S-") or item.startswith("I-"):
+                return True
+        return False
+
     def start_stop_tags_are_set(self):
         if {"<START>".encode(), "<STOP>".encode()}.issubset(self.item2idx.keys()):
             return True

--- a/flair/data.py
+++ b/flair/data.py
@@ -1475,7 +1475,6 @@ class Corpus(typing.Generic[T_co]):
         datapoint_type = None
         for sentence in Tqdm.tqdm(_iter_dataset(data)):
             labels = sentence.get_labels(label_type)
-            print(labels)
             for label in labels:
                 datapoint_type = type(label.data_point)
             if datapoint_type:

--- a/flair/data.py
+++ b/flair/data.py
@@ -1441,14 +1441,15 @@ class Corpus(typing.Generic[T_co]):
         )
 
     def make_label_dictionary(
-        self, label_type: str, min_count: int = -1, add_unk: bool = True, add_dev_test: bool = False
+        self, label_type: str, min_count: int = -1, add_unk: bool = False, add_dev_test: bool = False
     ) -> Dictionary:
         """
         Creates a dictionary of all labels assigned to the sentences in the corpus.
         :return: dictionary of labels
         """
         if min_count > 0 and not add_unk:
-            raise ValueError("Cannot require a minimum count if no unk-token is created.")
+            add_unk = True
+            log.info("Adding <unk>-token to dictionary since min_count is set.")
 
         label_dictionary: Dictionary = Dictionary(add_unk=add_unk)
         label_dictionary.span_labels = False
@@ -1469,6 +1470,20 @@ class Corpus(typing.Generic[T_co]):
         sentence_label_type_counter: typing.Counter[str] = Counter()
         label_value_counter: typing.Counter[str] = Counter()
         all_sentence_labels: List[str] = []
+
+        # first, determine the datapoint type by going through dataset until first label is found
+        datapoint_type = None
+        for sentence in Tqdm.tqdm(_iter_dataset(data)):
+            labels = sentence.get_labels(label_type)
+            print(labels)
+            for label in labels:
+                datapoint_type = type(label.data_point)
+            if datapoint_type:
+                break
+
+        if datapoint_type == Span:
+            label_dictionary.span_labels = True
+
         for sentence in Tqdm.tqdm(_iter_dataset(data)):
             # count all label types per sentence
             sentence_label_type_counter.update(sentence.annotation_layers.keys())
@@ -1476,12 +1491,10 @@ class Corpus(typing.Generic[T_co]):
             # go through all labels of label_type and count values
             labels = sentence.get_labels(label_type)
             label_value_counter.update(label.value for label in labels if label.value not in all_sentence_labels)
-            if not label_dictionary.span_labels:
-                for label in labels:
-                    # check if there are any span labels
-                    if type(label.data_point) == Span and len(label.data_point) > 1:
-                        label_dictionary.span_labels = True
-                        break
+
+            # special handling for Token-level annotations. Add all untagged as 'O' label
+            if datapoint_type == Token and len(sentence) > len(labels):
+                label_value_counter["O"] += len(sentence) - len(labels)
 
             if not label_dictionary.multi_label:
                 if len(labels) > 1:

--- a/flair/models/__init__.py
+++ b/flair/models/__init__.py
@@ -11,7 +11,7 @@ from .sequence_tagger_model import SequenceTagger
 from .tars_model import FewshotClassifier, TARSClassifier, TARSTagger
 from .text_classification_model import TextClassifier
 from .text_regression_model import TextRegressor
-from .word_tagger_model import WordTagger
+from .word_tagger_model import TokenClassifier
 
 __all__ = [
     "EntityLinker",
@@ -22,7 +22,7 @@ __all__ = [
     "RelationExtractor",
     "RegexpTagger",
     "SequenceTagger",
-    "WordTagger",
+    "TokenClassifier",
     "FewshotClassifier",
     "TARSClassifier",
     "TARSTagger",

--- a/flair/models/__init__.py
+++ b/flair/models/__init__.py
@@ -11,7 +11,7 @@ from .sequence_tagger_model import SequenceTagger
 from .tars_model import FewshotClassifier, TARSClassifier, TARSTagger
 from .text_classification_model import TextClassifier
 from .text_regression_model import TextRegressor
-from .word_tagger_model import TokenClassifier
+from .word_tagger_model import TokenClassifier, WordTagger
 
 __all__ = [
     "EntityLinker",
@@ -23,6 +23,7 @@ __all__ = [
     "RegexpTagger",
     "SequenceTagger",
     "TokenClassifier",
+    "WordTagger",
     "FewshotClassifier",
     "TARSClassifier",
     "TARSTagger",

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -11,6 +11,15 @@ from flair.embeddings import TokenEmbeddings
 log = logging.getLogger("flair")
 
 
+def WordTagger(embeddings, tag_dictionary, tag_type, **classifierargs):
+    from warnings import warn
+
+    warn("The WordTagger class is deprecated after Flair version 0.12.2. Use TokenClassifier instead!")
+    return TokenClassifier(
+        embeddings=embeddings, label_dictionary=tag_dictionary, label_type=tag_type, **classifierargs
+    )
+
+
 class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
     """This is a simple class of models that tags individual words in text."""
 

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -146,8 +146,8 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
 
                     # if an existing span is ended (either by reaching O or starting a new span)
                     if (starts_new_span or not in_span) and len(current_span) > 0:
-                        # reset for-loop variables for new span
                         sentence[current_span[0].idx - 1: current_span[-1].idx].set_label(label_name, previous_tag[2:])
+                        # reset for-loop variables for new span
                         current_span = []
 
                     if in_span:
@@ -158,6 +158,10 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
 
                     token.remove_labels(label_name)
                     token.remove_labels(self.label_type)
+
+                # if there is a span at end of sentence, add it
+                if len(current_span) > 0:
+                    sentence[current_span[0].idx - 1: current_span[-1].idx].set_label(label_name, previous_tag[2:])
 
     @property
     def label_type(self):

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -22,7 +22,7 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
         span_encoding: str = "BIOES",
         **classifierargs,
     ):
-        """Initializes a TokenClassifier
+        """Initializes a TokenClassifier.
 
         :param embeddings: word embeddings used in tagger
         :param tag_dictionary: dictionary of tags you want to predict

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -5,13 +5,13 @@ from typing import Any, Dict, List, Union
 import torch
 
 import flair.nn
-from flair.data import Dictionary, Sentence, Token
+from flair.data import Dictionary, Sentence, Span, Token
 from flair.embeddings import TokenEmbeddings
 
 log = logging.getLogger("flair")
 
 
-class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
+class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
     """
     This is a simple class of models that tags individual words in text.
     """
@@ -19,36 +19,69 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
     def __init__(
         self,
         embeddings: TokenEmbeddings,
-        tag_dictionary: Dictionary,
-        tag_type: str,
+        label_dictionary: Dictionary,
+        label_type: str,
+        span_encoding: str = "BIOES",
         **classifierargs,
     ):
         """
-        Initializes a WordTagger
+        Initializes a TokenClassifier
         :param embeddings: word embeddings used in tagger
         :param tag_dictionary: dictionary of tags you want to predict
         :param tag_type: string identifier for tag type
-        :param beta: Parameter for F-beta score for evaluation and training annealing
         """
+        # if the classifier predicts BIO/BIOES span labels, the internal label dictionary must be computed
+        if label_dictionary.span_labels:
+            internal_label_dictionary = self._create_internal_label_dictionary(label_dictionary, span_encoding)
+        else:
+            internal_label_dictionary = label_dictionary
+
         super().__init__(
             embeddings=embeddings,
-            label_dictionary=tag_dictionary,
+            label_dictionary=internal_label_dictionary,
             final_embedding_size=embeddings.embedding_length,
             **classifierargs,
         )
 
-        # dictionaries
-        self.tag_type: str = tag_type
+        # fields in case this is a span-prediction problem
+        self.span_prediction_problem = self._determine_if_span_prediction_problem(internal_label_dictionary)
+        self.span_encoding = span_encoding
+
+        # the label type
+        self._label_type: str = label_type
 
         # all parameters will be pushed internally to the specified device
         self.to(flair.device)
+
+    def _create_internal_label_dictionary(self, label_dictionary, span_encoding):
+        internal_label_dictionary = Dictionary(add_unk=False)
+        for label in label_dictionary.get_items():
+            if label == "<unk>":
+                continue
+            internal_label_dictionary.add_item("O")
+            if span_encoding == "BIOES":
+                internal_label_dictionary.add_item("S-" + label)
+                internal_label_dictionary.add_item("B-" + label)
+                internal_label_dictionary.add_item("E-" + label)
+                internal_label_dictionary.add_item("I-" + label)
+            if span_encoding == "BIO":
+                internal_label_dictionary.add_item("B-" + label)
+                internal_label_dictionary.add_item("I-" + label)
+
+        return internal_label_dictionary
+
+    def _determine_if_span_prediction_problem(self, dictionary: Dictionary) -> bool:
+        for item in dictionary.get_items():
+            if item.startswith("B-") or item.startswith("S-") or item.startswith("I-"):
+                return True
+        return False
 
     def _get_state_dict(self):
         model_state = {
             **super()._get_state_dict(),
             "embeddings": self.embeddings.save_embeddings(use_state_dict=False),
-            "tag_dictionary": self.label_dictionary,
-            "tag_type": self.tag_type,
+            "label_dictionary": self.label_dictionary,
+            "label_type": self.label_type,
         }
         return model_state
 
@@ -57,8 +90,8 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
         return super()._init_model_with_state_dict(
             state,
             embeddings=state.get("embeddings"),
-            tag_dictionary=state.get("tag_dictionary"),
-            tag_type=state.get("tag_type"),
+            label_dictionary=state.get("label_dictionary"),
+            label_type=state.get("label_type"),
             **kwargs,
         )
 
@@ -67,28 +100,92 @@ class WordTagger(flair.nn.DefaultClassifier[Sentence, Token]):
         return prediction_data_point.get_embedding(names)
 
     def _get_data_points_from_sentence(self, sentence: Sentence) -> List[Token]:
+        # special handling during training if this is a span prediction problem
+        if self.training and self.span_prediction_problem:
+            for token in sentence.tokens:
+                token.set_label(self.label_type, "O")
+            for span in sentence.get_spans(self.label_type):
+                span_label = span.get_label(self.label_type).value
+                if len(span) == 1:
+                    span.tokens[0].set_label(self.label_type, "S-" + span_label)
+                else:
+                    for token in span.tokens:
+                        token.set_label(self.label_type, "I-" + span_label)
+                    span.tokens[0].set_label(self.label_type, "B-" + span_label)
+                    span.tokens[-1].set_label(self.label_type, "E-" + span_label)
+
         return sentence.tokens
+
+    def _post_process_batch_after_prediction(self, batch, label_name):
+        if self.span_prediction_problem:
+            for sentence in batch:
+                start = -1
+                for token in sentence:
+                    label = token.get_label(label_name).value
+                    if label.startswith("S-"):
+                        sentence[token.idx - 1 : token.idx].set_label(label_name, label[2:])
+                    if label.startswith("B-"):
+                        start = token.idx
+                    if label.startswith("E-") and start != -1:
+                        sentence[start - 1 : token.idx].set_label(label_name, label[2:])
+                        start = -1
+                    token.remove_labels(label_name)
+                    token.remove_labels(self.label_type)
 
     @property
     def label_type(self):
-        return self.tag_type
+        return self._label_type
 
     def _print_predictions(self, batch, gold_label_type):
         lines = []
-        for datapoint in batch:
-            # now print labels in CoNLL format
-            for token in datapoint:
-                eval_line = (
-                    f"{token.text} "
-                    f"{token.get_label(gold_label_type, 'O').value} "
-                    f"{token.get_label('predicted', 'O').value}\n"
-                )
-                lines.append(eval_line)
-            lines.append("\n")
+        if self.span_prediction_problem:
+            for datapoint in batch:
+                # all labels default to "O"
+                for token in datapoint:
+                    token.set_label("gold_bio", "O")
+                    token.set_label("predicted_bio", "O")
+
+                # set gold token-level
+                for gold_label in datapoint.get_labels(gold_label_type):
+                    gold_span: Span = gold_label.data_point
+                    prefix = "B-"
+                    for token in gold_span:
+                        token.set_label("gold_bio", prefix + gold_label.value)
+                        prefix = "I-"
+
+                # set predicted token-level
+                for predicted_label in datapoint.get_labels("predicted"):
+                    predicted_span: Span = predicted_label.data_point
+                    prefix = "B-"
+                    for token in predicted_span:
+                        token.set_label("predicted_bio", prefix + predicted_label.value)
+                        prefix = "I-"
+
+                # now print labels in CoNLL format
+                for token in datapoint:
+                    eval_line = (
+                        f"{token.text} "
+                        f"{token.get_label('gold_bio').value} "
+                        f"{token.get_label('predicted_bio').value}\n"
+                    )
+                    lines.append(eval_line)
+                lines.append("\n")
+
+        else:
+            for datapoint in batch:
+                # print labels in CoNLL format
+                for token in datapoint:
+                    eval_line = (
+                        f"{token.text} "
+                        f"{token.get_label(gold_label_type).value} "
+                        f"{token.get_label('predicted').value}\n"
+                    )
+                    lines.append(eval_line)
+                lines.append("\n")
         return lines
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "WordTagger":
+    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TokenClassifier":
         from typing import cast
 
-        return cast("WordTagger", super().load(model_path=model_path))
+        return cast("TokenClassifier", super().load(model_path=model_path))

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -14,17 +14,16 @@ log = logging.getLogger("flair")
 class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
     """This is a simple class of models that tags individual words in text."""
 
-
     def __init__(
-            self,
-            embeddings: TokenEmbeddings,
-            label_dictionary: Dictionary,
-            label_type: str,
-            span_encoding: str = "BIOES",
-            **classifierargs,
+        self,
+        embeddings: TokenEmbeddings,
+        label_dictionary: Dictionary,
+        label_type: str,
+        span_encoding: str = "BIOES",
+        **classifierargs,
     ):
         """Initializes a TokenClassifier
-        
+
         :param embeddings: word embeddings used in tagger
         :param tag_dictionary: dictionary of tags you want to predict
         :param tag_type: string identifier for tag type
@@ -145,7 +144,7 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
 
                     # if an existing span is ended (either by reaching O or starting a new span)
                     if (starts_new_span or not in_span) and len(current_span) > 0:
-                        sentence[current_span[0].idx - 1: current_span[-1].idx].set_label(label_name, previous_tag[2:])
+                        sentence[current_span[0].idx - 1 : current_span[-1].idx].set_label(label_name, previous_tag[2:])
                         # reset for-loop variables for new span
                         current_span = []
 
@@ -160,7 +159,7 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
 
                 # if there is a span at end of sentence, add it
                 if len(current_span) > 0:
-                    sentence[current_span[0].idx - 1: current_span[-1].idx].set_label(label_name, previous_tag[2:])
+                    sentence[current_span[0].idx - 1 : current_span[-1].idx].set_label(label_name, previous_tag[2:])
 
     @property
     def label_type(self):

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -17,12 +17,12 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
     """
 
     def __init__(
-        self,
-        embeddings: TokenEmbeddings,
-        label_dictionary: Dictionary,
-        label_type: str,
-        span_encoding: str = "BIOES",
-        **classifierargs,
+            self,
+            embeddings: TokenEmbeddings,
+            label_dictionary: Dictionary,
+            label_type: str,
+            span_encoding: str = "BIOES",
+            **classifierargs,
     ):
         """
         Initializes a TokenClassifier
@@ -119,16 +119,43 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
     def _post_process_batch_after_prediction(self, batch, label_name):
         if self.span_prediction_problem:
             for sentence in batch:
-                start = -1
+                # internal variables
+                previous_tag = "O-"
+                current_span: List[Token] = []
+
                 for token in sentence:
-                    label = token.get_label(label_name).value
-                    if label.startswith("S-"):
-                        sentence[token.idx - 1 : token.idx].set_label(label_name, label[2:])
-                    if label.startswith("B-"):
-                        start = token.idx
-                    if label.startswith("E-") and start != -1:
-                        sentence[start - 1 : token.idx].set_label(label_name, label[2:])
-                        start = -1
+                    bioes_tag = token.get_label(label_name).value
+
+                    # non-set tags are OUT tags
+                    if bioes_tag == "" or bioes_tag == "O" or bioes_tag == "_":
+                        bioes_tag = "O-"
+
+                    # anything that is not OUT is IN
+                    in_span = bioes_tag != "O-"
+
+                    # does this prediction start a new span?
+                    starts_new_span = False
+
+                    # begin and single tags start new spans
+                    if bioes_tag[:2] in {"B-", "S-"}:
+                        starts_new_span = True
+                    elif in_span and previous_tag[2:] != bioes_tag[2:]:  # predicted class changed
+                        # If the current tag is I- or the previous tag was S-, we start a new span
+                        if bioes_tag[:2] == "I-" or previous_tag[2:] == "S-":
+                            starts_new_span = True
+
+                    # if an existing span is ended (either by reaching O or starting a new span)
+                    if (starts_new_span or not in_span) and len(current_span) > 0:
+                        # reset for-loop variables for new span
+                        sentence[current_span[0].idx - 1: current_span[-1].idx].set_label(label_name, previous_tag[2:])
+                        current_span = []
+
+                    if in_span:
+                        current_span.append(token)
+
+                    # remember previous tag
+                    previous_tag = bioes_tag
+
                     token.remove_labels(label_name)
                     token.remove_labels(self.label_type)
 

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -538,7 +538,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
     flair.nn.Model. All features shared by all classifiers are implemented here,
     including the loss calculation and the predict() method. Currently, the
     TextClassifier, RelationExtractor, TextPairClassifier and
-    SimpleSequenceTagger implement this class.
+    TokenClassifier implement this class.
     """
 
     def __init__(
@@ -857,8 +857,13 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
 
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
+                self._post_process_batch_after_prediction(batch, label_name)
+
             if return_loss:
                 return overall_loss, label_count
+
+    def _post_process_batch_after_prediction(self, batch, label_name):
+        pass
 
     def _get_label_threshold(self, label_value):
         label_threshold = self.multi_label_threshold["default"]

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -892,8 +892,8 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
             if return_loss:
                 if has_unknown_label:
                     log.info(
-                        f"During evaluation, encountered labels that are not in the label_dictionary:"
-                        f"Evaluation loss is computed without them."
+                        "During evaluation, encountered labels that are not in the label_dictionary:"
+                        "Evaluation loss is computed without them."
                     )
                 return overall_loss, label_count
 

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -878,8 +878,8 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
                                     label_score = softmax[s_idx, l_idx].item()
                                     data_point.add_label(typename=label_name, value=label_value, score=label_score)
                         else:
-                            conf, idx = torch.max(softmax, dim=-1)
-                            for data_point, c, i in zip(data_points, conf, idx):
+                            conf, indices = torch.max(softmax, dim=-1)
+                            for data_point, c, i in zip(data_points, conf, indices):
                                 label_value = self.label_dictionary.get_item_for_index(i.item())
                                 if label_value == "O":
                                     continue

--- a/tests/models/test_word_tagger.py
+++ b/tests/models/test_word_tagger.py
@@ -28,8 +28,8 @@ class TestWordTagger(BaseModelTest):
                 del model_args[k]
         return self.model_cls(
             embeddings=embeddings,
-            tag_dictionary=label_dict,
-            tag_type=self.train_label_type,
+            label_dictionary=label_dict,
+            label_type=self.train_label_type,
             **model_args,
             **kwargs,
         )

--- a/tests/models/test_word_tagger.py
+++ b/tests/models/test_word_tagger.py
@@ -2,12 +2,12 @@ import pytest
 
 import flair
 from flair.embeddings import TransformerWordEmbeddings
-from flair.models import WordTagger
+from flair.models import TokenClassifier
 from tests.model_test_utils import BaseModelTest
 
 
 class TestWordTagger(BaseModelTest):
-    model_cls = WordTagger
+    model_cls = TokenClassifier
     train_label_type = "pos"
     training_args = dict(
         max_epochs=2,

--- a/tests/test_corpus_dictionary.py
+++ b/tests/test_corpus_dictionary.py
@@ -8,7 +8,7 @@ from flair.datasets import ColumnCorpus, FlairDatapointDataset, SentenceDataset
 
 
 def test_dictionary_get_items_with_unk():
-    dictionary: Dictionary = Dictionary()
+    dictionary: Dictionary = Dictionary(add_unk=True)
 
     dictionary.add_item("class_1")
     dictionary.add_item("class_2")

--- a/tests/test_corpus_dictionary.py
+++ b/tests/test_corpus_dictionary.py
@@ -150,7 +150,7 @@ def test_tagged_corpus_make_label_dictionary():
         FlairDatapointDataset([]),
     )
 
-    label_dict = corpus.make_label_dictionary("label")
+    label_dict = corpus.make_label_dictionary("label", add_unk=True)
 
     assert 3 == len(label_dict)
     assert "<unk>" in label_dict.get_items()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -627,7 +627,7 @@ def test_hipe_2022_corpus(tasks_base_path):
 
                     current_sents = stats["sents"]
                     current_docs = stats["docs"]
-                    current_labels = set(stats["labels"] + ["<unk>"])
+                    current_labels = set(stats["labels"])
 
                     total_sentences = current_sents + current_docs if add_document_separator else stats["sents"]
 
@@ -871,7 +871,7 @@ def test_ontonotes_extraction(tasks_base_path):
         corpus = ONTONOTES(base_path=tmp_dir)
         label_dictionary = corpus.make_label_dictionary("ner")
 
-        assert len(label_dictionary) == 15
+        assert len(label_dictionary) == 14
         assert label_dictionary.span_labels
 
         domain_specific_corpus = ONTONOTES(base_path=tmp_dir, domain=["bc"])


### PR DESCRIPTION
This PR introduces the `TokenClassifier` class, a renamed and extended version of `WordTagger`. It directly inherits from  `DefaultClassifier` and should be used for all token-level prediction tasks that do not require an LSTM-CRF decoder (for such tasks, the `SequenceTagger` should be used).

The main idea is to offer a model that inherits from `DefaultClassifier` for each label type we predict, i.e.:
- `TokenClassifier` for predicting `Token` labels
- `TextPairClassifier` for predicting `TextPair` labels
- `RelationClassifier` for predicting `Relation` labels
- `SpanClassifier` for predicting `Span` labels (this class is currently called `EntityLinker` and should be renamed)
- `TextClassifier` for predicting `Sentence` labels (might need to be renamed to SentenceClassifier)

An advantage of such a structure is that most functionality (such as new decoders) needs to only be implemented once in `DefaultClassifier` and then is immediately usable for all model classes.

Edit: This class also changes the default behavior of the make_label_dictionary method. The UNK token is no longer automatically added to a dictionary. We now skip unknown labels to handle loss computation in such cases.
