### PR TITLE
pip: bump min. version of bpemb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3>=1.20.27
-bpemb>=0.3.2
+bpemb>=0.3.5
 conllu>=4.0
 deprecated>=1.2.13
 ftfy>=6.1.0


### PR DESCRIPTION
Hi,

due to a recent bugfix release of `bpemb` (see https://github.com/bheinzerling/bpemb/issues/66 ), we should use this version as minimum required one!

In versions < 0.3.5 the download of embeddings is no longer working.

Related to #3467.