### PR TITLE
add action to remove Awaiting Response label when an response was made

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,11 @@
+on: issue_comment
+
+jobs:
+  issue_commented:
+    name: Issue comment
+    if: ${{ !github.event.issue.pull_request && github.event.issue.author == github.even.issue_comment.author }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: "Awaiting Response"


### PR DESCRIPTION
The basic Concept of the "Awaiting Response" label is:

* Whenever an issue requires more input or an additional check of the author, mark it with the "Awaiting Response"
* When looking for unhandled issues, add `-label:"Awaiting Response"`  to the filter

Whenever the Author responds again to the issue, the "Awaiting Response" label will be removed again