### PR TITLE
Update transformer.py

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -1073,7 +1073,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
                 model, add_prefix_space=True, **transformers_tokenizer_kwargs, **kwargs
             )
             try:
-                self.feature_extractor = AutoFeatureExtractor.from_pretrained(model, apply_ocr=False)
+                self.feature_extractor = AutoFeatureExtractor.from_pretrained(model, apply_ocr=False, **kwargs)
             except OSError:
                 self.feature_extractor = None
         else:


### PR DESCRIPTION
Adding  **kwargs  to AutoFeatureExtractor.from_pretrained, in order to work with proxy configuration.


`bert_embedding = TransformerWordEmbeddings('bert-base-multilingual-cased', proxies={"http": "...", "https": "..."})
`

This file is not dowloaded if **kwargs is not added.

requests.exceptions.SSLError: (MaxRetryError("HTTPSConnectionPool(host='huggingface.co', port=443): Max retries exceeded with url: /bert-base-multilingual-cased/resolve/main/model.safetensors (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)')))"), '(Request ID: dd8502e8-072c-4735-89f6-0e13a81c4efd)')

https://huggingface.co/bert-base-multilingual-cased/resolve/main/model.safetensors