### PR TITLE
feat: allow cpu device even if gpu available

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -24,12 +24,12 @@ environment variable to its index.
 """
 
 # Get the device from the environment variable
-flair_device = os.environ.get("FLAIR_DEVICE")
+device_id = os.environ.get("FLAIR_DEVICE")
 
 # global variable: device
-if torch.cuda.is_available() and flair_device != "cpu":
+if torch.cuda.is_available() and device_id != "cpu":
     # No need for correctness checks, torch is doing it
-    device = torch.device(f"cuda:{flair_device}") if flair_device else torch.device("cuda:0")
+    device = torch.device(f"cuda:{device_id}") if device_id else torch.device("cuda:0")
 else:
     device = torch.device("cpu")
 

--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -18,17 +18,18 @@ You can choose the path by setting the `FLAIR_CACHE_ROOT` environment variable.
 device: torch.device
 """Flair is using a single device for everything. You can set this device by overwriting this variable.
 
-This value will be automatically set to the first found GPU if available and to CPU otherwise.
-You can choose a specific GPU, by setting the `FLAIR_DEVICE` environment variable to its index.
+The device will be automatically set to the first available GPU if a GPU is present and the 'FLAIR_DEVICE' environment 
+variable is not set to 'cpu', otherwise it will default to the CPU, and a specific GPU can be chosen by setting the 'FLAIR_DEVICE' 
+environment variable to its index.
 """
 
+# Get the device from the environment variable
+flair_device = os.environ.get("FLAIR_DEVICE")
 
 # global variable: device
-if torch.cuda.is_available():
-    device_id = os.environ.get("FLAIR_DEVICE")
-
+if torch.cuda.is_available() and flair_device != "cpu":
     # No need for correctness checks, torch is doing it
-    device = torch.device(f"cuda:{device_id}") if device_id else torch.device("cuda:0")
+    device = torch.device(f"cuda:{flair_device}") if flair_device else torch.device("cuda:0")
 else:
     device = torch.device("cpu")
 


### PR DESCRIPTION
This PR updates the init to check if `FLAIR_DEVICE="cpu"` and will use the cpu even on a system with cuda available. Currently its not possible to use flair on your cpu if you have a gpu which may be undesirable when managing memory