### PR TITLE
deps: relax version constraint for konoha

### DIFF
--- a/flair/tokenization.py
+++ b/flair/tokenization.py
@@ -159,7 +159,7 @@ class JapaneseTokenizer(Tokenizer):
             )
             log.warning('- Install konoha with "pip install konoha[{tokenizer_name}]"')
             log.warning('  - You can choose tokenizer from ["mecab", "janome", "sudachi"].')
-            log.warning("Note that we Flair support only konoha<5.0.0,>=4.0.0")
+            log.warning("Note that we Flair support only konoha<6.0.0")
             log.warning("-" * 100)
             sys.exit()
 

--- a/flair/tokenization.py
+++ b/flair/tokenization.py
@@ -159,7 +159,6 @@ class JapaneseTokenizer(Tokenizer):
             )
             log.warning('- Install konoha with "pip install konoha[{tokenizer_name}]"')
             log.warning('  - You can choose tokenizer from ["mecab", "janome", "sudachi"].')
-            log.warning("Note that we Flair support only konoha<6.0.0")
             log.warning("-" * 100)
             sys.exit()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black[jupyter]>=23.3.0
-konoha>=4.6.5,<5.0.0
+konoha<6.0.0
 mypy>=1.2.0
 pytest>=7.3.1
 pytest-black-ng>=0.4.1


### PR DESCRIPTION
This PR updates the version constraint for konoha.

I'm so sorry that I didn't notice the issue https://github.com/flairNLP/flair/issues/3059.
I updated konoha that removed the dependency for `importlib-metadata`, let me update `requirements-dev.txt`.

Now konoha only depends on `requests` with the support for Python3.8+ (https://github.com/himkt/konoha/blob/v5.5.2/pyproject.toml#L27).
So I think it can be safely used with flair and I update the requirements file.

And I have one question for dependency of `janome`. `janome` is only used in `JapaneseTokenizer`, which depends on `konoha`, therefore `janome` should be installed in the same place of `konoha`, I think. There are multiple options:

- (1) move `janome` to `requirements-dev.txt`
- (2) remove `janome` from `requirements.txt` and install with `konoha[janome]` (extras)
- (3) move `konoha` to `requirements.txt`
- (4) remove `konoha` from `requirements-dev.txt` and install `konoha` with `konoha[janome]` (extras)

I'd like to a maintainer's opinion.