### PR TITLE
Remove urllib3<2.0.0 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ torch>=1.5.0,!=1.8
 tqdm>=4.63.0
 transformer-smaller-training-vocab>=0.2.3
 transformers[sentencepiece]>=4.18.0,<5.0.0
-urllib3<2.0.0,>=1.0.0  # pin below 2 to make dependency resolution faster.
 wikipedia-api>=0.5.7
 semver<4.0.0,>=3.0.0
 bioc<3.0.0,>=2.0.0


### PR DESCRIPTION
This PR removes the restriction on urllib3 and closes https://github.com/flairNLP/flair/issues/3482