### PR TITLE
ci: fix black and ruff

### DIFF
--- a/flair/embeddings/base.py
+++ b/flair/embeddings/base.py
@@ -168,9 +168,7 @@ class ScalarMix(torch.nn.Module):
         """
         if len(tensors) != self.mixture_size:
             log.error(
-                "{} tensors were passed, but the module was initialized to mix {} tensors.".format(
-                    len(tensors), self.mixture_size
-                )
+                f"{len(tensors)} tensors were passed, but the module was initialized to mix {self.mixture_size} tensors."
             )
 
         normed_weights = torch.nn.functional.softmax(torch.cat(list(self.scalar_parameters)), dim=0)

--- a/flair/models/pairwise_regression_model.py
+++ b/flair/models/pairwise_regression_model.py
@@ -318,9 +318,7 @@ class TextPairRegressor(flair.nn.Model[TextPair], ReduceTransformerVocabMixin):
 
                     if out_path is not None:
                         for pair, prediction, true_value in zip(batch, results, true_values):
-                            eval_line = "{}\t{}\t{}\t{}\n".format(
-                                pair.first.to_original_text(), pair.second.to_original_text(), true_value, prediction
-                            )
+                            eval_line = f"{pair.first.to_original_text()}\t{pair.second.to_original_text()}\t{true_value}\t{prediction}\n"
                             out_file.write(eval_line)
 
                     store_embeddings(batch, embedding_storage_mode)

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -80,12 +80,7 @@ class MetricRegression:
         return "\t_\t_\t_\t_"
 
     def __str__(self) -> str:
-        line = "mean squared error: {:.4f} - mean absolute error: {:.4f} - pearson: {:.4f} - spearman: {:.4f}".format(
-            self.mean_squared_error(),
-            self.mean_absolute_error(),
-            self.pearsonr(),
-            self.spearmanr(),
-        )
+        line = f"mean squared error: {self.mean_squared_error():.4f} - mean absolute error: {self.mean_absolute_error():.4f} - pearson: {self.pearsonr():.4f} - spearman: {self.spearmanr():.4f}"
         return line
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
-black[jupyter]>=23.3.0
+black[jupyter]==24.2.0
 konoha[janome]<6.0.0
 mypy>=1.2.0
 pytest>=7.3.1
-pytest-black-ng>=0.4.1
+pytest-black-ng==0.4.1
 pytest-github-actions-annotate-failures>=0.1.8
 pytest-mypy>=0.10.3
-pytest-ruff>=0.0.5
+pytest-ruff==0.3.1
 types-dataclasses>=0.6.6
 types-Deprecated>=1.2.9.2
 types-requests>=2.28.11.17


### PR DESCRIPTION
Hi,

this PR pins both `black` and `ruff` versions and also applies tree-wide formatting.

Hopefully, CI will be green then :)