### PR TITLE
Fix loading of (not so) old models

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -1172,6 +1172,10 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
 
     @classmethod
     def from_params(cls, params):
+        params.pop("truncate", None)
+        params.pop("stride", None)
+        params.pop("embedding_length", None)
+        params.pop("use_lang_emb", None)
         params["use_context"] = params.pop("context_length", 0)
         config_state_dict = params.pop("config_state_dict", None)
         config = None


### PR DESCRIPTION
This MR fixes the loading of models like Zelda,
in general, this affects all models with transformer-embeddings that were created before https://github.com/flairNLP/flair/pull/3178 was merged, but after https://github.com/flairNLP/flair/pull/3011