### PR TITLE
GH-3284 prevent using transformers 4.31.0 and lint

### DIFF
--- a/flair/embeddings/image.py
+++ b/flair/embeddings/image.py
@@ -73,7 +73,7 @@ class PrecomputedImageEmbeddings(ImageEmbeddings):
     def __init__(self, url2tensor_dict, name) -> None:
         self.url2tensor_dict = url2tensor_dict
         self.name = name
-        self.__embedding_length = len(list(self.url2tensor_dict.values())[0])
+        self.__embedding_length = len(next(iter(self.url2tensor_dict.values())))
         self.static_embeddings = True
         super().__init__()
 

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -66,12 +66,7 @@ class MetricRegression:
         return self.mean_squared_error()
 
     def to_tsv(self):
-        return "{}\t{}\t{}\t{}".format(
-            self.mean_squared_error(),
-            self.mean_absolute_error(),
-            self.pearsonr(),
-            self.spearmanr(),
-        )
+        return f"{self.mean_squared_error()}\t{self.mean_absolute_error()}\t{self.pearsonr()}\t{self.spearmanr()}"
 
     @staticmethod
     def tsv_header(prefix=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ tabulate>=0.8.10
 torch>=1.5.0,!=1.8
 tqdm>=4.63.0
 transformer-smaller-training-vocab>=0.2.3
+transformers>=4.30.2,!=4.31.0
 transformers[sentencepiece]>=4.18.0,<5.0.0
 urllib3<2.0.0,>=1.0.0  # pin below 2 to make dependency resolution faster.
 wikipedia-api>=0.5.7


### PR DESCRIPTION
When the python environment is updated to use the latest version of transformers, SequenceTagger fails due to an unexpected key in state_dict:

Error(s) in loading state_dict for SequenceTagger:
	Unexpected key(s) in state_dict: "embeddings.model.embeddings.position_ids".

If I may, I would suggest to patch this issue by preventing transformers 4.31.0 to be used until a fix is released ?

Other changes were made by linter (`black . && ruff --fix .`).