### PR TITLE
GH-3250: Save final model only if `save_final_model` is True (even if the training is interrupted)

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -703,8 +703,9 @@ class ModelTrainer(Pluggable):
 
             self.dispatch("training_interrupt")  # TODO: no plugin calls this event
 
-            log.info("Saving model ...")
-            self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
+            if save_final_model:
+                log.info("Saving model ...")
+                self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
             log.info("Done.")
 
         except TrainingInterrupt as exc:
@@ -713,8 +714,9 @@ class ModelTrainer(Pluggable):
             log_line(log)
             self.dispatch("training_interrupt")  # TODO: no plugin calls this event
 
-            log.info("Saving model ...")
-            self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
+            if save_final_model:
+                log.info("Saving model ...")
+                self.model.save(base_path / "final-model.pt", checkpoint=save_optimizer_state)
             log.info("Done.")
 
         except Exception:


### PR DESCRIPTION
`ModelTrainer` should only save `final-model.pt` if the respective flag is True (regardless of the reason the training ended (see #3250).