### PR TITLE
Add AGNews corpus

### DIFF
--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -108,6 +108,7 @@ from .document_classification import (
     GO_EMOTIONS,
     IMDB,
     NEWSGROUPS,
+    AGNEWS,
     SENTEVAL_CR,
     SENTEVAL_MPQA,
     SENTEVAL_MR,

--- a/flair/datasets/__init__.py
+++ b/flair/datasets/__init__.py
@@ -100,6 +100,7 @@ from .biomedical import (
 
 # Expose all document classification datasets
 from .document_classification import (
+    AGNEWS,
     AMAZON_REVIEWS,
     COMMUNICATIVE_FUNCTIONS,
     GERMEVAL_2018_OFFENSIVE_LANGUAGE,
@@ -108,7 +109,6 @@ from .document_classification import (
     GO_EMOTIONS,
     IMDB,
     NEWSGROUPS,
-    AGNEWS,
     SENTEVAL_CR,
     SENTEVAL_MPQA,
     SENTEVAL_MR,
@@ -315,6 +315,7 @@ __all__ = [
     "SentenceDataset",
     "MongoDataset",
     "StringDataset",
+    "AGNEWS",
     "ANAT_EM",
     "AZDZ",
     "BC2GM",

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -908,8 +908,7 @@ class NEWSGROUPS(ClassificationCorpus):
 
 
 class AGNEWS(ClassificationCorpus):
-    """
-    The AG's News Topic Classification Corpus, classifying news into 4 coarse-grained topics
+    """The AG's News Topic Classification Corpus, classifying news into 4 coarse-grained topics
     (World, Sports, Business, Sci/Tech).
     """
 
@@ -920,8 +919,7 @@ class AGNEWS(ClassificationCorpus):
         memory_mode="partial",
         **corpusargs,
     ):
-        """
-        Instantiates AGNews Classification Corpus with 4 classes.
+        """Instantiates AGNews Classification Corpus with 4 classes.
         :param base_path: Provide this only if you store the AGNEWS corpus in a specific folder, otherwise use default.
         :param tokenizer: Custom tokenizer to use (default is SpaceTokenizer)
         :param memory_mode: Set to 'partial' by default. Can also be 'full' or 'none'.
@@ -936,27 +934,27 @@ class AGNEWS(ClassificationCorpus):
         # download data from same source as in huggingface's implementations
         agnews_path = "https://raw.githubusercontent.com/mhjabreel/CharCnn_Keras/master/data/ag_news_csv/"
 
-        original_filenames = ["train.csv", "test.csv",'classes.txt']
+        original_filenames = ["train.csv", "test.csv", "classes.txt"]
         new_filenames = ["train.txt", "test.txt"]
-        
+
         for original_filename in original_filenames:
             cached_path(f"{agnews_path}{original_filename}", Path("datasets") / dataset_name / "original")
 
         data_file = data_folder / new_filenames[0]
         label_dict = []
         label_path = original_filenames[-1]
-        
-        #read label order
-        with open(data_folder / "original" / label_path, "rt") as f:
+
+        # read label order
+        with open(data_folder / "original" / label_path) as f:
             for line in f:
                 line = line.rstrip()
                 label_dict.append(line)
 
-        original_filenames=original_filenames[:-1]
+        original_filenames = original_filenames[:-1]
         if not data_file.is_file():
             for original_filename, new_filename in zip(original_filenames, new_filenames):
-                with open(data_folder / "original" / original_filename, "rt", encoding="utf-8") as open_fp:
-                    with open(data_folder / new_filename, "wt", encoding="utf-8") as write_fp:
+                with open(data_folder / "original" / original_filename, encoding="utf-8") as open_fp:
+                    with open(data_folder / new_filename, "w", encoding="utf-8") as write_fp:
                         csv_reader = csv.reader(
                             open_fp, quotechar='"', delimiter=",", quoting=csv.QUOTE_ALL, skipinitialspace=True
                         )
@@ -967,15 +965,13 @@ class AGNEWS(ClassificationCorpus):
                             label = int(label) - 1
                             text = " ".join((title, description))
 
-
                             new_label = "__label__"
                             new_label += label_dict[label]
 
                             write_fp.write(f"{new_label} {text}\n")
 
-        super(AGNEWS, self).__init__(
-            data_folder, label_type="topic", tokenizer=tokenizer, memory_mode=memory_mode, **corpusargs
-        )
+        super().__init__(data_folder, label_type="topic", tokenizer=tokenizer, memory_mode=memory_mode, **corpusargs)
+
 
 class STACKOVERFLOW(ClassificationCorpus):
     """Stackoverflow corpus classifying questions into one of 20 labels.

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -965,11 +965,10 @@ class AGNEWS(ClassificationCorpus):
                         label, title, description = row
                         # Original labels are [1, 2, 3, 4] -> ['World', 'Sports', 'Business', 'Sci/Tech']
                         # Re-map to [0, 1, 2, 3].
-                        label = int(label) - 1
                         text = " ".join((title, description))
 
                         new_label = "__label__"
-                        new_label += label_dict[label]
+                        new_label += label_dict[int(label) - 1]
 
                         write_fp.write(f"{new_label} {text}\n")
 

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -908,8 +908,9 @@ class NEWSGROUPS(ClassificationCorpus):
 
 
 class AGNEWS(ClassificationCorpus):
-    """The AG's News Topic Classification Corpus, classifying news into 4 coarse-grained topics
-    (World, Sports, Business, Sci/Tech).
+    """The AG's News Topic Classification Corpus, classifying news into 4 coarse-grained topics.
+
+    Labels: World, Sports, Business, Sci/Tech.
     """
 
     def __init__(
@@ -920,6 +921,7 @@ class AGNEWS(ClassificationCorpus):
         **corpusargs,
     ):
         """Instantiates AGNews Classification Corpus with 4 classes.
+
         :param base_path: Provide this only if you store the AGNEWS corpus in a specific folder, otherwise use default.
         :param tokenizer: Custom tokenizer to use (default is SpaceTokenizer)
         :param memory_mode: Set to 'partial' by default. Can also be 'full' or 'none'.
@@ -953,22 +955,23 @@ class AGNEWS(ClassificationCorpus):
         original_filenames = original_filenames[:-1]
         if not data_file.is_file():
             for original_filename, new_filename in zip(original_filenames, new_filenames):
-                with open(data_folder / "original" / original_filename, encoding="utf-8") as open_fp:
-                    with open(data_folder / new_filename, "w", encoding="utf-8") as write_fp:
-                        csv_reader = csv.reader(
-                            open_fp, quotechar='"', delimiter=",", quoting=csv.QUOTE_ALL, skipinitialspace=True
-                        )
-                        for id_, row in enumerate(csv_reader):
-                            label, title, description = row
-                            # Original labels are [1, 2, 3, 4] -> ['World', 'Sports', 'Business', 'Sci/Tech']
-                            # Re-map to [0, 1, 2, 3].
-                            label = int(label) - 1
-                            text = " ".join((title, description))
+                with open(data_folder / "original" / original_filename, encoding="utf-8") as open_fp, open(
+                    data_folder / new_filename, "w", encoding="utf-8"
+                ) as write_fp:
+                    csv_reader = csv.reader(
+                        open_fp, quotechar='"', delimiter=",", quoting=csv.QUOTE_ALL, skipinitialspace=True
+                    )
+                    for id_, row in enumerate(csv_reader):
+                        label, title, description = row
+                        # Original labels are [1, 2, 3, 4] -> ['World', 'Sports', 'Business', 'Sci/Tech']
+                        # Re-map to [0, 1, 2, 3].
+                        label = int(label) - 1
+                        text = " ".join((title, description))
 
-                            new_label = "__label__"
-                            new_label += label_dict[label]
+                        new_label = "__label__"
+                        new_label += label_dict[label]
 
-                            write_fp.write(f"{new_label} {text}\n")
+                        write_fp.write(f"{new_label} {text}\n")
 
         super().__init__(data_folder, label_type="topic", tokenizer=tokenizer, memory_mode=memory_mode, **corpusargs)
 

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -907,6 +907,76 @@ class NEWSGROUPS(ClassificationCorpus):
         super().__init__(data_folder, tokenizer=tokenizer, memory_mode=memory_mode, **corpusargs)
 
 
+class AGNEWS(ClassificationCorpus):
+    """
+    The AG's News Topic Classification Corpus, classifying news into 4 coarse-grained topics
+    (World, Sports, Business, Sci/Tech).
+    """
+
+    def __init__(
+        self,
+        base_path: Optional[Union[str, Path]] = None,
+        tokenizer: Union[bool, Tokenizer] = SpaceTokenizer(),
+        memory_mode="partial",
+        **corpusargs,
+    ):
+        """
+        Instantiates AGNews Classification Corpus with 4 classes.
+        :param base_path: Provide this only if you store the AGNEWS corpus in a specific folder, otherwise use default.
+        :param tokenizer: Custom tokenizer to use (default is SpaceTokenizer)
+        :param memory_mode: Set to 'partial' by default. Can also be 'full' or 'none'.
+        :param corpusargs: Other args for ClassificationCorpus.
+        """
+        base_path = flair.cache_root / "datasets" if not base_path else Path(base_path)
+
+        dataset_name = self.__class__.__name__.lower()
+
+        data_folder = base_path / dataset_name
+
+        # download data from same source as in huggingface's implementations
+        agnews_path = "https://raw.githubusercontent.com/mhjabreel/CharCnn_Keras/master/data/ag_news_csv/"
+
+        original_filenames = ["train.csv", "test.csv",'classes.txt']
+        new_filenames = ["train.txt", "test.txt"]
+        
+        for original_filename in original_filenames:
+            cached_path(f"{agnews_path}{original_filename}", Path("datasets") / dataset_name / "original")
+
+        data_file = data_folder / new_filenames[0]
+        label_dict = []
+        label_path = original_filenames[-1]
+        
+        #read label order
+        with open(data_folder / "original" / label_path, "rt") as f:
+            for line in f:
+                line = line.rstrip()
+                label_dict.append(line)
+
+        original_filenames=original_filenames[:-1]
+        if not data_file.is_file():
+            for original_filename, new_filename in zip(original_filenames, new_filenames):
+                with open(data_folder / "original" / original_filename, "rt", encoding="utf-8") as open_fp:
+                    with open(data_folder / new_filename, "wt", encoding="utf-8") as write_fp:
+                        csv_reader = csv.reader(
+                            open_fp, quotechar='"', delimiter=",", quoting=csv.QUOTE_ALL, skipinitialspace=True
+                        )
+                        for id_, row in enumerate(csv_reader):
+                            label, title, description = row
+                            # Original labels are [1, 2, 3, 4] -> ['World', 'Sports', 'Business', 'Sci/Tech']
+                            # Re-map to [0, 1, 2, 3].
+                            label = int(label) - 1
+                            text = " ".join((title, description))
+
+
+                            new_label = "__label__"
+                            new_label += label_dict[label]
+
+                            write_fp.write(f"{new_label} {text}\n")
+
+        super(AGNEWS, self).__init__(
+            data_folder, label_type="topic", tokenizer=tokenizer, memory_mode=memory_mode, **corpusargs
+        )
+
 class STACKOVERFLOW(ClassificationCorpus):
     """Stackoverflow corpus classifying questions into one of 20 labels.
 


### PR DESCRIPTION
This PR extends ```ClassificationCorpus``` to add support for the AGNews dataset (https://github.com/mhjabreel/CharCnn_Keras/tree/555590db4219b1243abb1918effd6a7425a2d75f/data/ag_news_csv).

#### Example usage: 

```
from flair.datasets import AGNEWS

corpus = AGNEWS()

print(corpus)
```