### PR TITLE
gh-3243: support pickle & deepcopy

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1025,8 +1025,7 @@ class Sentence(DataPoint):
     def __getitem__(self, s: slice) -> Span: ...
 
     @typing.overload
-    def __getitem__(self, s: typing.Tuple[Span, Span]) -> Relation:
-        ...
+    def __getitem__(self, s: typing.Tuple[Span, Span]) -> Relation: ...
 
     def __getitem__(self, subscript):
         if isinstance(subscript, tuple):

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -22,7 +22,6 @@ from flair.data import (
     Corpus,
     FlairDataset,
     MultiCorpus,
-    Relation,
     Sentence,
     Token,
     get_spans_from_bio,
@@ -727,9 +726,7 @@ class ColumnDataset(FlairDataset):
                     tail_end = int(indices[3])
                     label = indices[4]
                     # head and tail span indices are 1-indexed and end index is inclusive
-                    relation = Relation(
-                        first=sentence[head_start - 1 : head_end], second=sentence[tail_start - 1 : tail_end]
-                    )
+                    relation = sentence[sentence[head_start - 1 : head_end], sentence[tail_start - 1 : tail_end]]
                     remapped = self._remap_label(label)
                     if remapped != "O":
                         relation.add_label(typename="relation", value=remapped)

--- a/flair/models/regexp_tagger.py
+++ b/flair/models/regexp_tagger.py
@@ -41,7 +41,7 @@ class TokenCollection:
         """
         span_start: int = self.__tokens_start_pos.index(span[0])
         span_end: int = self.__tokens_end_pos.index(span[1])
-        return Span(self.tokens[span_start : span_end + 1])
+        return self.sentence[span_start : span_end + 1]
 
 
 class RegexpTagger:

--- a/flair/models/relation_classifier_model.py
+++ b/flair/models/relation_classifier_model.py
@@ -387,7 +387,9 @@ class RelationClassifier(flair.nn.DefaultClassifier[EncodedSentence, EncodedSent
 
             # Obtain gold label, if existing
             gold_relation = sentence[head.span, tail.span]
-            gold_label: Optional[str] = gold_relation.get_label(self.label_type, zero_tag_value=None).value
+            gold_label: Optional[str] = gold_relation.get_label(self.label_type, zero_tag_value="O").value
+            if gold_label == "O":
+                gold_label = None
             yield head, tail, gold_label
 
     def _encode_sentence(

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -82,7 +82,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
                 ):
                     continue
 
-                relation = Relation(span_1, span_2)
+                relation = sentence[span_1, span_2]
                 if self.training and self.train_on_gold_pairs_only and relation.get_label(self.label_type).value == "O":
                     continue
                 entity_pairs.append(relation)

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -571,19 +571,16 @@ class TARSTagger(FewshotClassifier):
 
                         already_set_indices: list[int] = []
 
-                        sorted_x = sorted(all_detected.items(), key=operator.itemgetter(1))
-                        sorted_x.reverse()
-                        for tuple in sorted_x:
-                            # get the span and its label
-                            label = tuple[0]
-
+                        sorted_x = sorted(all_detected.items(), key=operator.itemgetter(1), reverse=True)
+                        for label, _ in sorted_x:
+                            span = typing.cast(Span, label.data_point)
                             label_length = (
                                 0 if not self.prefix else len(label.value.split(" ")) + len(self.separator.split(" "))
                             )
 
                             # determine whether tokens in this span already have a label
                             tag_this = True
-                            for token in label.data_point:
+                            for token in span:
                                 corresponding_token = sentence.get_token(token.idx - label_length)
                                 if corresponding_token is None:
                                     tag_this = False
@@ -595,8 +592,8 @@ class TARSTagger(FewshotClassifier):
                             # only add if all tokens have no label
                             if tag_this:
                                 # make and add a corresponding predicted span
-                                start_pos = label.data_point.data_point[0].idx - label_length - 1
-                                end_pos = label.data_point.data_point[-1].idx - label_length
+                                start_pos = span.tokens[0].idx - label_length - 1
+                                end_pos = span.tokens[-1].idx - label_length
 
                                 predicted_span = sentence[start_pos:end_pos]
                                 predicted_span.add_label(label_name, value=label.value, score=label.score)

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -412,10 +412,9 @@ class TARSTagger(FewshotClassifier):
 
         for entity_label in sentence.get_labels(self.label_type):
             if entity_label.value == label:
-                new_span = Span(
-                    [tars_sentence.get_token(token.idx + label_length) for token in entity_label.data_point]
-                )
-                new_span.add_label(self.static_label_type, value="entity")
+                start_pos = entity_label.data_point[0].idx + label_length - 1
+                end_pos = entity_label.data_point[-1].idx + label_length
+                tars_sentence[start_pos:end_pos].add_label(self.static_label_type, value="entity")
         tars_sentence.copy_context_from_sentence(sentence)
         return tars_sentence
 
@@ -596,9 +595,10 @@ class TARSTagger(FewshotClassifier):
                             # only add if all tokens have no label
                             if tag_this:
                                 # make and add a corresponding predicted span
-                                predicted_span = Span(
-                                    [sentence.get_token(token.idx - label_length) for token in label.data_point]
-                                )
+                                start_pos = label.data_point.data_point[0].idx - label_length - 1
+                                end_pos = label.data_point.data_point[-1].idx - label_length
+
+                                predicted_span = sentence[start_pos:end_pos]
                                 predicted_span.add_label(label_name, value=label.value, score=label.score)
 
                                 # set indices so that no token can be tagged twice

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -187,9 +187,9 @@ def test_relation_tags():
     sentence = Sentence("Humboldt Universität zu Berlin is located in Berlin .")
 
     # create two relation label
-    Relation(sentence[0:4], sentence[7:8]).add_label("rel", "located in")
-    Relation(sentence[0:2], sentence[3:4]).add_label("rel", "university of")
-    Relation(sentence[0:2], sentence[3:4]).add_label("syntactic", "apposition")
+    sentence[sentence[0:4], sentence[7:8]].add_label("rel", "located in")
+    sentence[sentence[0:2], sentence[3:4]].add_label("rel", "university of")
+    sentence[sentence[0:2], sentence[3:4]].add_label("syntactic", "apposition")
 
     # there should be two relation labels
     labels: list[Label] = sentence.get_labels("rel")

--- a/tests/test_sentence.py
+++ b/tests/test_sentence.py
@@ -1,3 +1,6 @@
+import copy
+import pickle
+
 from flair.data import Sentence
 
 
@@ -73,3 +76,37 @@ def test_start_end_position_pretokenized() -> None:
         (10, 18),
         (19, 20),
     ]
+
+
+def test_spans_support_deepcopy() -> None:
+    sentence = Sentence(["I", "live", "in", "Vienna", "."])
+    sentence[3:4].add_label("ner", "LOC")
+
+    _ = copy.deepcopy(sentence)
+
+
+def test_spans_support_pickle() -> None:
+    sentence = Sentence(["I", "live", "in", "Vienna", "."])
+    sentence[3:4].add_label("ner", "LOC")
+
+    pickle_data = pickle.dumps(sentence)
+    _ = pickle.loads(pickle_data)
+
+
+def test_relations_support_deepcopy() -> None:
+    sentence = Sentence(["Vienna", "is", "the", "capital", "of", "Austria"])
+    sentence[0:1].add_label("ner", "LOC")
+    sentence[5:6].add_label("ner", "LOC")
+    sentence[sentence[0:1], sentence[5:6]].add_label("rel", "capital")
+
+    _ = copy.deepcopy(sentence)
+
+
+def test_relations_support_pickle() -> None:
+    sentence = Sentence(["Vienna", "is", "the", "capital", "of", "Austria"])
+    sentence[0:1].add_label("ner", "LOC")
+    sentence[5:6].add_label("ner", "LOC")
+    sentence[sentence[0:1], sentence[5:6]].add_label("rel", "capital")
+
+    pickle_data = pickle.dumps(sentence)
+    _ = pickle.loads(pickle_data)


### PR DESCRIPTION
Closes gh-3243

A suggestion how we could support pickle and deepcopy without having to create multiple spans etc.

The idea is to use `__getitem__` to create spans and relations by indexing: `sentence[0:5]` to create a span, `sentence[span_a, span_b]` to create a relation.

Downside would be, that those who still instantiate `Span` or `Relation` manually, would receive unexpected results.

@dobbersc @alanakbik what do you think?