### PR TITLE
QuickFix: extract hidden states of transformers by key

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -1321,7 +1321,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
             model_kwargs["bbox"] = bbox
         if pixel_values is not None:
             model_kwargs["pixel_values"] = pixel_values
-        hidden_states = self.model(input_ids, **model_kwargs)[-1]
+        hidden_states = self.model(input_ids, **model_kwargs).hidden_states
         # make the tuple a tensor; makes working with it easier.
         hidden_states = torch.stack(hidden_states)
 


### PR DESCRIPTION
Hi,

The extraction of hidden states within transformer embeddings was previously done by accessing the last item in the transformer model output. This causes some older models, e.g. **dvm1983/TinyBERT_General_4L_312D_de** to crash during inference, due to a different output ordering.
This is fixed by extracting the hidden states by the corresponding key instead, which is also more readable. 