### PR TITLE
ci: fix ruff error on numpy deprecation

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -204,7 +204,7 @@ class WordEmbeddings(TokenEmbeddings):
 
             self.__embedding_length: int = precomputed_word_embeddings.vector_size
 
-            vectors = np.row_stack(
+            vectors = np.vstack(
                 (
                     precomputed_word_embeddings.vectors,
                     np.zeros(self.__embedding_length, dtype="float"),
@@ -399,7 +399,7 @@ class WordEmbeddings(TokenEmbeddings):
         state.setdefault("field", None)
         if "precomputed_word_embeddings" in state:
             precomputed_word_embeddings: KeyedVectors = state.pop("precomputed_word_embeddings")
-            vectors = np.row_stack(
+            vectors = np.vstack(
                 (
                     precomputed_word_embeddings.vectors,
                     np.zeros(precomputed_word_embeddings.vector_size, dtype="float"),


### PR DESCRIPTION
Replace deprecated `numpy.row_stack` cause ruff error.