### PR TITLE
Fixes the incorrect token prediction distribution from _all_scores_for_token() in sequence_tagger_model.py

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -589,7 +589,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         previous = 0
         for length in lengths:
             prob_tags_per_sentence.append(prob_all_tags[previous : previous + length])
-            previous = length
+            previous += length
         return prob_tags_per_sentence
 
     def _get_state_dict(self):


### PR DESCRIPTION
This PR fixes the issue #3448 . Previously, due to incorrect length calculation for each sentence in the batch, the returned tag probability distribution for each token was incorrect (from the _all_scores_for_token() function in sequence_tagger_model.py). This PR makes a small change in _all_scores_for_token() function to correctly compute the length.