### PR TITLE
Include `flair/py.typed` and `requirements.txt` in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include flair/py.typed
+include requirements.txt


### PR DESCRIPTION
This PR fixes the following issues by including the `flair/py.typed` and `requirements.txt` in the source distribution (sdist):

- The `py.typed` file was added in #2858. Although the file was added to the repository, it is not present in the distributed package.
- The `requirements.txt` file was not included in [flair-0.12.2.tar.gz](https://files.pythonhosted.org/packages/4c/d2/05684b6296c332d51368047dd0b64930826b4ae2748cbb4080c33cf566ee/flair-0.12.2.tar.gz) on PyPI, which was causing issues when installing flair via the tarball. Closes #2759

This is done by including these files in the source distribution (`sdist`) by adding a [`MANIFEST.in`](https://packaging.python.org/guides/using-manifest-in/) file. To test that this works, git checkout this branch, and run:

```
python setup.py sdist
```

Then untar the `flair-0.12.2.tar.gz` file. You should see the `requirements.txt` and `py.typed` files inside. Confirm that things work by running the following command:

```
pip install flair-0.12.2.tar.gz
```

This should install the package and report:

```
Processing ./flair-0.12.2.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
[...]
Successfully built flair
Installing collected packages: flair
Successfully installed flair-0.12.2
```

