### PR TITLE
Fix loading of old models

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -337,10 +337,7 @@ class WordEmbeddings(TokenEmbeddings):
 
         word_indices: List[int] = []
         for token in tokens:
-            if self.field is None:
-                word = token.text
-            else:
-                word = token.get_label(self.field).value
+            word = token.text if self.field is None else token.get_label(self.field).value
             word_indices.append(self.get_cached_token_index(word))
 
         embeddings = self.embedding(torch.tensor(word_indices, dtype=torch.long, device=self.device))
@@ -1062,10 +1059,7 @@ class FastTextEmbeddings(TokenEmbeddings):
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
         for sentence in sentences:
             for token in sentence.tokens:
-                if self.field is None:
-                    word = token.text
-                else:
-                    word = token.get_label(self.field).value
+                word = token.text if self.field is None else token.get_label(self.field).value
 
                 word_embedding = self.get_cached_vec(word)
 


### PR DESCRIPTION
closes https://github.com/flairNLP/flair/issues/3216 

moves the "add default values for older embeddings" logic to the __setstate__ method and ensures, that the old WordEmbeddings will store the torch weights correctly on resave.