### PR TITLE
Extend German LER Dataset

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -2592,7 +2592,7 @@ class NER_GERMAN_LEGAL(ColumnCorpus):
         ler_path = "https://raw.githubusercontent.com/elenanereiss/Legal-Entity-Recognition/master/data/"
 
         for split in ["train", "dev", "test"]:
-          cached_path(f"{ler_path}ler_{split}.conll", Path("datasets") / dataset_name)
+            cached_path(f"{ler_path}ler_{split}.conll", Path("datasets") / dataset_name)
 
         super().__init__(
             data_folder,

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -2577,7 +2577,6 @@ class NER_GERMAN_LEGAL(ColumnCorpus):
         :param base_path: Default is None, meaning that corpus gets auto-downloaded and loaded. You can override this
         to point to a different folder but typically this should not be necessary.
         :param in_memory: If True, keeps dataset in memory giving speedups in training. Not recommended due to heavy RAM usage.
-        :param document_as_sequence: If True, all sentences of a document are read into a single Sentence object
         """
         base_path = flair.cache_root / "datasets" if not base_path else Path(base_path)
 
@@ -2591,13 +2590,17 @@ class NER_GERMAN_LEGAL(ColumnCorpus):
 
         # download data if necessary
         ler_path = "https://raw.githubusercontent.com/elenanereiss/Legal-Entity-Recognition/master/data/"
-        cached_path(f"{ler_path}ler.conll", Path("datasets") / dataset_name)
+
+        for split in ["train", "dev", "test"]:
+          cached_path(f"{ler_path}ler_{split}.conll", Path("datasets") / dataset_name)
 
         super().__init__(
             data_folder,
             columns,
             in_memory=in_memory,
-            train_file="ler.conll",
+            train_file="ler_train.conll",
+            dev_file="ler_dev.conll",
+            test_file="ler_test.conll",
             **corpusargs,
         )
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -804,8 +804,8 @@ def test_german_ler_corpus(tasks_base_path):
 
     # Number of instances per dataset split are taken from https://huggingface.co/datasets/elenanereiss/german-ler
     assert len(corpus.train) == 53384, "Mismatch in number of sentences for train split"
-    assert len(corpus.dev) == 6666, "Mismatch in number of sentences for train split"
-    assert len(corpus.test) == 6673, "Mismatch in number of sentences for train split"
+    assert len(corpus.dev) == 6666, "Mismatch in number of sentences for dev split"
+    assert len(corpus.test) == 6673, "Mismatch in number of sentences for test split"
 
 
 def test_multi_file_jsonl_corpus_should_use_label_type(tasks_base_path):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -799,6 +799,15 @@ def test_nermud_corpus(tasks_base_path):
         check_number_sentences(len(corpus.dev), stats["dev"], "dev")
 
 
+def test_german_ler_corpus(tasks_base_path):
+    corpus = flair.datasets.NER_GERMAN_LEGAL()
+
+    # Number of instances per dataset split are taken from https://huggingface.co/datasets/elenanereiss/german-ler
+    assert len(corpus.train) == 53384, "Mismatch in number of sentences for train split"
+    assert len(corpus.dev) == 6666, "Mismatch in number of sentences for train split"
+    assert len(corpus.test) == 6673, "Mismatch in number of sentences for train split"
+
+
 def test_multi_file_jsonl_corpus_should_use_label_type(tasks_base_path):
     corpus = MultiFileJsonlCorpus(
         train_files=[tasks_base_path / "jsonl/train.jsonl"],


### PR DESCRIPTION
Hi,

recently, proper dataset splits for the German LER Dataset were introduced:

https://github.com/elenanereiss/Legal-Entity-Recognition/commit/eda16d35f2c174845c83005e35d23bab10cd7dad

I updated the `NER_GERMAN_LEGAL` dataset, so these newly introduced splits are used.

A basic unit test was also added that checks if number of instances for all dataset splits are identical with reported numbers (see e.g. [here](https://huggingface.co/datasets/elenanereiss/german-ler#data-splits)).