### PR TITLE
Bugfix in pairwise_regression_model.py

### DIFF
--- a/flair/models/pairwise_regression_model.py
+++ b/flair/models/pairwise_regression_model.py
@@ -257,7 +257,7 @@ class TextPairRegressor(flair.nn.Model[TextPair], ReduceTransformerVocabMixin):
                 if not batch:
                     continue
 
-                data_point_tensor = self._encode_data_points(pairs)
+                data_point_tensor = self._encode_data_points(batch)
                 scores = self.decoder(data_point_tensor)
 
                 for sentence, score in zip(batch, scores.tolist()):


### PR DESCRIPTION
It seems like `batch` should be used in iterations, rather than `pairs`.

I'm not 100% sure about this fix, please feel free to close it if I'm wrong.