### PR TITLE
Add a convenience conversion for flair.device

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -486,6 +486,10 @@ class ModelTrainer(Pluggable):
         if epoch == 0:
             self.check_for_and_delete_previous_best_models(base_path)
 
+        # Sanity conversion: if flair.device was set as a string, convert to torch.device
+        if isinstance(flair.device, str):
+            flair.device = torch.device(flair.device)
+
         # -- AmpPlugin -> wraps with AMP
         # -- AnnealingPlugin -> initialize schedulers (requires instantiated optimizer)
         with contextlib.ExitStack() as context_stack:


### PR DESCRIPTION
A small fix to enable setting devices by string identifiers (`flair.device = 'cuda:1'`) again.