### PR TITLE
Use built-in version parsing from packaging

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, cast
 
 import torch
 import transformers
-from semver import Version
+from packaging.version import Version
 from torch.jit import ScriptModule
 from transformers import (
     CONFIG_MAPPING,
@@ -1222,7 +1222,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
     ):
-        if transformers.__version__ >= Version(4, 31, 0):
+        if Version(transformers.__version__) >= Version("4.31.0"):
             assert isinstance(state_dict, dict)
             state_dict.pop(f"{prefix}model.embeddings.position_ids", None)
         super()._load_from_state_dict(
@@ -1307,7 +1307,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
             self.__dict__[key] = embedding.__dict__[key]
 
         if model_state_dict:
-            if transformers.__version__ >= Version(4, 31, 0):
+            if Version(transformers.__version__) >= Version("4.31.0"):
                 model_state_dict.pop("embeddings.position_ids", None)
             self.model.load_state_dict(model_state_dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,4 @@ tqdm>=4.63.0
 transformer-smaller-training-vocab>=0.2.3
 transformers[sentencepiece]>=4.18.0,<5.0.0
 wikipedia-api>=0.5.7
-semver<4.0.0,>=3.0.0
 bioc<3.0.0,>=2.0.0


### PR DESCRIPTION
Use version parsing from `packaging` to support all valid python version identifiers instead of the external `semver` library.