### PR TITLE
deps: make janome optional

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 black[jupyter]>=23.3.0
-janome>=0.4.2
-konoha<6.0.0
+konoha[janome]<6.0.0
 mypy>=1.2.0
 pytest>=7.3.1
 pytest-black-ng>=0.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black[jupyter]>=23.3.0
+konoha[janome]<6.0.0
 mypy>=1.2.0
 pytest>=7.3.1
 pytest-black-ng>=0.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black[jupyter]>=23.3.0
+janome>=0.4.2
 konoha<6.0.0
 mypy>=1.2.0
 pytest>=7.3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 black[jupyter]>=23.3.0
-konoha[janome]<6.0.0
 mypy>=1.2.0
 pytest>=7.3.1
 pytest-black-ng>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ ftfy>=6.1.0
 gdown>=4.4.0
 gensim>=4.2.0
 huggingface-hub>=0.10.0
-janome>=0.4.2
 langdetect>=1.0.9
 lxml>=4.8.0
 matplotlib>=2.2.3


### PR DESCRIPTION
Make `janome` optional and install with `konoha` (for `JapaneseTokenizer`).
Based on the discussion https://github.com/flairNLP/flair/pull/3394#issuecomment-1935771503.