### PR TITLE
fix: use proper eval default main eval metrics for text pair regressor

### DIFF
--- a/flair/models/pairwise_regression_model.py
+++ b/flair/models/pairwise_regression_model.py
@@ -283,7 +283,7 @@ class TextPairRegressor(flair.nn.Model[TextPair], ReduceTransformerVocabMixin):
         out_path: Union[str, Path, None] = None,
         embedding_storage_mode: EmbeddingStorageMode = "none",
         mini_batch_size: int = 32,
-        main_evaluation_metric: Tuple[str, str] = ("micro avg", "f1-score"),
+        main_evaluation_metric: Tuple[str, str] = ("correlation", "pearson"),
         exclude_labels: Optional[List[str]] = None,
         gold_label_dictionary: Optional[Dictionary] = None,
         return_loss: bool = True,


### PR DESCRIPTION
The `TextPairRegressor` model uses the wrong default evaluation metric for a regression. This changes it from micro avg f1 score to pearson correlation coefficient