### PR TITLE
drop python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
       FLAIR_CACHE_ROOT: ./cache/flair
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install Torch cpu
         run: pip install torch --index-url https://download.pytorch.org/whl/cpu
       - name: Install Flair dependencies

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build the docs using Sphinx and push to gh-pages
     runs-on: ubuntu-latest
     env:
-      python-version: 3.8
+      python-version: 3.9
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ the code should hopefully be easy.
 
 ### Setup
 
-Flair requires python-3.8 or higher. To make sure your code also runs on the oldest supported
-python version, it is recommended to use python-3.8.x for flair development.
+Flair requires python-3.9 or higher. To make sure your code also runs on the oldest supported
+python version, it is recommended to use python-3.9.x for flair development.
 
 Create a python environment of your preference and run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In your favorite virtual environment, simply do:
 pip install flair
 ```
 
-Flair requires Python 3.8+. 
+Flair requires Python 3.9+. 
 
 ### Example 1: Tag Entities in Text
 

--- a/docs/contributing/local_development.md
+++ b/docs/contributing/local_development.md
@@ -6,8 +6,8 @@ the code should hopefully be easy.
 
 ## Setup
 
-Flair requires python-3.8 or higher. To make sure our code also runs on the oldest supported
-python version, it is recommended to use python-3.8.x for flair development.
+Flair requires python-3.9 or higher. To make sure our code also runs on the oldest supported
+python version, it is recommended to use python-3.9.x for flair development.
 
 Create a python environment of your preference and run:
 ```bash

--- a/docs/tutorial/intro.md
+++ b/docs/tutorial/intro.md
@@ -16,7 +16,7 @@ In your favorite virtual environment, simply do:
 pip install flair
 ```
 
-Flair requires Python 3.8+. 
+Flair requires Python 3.9+. 
 
 ## Example 1: Tag Entities in Text
 

--- a/flair/class_utils.py
+++ b/flair/class_utils.py
@@ -1,12 +1,13 @@
 import importlib
 import inspect
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Any, Iterable, List, Optional, Type, TypeVar, Union, overload
+from typing import Any, Optional, TypeVar, Union, overload
 
 T = TypeVar("T")
 
 
-def get_non_abstract_subclasses(cls: Type[T]) -> Iterable[Type[T]]:
+def get_non_abstract_subclasses(cls: type[T]) -> Iterable[type[T]]:
     for subclass in cls.__subclasses__():
         yield from get_non_abstract_subclasses(subclass)
         if inspect.isabstract(subclass):
@@ -14,7 +15,7 @@ def get_non_abstract_subclasses(cls: Type[T]) -> Iterable[Type[T]]:
         yield subclass
 
 
-def get_state_subclass_by_name(cls: Type[T], cls_name: Optional[str]) -> Type[T]:
+def get_state_subclass_by_name(cls: type[T], cls_name: Optional[str]) -> type[T]:
     for sub_cls in get_non_abstract_subclasses(cls):
         if sub_cls.__name__ == cls_name:
             return sub_cls
@@ -26,12 +27,12 @@ def lazy_import(group: str, module: str, first_symbol: None) -> ModuleType: ...
 
 
 @overload
-def lazy_import(group: str, module: str, first_symbol: str, *symbols: str) -> List[Any]: ...
+def lazy_import(group: str, module: str, first_symbol: str, *symbols: str) -> list[Any]: ...
 
 
 def lazy_import(
     group: str, module: str, first_symbol: Optional[str] = None, *symbols: str
-) -> Union[List[Any], ModuleType]:
+) -> Union[list[Any], ModuleType]:
     try:
         imported_module = importlib.import_module(module)
     except ImportError:

--- a/flair/datasets/base.py
+++ b/flair/datasets/base.py
@@ -1,7 +1,7 @@
 import logging
 from abc import abstractmethod
 from pathlib import Path
-from typing import Generic, List, Optional, Union
+from typing import Generic, Optional, Union
 
 import torch.utils.data.dataloader
 from deprecated.sphinx import deprecated
@@ -41,7 +41,7 @@ class DataLoader(torch.utils.data.dataloader.DataLoader):
 class FlairDatapointDataset(FlairDataset, Generic[DT]):
     """A simple Dataset object to wrap a List of Datapoints, for example Sentences."""
 
-    def __init__(self, datapoints: Union[DT, List[DT]]) -> None:
+    def __init__(self, datapoints: Union[DT, list[DT]]) -> None:
         """Instantiate FlairDatapointDataset.
 
         Args:
@@ -64,7 +64,7 @@ class FlairDatapointDataset(FlairDataset, Generic[DT]):
 
 class SentenceDataset(FlairDatapointDataset):
     @deprecated(version="0.11", reason="The 'SentenceDataset' class was renamed to 'FlairDatapointDataset'")
-    def __init__(self, sentences: Union[Sentence, List[Sentence]]) -> None:
+    def __init__(self, sentences: Union[Sentence, list[Sentence]]) -> None:
         super().__init__(sentences)
 
 
@@ -73,7 +73,7 @@ class StringDataset(FlairDataset):
 
     def __init__(
         self,
-        texts: Union[str, List[str]],
+        texts: Union[str, list[str]],
         use_tokenizer: Union[bool, Tokenizer] = SpaceTokenizer(),
     ) -> None:
         """Instantiate StringDataset.
@@ -111,7 +111,7 @@ class MongoDataset(FlairDataset):
         database: str,
         collection: str,
         text_field: str,
-        categories_field: Optional[List[str]] = None,
+        categories_field: Optional[list[str]] = None,
         max_tokens_per_doc: int = -1,
         max_chars_per_doc: int = -1,
         tokenizer: Tokenizer = SegtokTokenizer(),
@@ -195,7 +195,7 @@ class MongoDataset(FlairDataset):
     def _parse_document_to_sentence(
         self,
         text: str,
-        labels: List[str],
+        labels: list[str],
         tokenizer: Union[bool, Tokenizer],
     ):
         if self.max_chars_per_doc > 0:

--- a/flair/datasets/ocr.py
+++ b/flair/datasets/ocr.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import gdown.download_folder
 import PIL
@@ -20,7 +20,7 @@ class OcrJsonDataset(FlairDataset):
         encoding: str = "utf-8",
         load_images: bool = False,
         normalize_coords_to_thousands: bool = True,
-        label_name_map: Optional[Dict[str, str]] = None,
+        label_name_map: Optional[dict[str, str]] = None,
     ) -> None:
         """Instantiates a Dataset from a OCR-Json format.
 
@@ -132,7 +132,7 @@ class OcrCorpus(Corpus):
         in_memory: bool = True,
         load_images: bool = False,
         normalize_coords_to_thousands: bool = True,
-        label_name_map: Optional[Dict[str, str]] = None,
+        label_name_map: Optional[dict[str, str]] = None,
         **corpusargs,
     ) -> None:
         """Instantiates a Corpus from a OCR-Json format.
@@ -205,7 +205,7 @@ class SROIE(OcrCorpus):
         in_memory: bool = True,
         load_images: bool = False,
         normalize_coords_to_thousands: bool = True,
-        label_name_map: Optional[Dict[str, str]] = None,
+        label_name_map: Optional[dict[str, str]] = None,
         **corpusargs,
     ) -> None:
         """Instantiates the SROIE corpus with perfect ocr boxes.

--- a/flair/datasets/relation_extraction.py
+++ b/flair/datasets/relation_extraction.py
@@ -5,8 +5,9 @@ import logging
 import os
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import conllu
 import gdown
@@ -279,7 +280,7 @@ class RE_ENGLISH_TACRED(ColumnCorpus):
                             token_list = self._tacred_example_to_token_list(example)
                             target_file.write(token_list.serialize())
 
-    def _tacred_example_to_token_list(self, example: Dict[str, Any]) -> conllu.TokenList:
+    def _tacred_example_to_token_list(self, example: dict[str, Any]) -> conllu.TokenList:
         id_ = example["id"]
         tokens = example["token"]
         ner = example["stanford_ner"]
@@ -379,7 +380,7 @@ class RE_ENGLISH_CONLL04(ColumnCorpus):
         }
         metadata_parsers = {"__fallback__": lambda k, v: tuple(k.split())}
 
-        lines: List[str] = []
+        lines: list[str] = []
         for index, line in enumerate(source_file):
             if index > 0 and line.startswith("#"):
                 source_str = "".join(lines)
@@ -416,9 +417,10 @@ class RE_ENGLISH_CONLL04(ColumnCorpus):
         ]
 
         for source_filename, target_filename in zip(source_filenames, target_filenames):
-            with (source_data_folder / source_filename).open(encoding="utf-8") as source_file, (
-                data_folder / target_filename
-            ).open("w", encoding="utf-8") as target_file:
+            with (
+                (source_data_folder / source_filename).open(encoding="utf-8") as source_file,
+                (data_folder / target_filename).open("w", encoding="utf-8") as target_file,
+            ):
                 # write CoNLL-U Plus header
                 target_file.write("# global.columns = id form ner\n")
 
@@ -426,7 +428,7 @@ class RE_ENGLISH_CONLL04(ColumnCorpus):
                     token_list = self._src_token_list_to_token_list(src_token_list)
                     target_file.write(token_list.serialize())
 
-    def _bio_tags_to_spans(self, tags: List[str]) -> List[Tuple[int, int]]:
+    def _bio_tags_to_spans(self, tags: list[str]) -> list[tuple[int, int]]:
         spans = []
         span_start = 0
         span_end = 0
@@ -590,7 +592,7 @@ class RE_ENGLISH_DRUGPROT(ColumnCorpus):
                         ent2 = arg2.split(":")[1]
                         pmid_to_relations[pmid].add((rel_type, ent1, ent2))
 
-                tokenlists: List[conllu.TokenList] = []
+                tokenlists: list[conllu.TokenList] = []
                 with zip_file.open(
                     f"drugprot-gs-training-development/{split}/drugprot_{split}_abstracs.tsv"
                 ) as abstracts_file:
@@ -652,13 +654,13 @@ class RE_ENGLISH_DRUGPROT(ColumnCorpus):
     def drugprot_document_to_tokenlists(
         self,
         pmid: str,
-        title_sentences: List[Sentence],
-        abstract_sentences: List[Sentence],
+        title_sentences: list[Sentence],
+        abstract_sentences: list[Sentence],
         abstract_offset: int,
-        entities: Dict[str, Tuple[str, int, int, str]],
-        relations: Set[Tuple[str, str, str]],
-    ) -> List[conllu.TokenList]:
-        tokenlists: List[conllu.TokenList] = []
+        entities: dict[str, tuple[str, int, int, str]],
+        relations: set[tuple[str, str, str]],
+    ) -> list[conllu.TokenList]:
+        tokenlists: list[conllu.TokenList] = []
         sentence_id = 1
         for offset, sents in [
             (0, title_sentences),

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -4,17 +4,13 @@ import logging
 import os
 import re
 import shutil
+import tarfile
 from collections import defaultdict
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import (
     Any,
-    DefaultDict,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
     Optional,
-    Tuple,
     Union,
     cast,
 )
@@ -224,7 +220,7 @@ class JsonlDataset(FlairDataset):
         self.label_type = label_type
         self.path_to_json_file = path_to_json_file
 
-        self.sentences: List[Sentence] = []
+        self.sentences: list[Sentence] = []
         with path_to_json_file.open(encoding=encoding) as jsonl_fp:
             for line in jsonl_fp:
                 current_line = json.loads(line)
@@ -238,7 +234,7 @@ class JsonlDataset(FlairDataset):
 
                 self.sentences.append(current_sentence)
 
-    def _add_labels_to_sentence(self, raw_text: str, sentence: Sentence, labels: List[List[Any]]):
+    def _add_labels_to_sentence(self, raw_text: str, sentence: Sentence, labels: list[list[Any]]):
         # Add tags for each annotated span
         for label in labels:
             self._add_label_to_sentence(raw_text, sentence, label[0], label[1], label[2])
@@ -288,7 +284,7 @@ class JsonlDataset(FlairDataset):
 
         sentence[start_idx : end_idx + 1].add_label(self.label_type, label)
 
-    def _add_metadatas_to_sentence(self, sentence: Sentence, metadatas: List[Tuple[str, str]]):
+    def _add_metadatas_to_sentence(self, sentence: Sentence, metadatas: list[tuple[str, str]]):
         # Add metadatas for sentence
         for metadata in metadatas:
             self._add_metadata_to_sentence(sentence, metadata[0], metadata[1])
@@ -313,7 +309,7 @@ class JsonlDataset(FlairDataset):
 class MultiFileColumnCorpus(Corpus):
     def __init__(
         self,
-        column_format: Dict[int, str],
+        column_format: dict[int, str],
         train_files=None,
         test_files=None,
         dev_files=None,
@@ -323,8 +319,8 @@ class MultiFileColumnCorpus(Corpus):
         document_separator_token: Optional[str] = None,
         skip_first_line: bool = False,
         in_memory: bool = True,
-        label_name_map: Optional[Dict[str, str]] = None,
-        banned_sentences: Optional[List[str]] = None,
+        label_name_map: Optional[dict[str, str]] = None,
+        banned_sentences: Optional[list[str]] = None,
         default_whitespace_after: int = 1,
         **corpusargs,
     ) -> None:
@@ -424,7 +420,7 @@ class ColumnCorpus(MultiFileColumnCorpus):
     def __init__(
         self,
         data_folder: Union[str, Path],
-        column_format: Dict[int, str],
+        column_format: dict[int, str],
         train_file=None,
         test_file=None,
         dev_file=None,
@@ -475,15 +471,15 @@ class ColumnDataset(FlairDataset):
     def __init__(
         self,
         path_to_column_file: Union[str, Path],
-        column_name_map: Dict[int, str],
+        column_name_map: dict[int, str],
         column_delimiter: str = r"\s+",
         comment_symbol: Optional[str] = None,
-        banned_sentences: Optional[List[str]] = None,
+        banned_sentences: Optional[list[str]] = None,
         in_memory: bool = True,
         document_separator_token: Optional[str] = None,
         encoding: str = "utf-8",
         skip_first_line: bool = False,
-        label_name_map: Optional[Dict[str, str]] = None,
+        label_name_map: Optional[dict[str, str]] = None,
         default_whitespace_after: int = 1,
     ) -> None:
         r"""Instantiates a column dataset.
@@ -537,7 +533,7 @@ class ColumnDataset(FlairDataset):
 
             # option 1: keep Sentence objects in memory
             if self.in_memory:
-                self.sentences: List[Sentence] = []
+                self.sentences: list[Sentence] = []
 
                 # pointer to previous
                 previous_sentence = None
@@ -579,7 +575,7 @@ class ColumnDataset(FlairDataset):
 
             # option 2: keep source data in memory
             if not self.in_memory:
-                self.sentences_raw: List[List[str]] = []
+                self.sentences_raw: list[list[str]] = []
 
                 while True:
                     # read lines for next sentence, but don't parse
@@ -679,10 +675,10 @@ class ColumnDataset(FlairDataset):
         return lines
 
     def _convert_lines_to_sentence(
-        self, lines, word_level_tag_columns: Dict[int, str], span_level_tag_columns: Optional[Dict[int, str]] = None
+        self, lines, word_level_tag_columns: dict[int, str], span_level_tag_columns: Optional[dict[int, str]] = None
     ):
         token: Optional[Token] = None
-        tokens: List[Token] = []
+        tokens: list[Token] = []
         filtered_lines = []
         comments = []
         for line in lines:
@@ -749,9 +745,9 @@ class ColumnDataset(FlairDataset):
             return sentence
         return None
 
-    def _parse_token(self, line: str, column_name_map: Dict[int, str], last_token: Optional[Token] = None) -> Token:
+    def _parse_token(self, line: str, column_name_map: dict[int, str], last_token: Optional[Token] = None) -> Token:
         # get fields from line
-        fields: List[str] = self.column_delimiter.split(line.rstrip())
+        fields: list[str] = self.column_delimiter.split(line.rstrip())
         field_count = len(fields)
         # get head_id if exists (only in dependency parses)
         head_id = int(fields[self.head_id_column]) if self.head_id_column else None
@@ -855,7 +851,7 @@ class ONTONOTES(MultiFileColumnCorpus):
         base_path: Optional[Union[str, Path]] = None,
         version: str = "v4",
         language: str = "english",
-        domain: Union[None, str, List[str], Dict[str, Union[None, str, List[str]]]] = None,
+        domain: Union[None, str, list[str], dict[str, Union[None, str, list[str]]]] = None,
         in_memory: bool = True,
         **corpusargs,
     ) -> None:
@@ -893,7 +889,7 @@ class ONTONOTES(MultiFileColumnCorpus):
         version: str = "v4",
         language: str = "english",
         split: str = "train",
-    ) -> List[str]:
+    ) -> list[str]:
         processed_data_path = cls._ensure_data_processed(base_path=base_path, language=language, version=version)
 
         processed_split_path = processed_data_path / "splits" / version / language / split
@@ -907,7 +903,7 @@ class ONTONOTES(MultiFileColumnCorpus):
         split: str = "train",
         version: str = "v4",
         language: str = "english",
-        domain: Optional[Union[str, List[str], Dict[str, Union[None, str, List[str]]]]] = None,
+        domain: Optional[Union[str, list[str], dict[str, Union[None, str, list[str]]]]] = None,
     ) -> Iterable[Path]:
         processed_split_path = processed_data_path / "splits" / version / language / split
 
@@ -1009,8 +1005,8 @@ class ONTONOTES(MultiFileColumnCorpus):
         cls,
         label: str,
         word_index: int,
-        clusters: DefaultDict[int, List[Tuple[int, int]]],
-        coref_stacks: DefaultDict[int, List[int]],
+        clusters: defaultdict[int, list[tuple[int, int]]],
+        coref_stacks: defaultdict[int, list[int]],
     ) -> None:
         """For a given coref label, add it to a currently open span(s), complete a span(s) or ignore it, if it is outside of all spans.
 
@@ -1048,9 +1044,9 @@ class ONTONOTES(MultiFileColumnCorpus):
     @classmethod
     def _process_span_annotations_for_word(
         cls,
-        annotations: List[str],
-        span_labels: List[List[str]],
-        current_span_labels: List[Optional[str]],
+        annotations: list[str],
+        span_labels: list[list[str]],
+        current_span_labels: list[Optional[str]],
     ) -> None:
         for annotation_index, annotation in enumerate(annotations):
             # strip all bracketing information to
@@ -1076,33 +1072,33 @@ class ONTONOTES(MultiFileColumnCorpus):
                 current_span_labels[annotation_index] = None
 
     @classmethod
-    def _conll_rows_to_sentence(cls, conll_rows: List[str]) -> Dict:
+    def _conll_rows_to_sentence(cls, conll_rows: list[str]) -> dict:
         document_id: str
         sentence_id: int
         # The words in the sentence.
-        sentence: List[str] = []
+        sentence: list[str] = []
         # The pos tags of the words in the sentence.
-        pos_tags: List[str] = []
+        pos_tags: list[str] = []
         # the pieces of the parse tree.
-        parse_pieces: List[Optional[str]] = []
+        parse_pieces: list[Optional[str]] = []
         # The lemmatised form of the words in the sentence which
         # have SRL or word sense information.
-        predicate_lemmas: List[Optional[str]] = []
+        predicate_lemmas: list[Optional[str]] = []
         # The FrameNet ID of the predicate.
-        predicate_framenet_ids: List[Optional[str]] = []
+        predicate_framenet_ids: list[Optional[str]] = []
         # The sense of the word, if available.
-        word_senses: List[Optional[float]] = []
+        word_senses: list[Optional[float]] = []
         # The current speaker, if available.
-        speakers: List[Optional[str]] = []
+        speakers: list[Optional[str]] = []
 
-        verbal_predicates: List[str] = []
-        span_labels: List[List[str]] = []
-        current_span_labels: List[Optional[str]] = []
+        verbal_predicates: list[str] = []
+        span_labels: list[list[str]] = []
+        current_span_labels: list[Optional[str]] = []
 
         # Cluster id -> List of (start_index, end_index) spans.
-        clusters: DefaultDict[int, List[Tuple[int, int]]] = defaultdict(list)
+        clusters: defaultdict[int, list[tuple[int, int]]] = defaultdict(list)
         # Cluster id -> List of start_indices which are open for this id.
-        coref_stacks: DefaultDict[int, List[int]] = defaultdict(list)
+        coref_stacks: defaultdict[int, list[int]] = defaultdict(list)
 
         for index, row in enumerate(conll_rows):
             conll_components = row.split()
@@ -1178,7 +1174,7 @@ class ONTONOTES(MultiFileColumnCorpus):
         srl_frames = list(zip(verbal_predicates, span_labels[1:]))
 
         # this would not be reached if parse_pieces contained None, hence the cast
-        parse_tree = "".join(cast(List[str], parse_pieces)) if all(parse_pieces) else None
+        parse_tree = "".join(cast(list[str], parse_pieces)) if all(parse_pieces) else None
 
         coref_span_tuples = {(cluster_id, span) for cluster_id, span_list in clusters.items() for span in span_list}
         return {
@@ -1197,7 +1193,7 @@ class ONTONOTES(MultiFileColumnCorpus):
         }
 
     @classmethod
-    def dataset_document_iterator(cls, file_path: Union[Path, str]) -> Iterator[List]:
+    def dataset_document_iterator(cls, file_path: Union[Path, str]) -> Iterator[list[dict]]:
         """An iterator over CONLL formatted files which yields documents, regardless of the number of document annotations in a particular file.
 
         This is useful for conll data which has been preprocessed, such
@@ -1206,7 +1202,7 @@ class ONTONOTES(MultiFileColumnCorpus):
         """
         with open(file_path, encoding="utf8") as open_file:
             conll_rows = []
-            document: List = []
+            document: list[dict] = []
             for line in open_file:
                 line = line.strip()
                 if line != "" and not line.startswith("#"):
@@ -1456,17 +1452,22 @@ class CONLL_2000(ColumnCorpus):
             cached_path(f"{conll_2000_path}train.txt.gz", Path("datasets") / dataset_name)
             cached_path(f"{conll_2000_path}test.txt.gz", Path("datasets") / dataset_name)
             import gzip
-            import shutil
 
-            with gzip.open(flair.cache_root / "datasets" / dataset_name / "train.txt.gz", "rb") as f_in, open(
-                flair.cache_root / "datasets" / dataset_name / "train.txt",
-                "wb",
-            ) as f_out:
+            with (
+                gzip.open(flair.cache_root / "datasets" / dataset_name / "train.txt.gz", "rb") as f_in,
+                open(
+                    flair.cache_root / "datasets" / dataset_name / "train.txt",
+                    "wb",
+                ) as f_out,
+            ):
                 shutil.copyfileobj(f_in, f_out)
-            with gzip.open(flair.cache_root / "datasets" / dataset_name / "test.txt.gz", "rb") as f_in, open(
-                flair.cache_root / "datasets" / dataset_name / "test.txt",
-                "wb",
-            ) as f_out:
+            with (
+                gzip.open(flair.cache_root / "datasets" / dataset_name / "test.txt.gz", "rb") as f_in,
+                open(
+                    flair.cache_root / "datasets" / dataset_name / "test.txt",
+                    "wb",
+                ) as f_out,
+            ):
                 shutil.copyfileobj(f_in, f_out)
 
         super().__init__(
@@ -1735,8 +1736,6 @@ class NER_BASQUE(ColumnCorpus):
         data_file = data_path / "named_ent_eu.train"
         if not data_file.is_file():
             cached_path(f"{ner_basque_path}/eiec_v1.0.tgz", Path("datasets") / dataset_name)
-            import shutil
-            import tarfile
 
             with tarfile.open(
                 flair.cache_root / "datasets" / dataset_name / "eiec_v1.0.tgz",
@@ -2247,15 +2246,13 @@ class NER_ENGLISH_WEBPAGES(ColumnCorpus):
         if not base_path:
             base_path = Path(flair.cache_root) / "datasets"
         data_folder = base_path / dataset_name
-        import tarfile
 
         if not os.path.isfile(data_folder / "webpages_ner.txt"):
             #     # download zip
             tar_file = "https://cogcomp.seas.upenn.edu/Data/NERWebpagesColumns.tgz"
             webpages_ner_path = cached_path(tar_file, Path("datasets") / dataset_name)
-            tf = tarfile.open(webpages_ner_path)
-            tf.extractall(data_folder)
-            tf.close()
+            with tarfile.open(webpages_ner_path) as tf:
+                tf.extractall(data_folder)
         outputfile = os.path.abspath(data_folder)
 
         # merge the files in one as the zip is containing multiples files
@@ -2538,7 +2535,7 @@ class NER_GERMAN_EUROPARL(ColumnCorpus):
             Specifies the ner-tagged column. The default is 1 (the second column).
         """
 
-        def add_I_prefix(current_line: List[str], ner: int, tag: str):
+        def add_I_prefix(current_line: list[str], ner: int, tag: str):
             for i in range(len(current_line)):
                 if i == 0:
                     f.write(line_list[i])
@@ -2779,9 +2776,11 @@ class NER_GERMAN_POLITICS(ColumnCorpus):
             train_len = round(num_lines * 0.8)
             test_len = round(num_lines * 0.1)
 
-            with (data_folder / "train.txt").open("w", encoding="utf-8") as train, (data_folder / "test.txt").open(
-                "w", encoding="utf-8"
-            ) as test, (data_folder / "dev.txt").open("w", encoding="utf-8") as dev:
+            with (
+                (data_folder / "train.txt").open("w", encoding="utf-8") as train,
+                (data_folder / "test.txt").open("w", encoding="utf-8") as test,
+                (data_folder / "dev.txt").open("w", encoding="utf-8") as dev,
+            ):
                 for k, line in enumerate(file.readlines(), start=1):
                     if k <= train_len:
                         train.write(line)
@@ -2972,7 +2971,7 @@ class NER_JAPANESE(ColumnCorpus):
 class NER_MASAKHANE(MultiCorpus):
     def __init__(
         self,
-        languages: Union[str, List[str]] = "luo",
+        languages: Union[str, list[str]] = "luo",
         version: str = "v2",
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = True,
@@ -3056,7 +3055,7 @@ class NER_MASAKHANE(MultiCorpus):
         if languages == ["all"]:
             languages = list(language_to_code.values())
 
-        corpora: List[Corpus] = []
+        corpora: list[Corpus] = []
         for language in languages:
             if language in language_to_code:
                 language = language_to_code[language]
@@ -3239,7 +3238,7 @@ class NER_MULTI_CONER_V2(MultiFileColumnCorpus):
 class NER_MULTI_WIKIANN(MultiCorpus):
     def __init__(
         self,
-        languages: Union[str, List[str]] = "en",
+        languages: Union[str, list[str]] = "en",
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = False,
         **corpusargs,
@@ -3251,7 +3250,7 @@ class NER_MULTI_WIKIANN(MultiCorpus):
 
         Parameters
         ----------
-        languages : Union[str, List[str]]
+        languages : Union[str, list[str]]
             Should be an abbreviation of a language ("en", "de",..) or a list of abbreviations.
             The datasets of all passed languages will be saved in one MultiCorpus.
             (Note that, even though listed on https://elisa-ie.github.io/wikiann/ some datasets are empty.
@@ -3282,7 +3281,7 @@ class NER_MULTI_WIKIANN(MultiCorpus):
         # this list is handed to the multicorpus
 
         # list that contains the columncopora
-        corpora: List[Corpus] = []
+        corpora: list[Corpus] = []
 
         google_drive_path = "https://drive.google.com/uc?id="
         # download data if necessary
@@ -3294,8 +3293,6 @@ class NER_MULTI_WIKIANN(MultiCorpus):
             # if language not downloaded yet, download it
             if not language_folder.exists():
                 if first:
-                    import tarfile
-
                     import gdown
 
                     first = False
@@ -3310,10 +3307,8 @@ class NER_MULTI_WIKIANN(MultiCorpus):
 
                 # unzip
                 log.info("Extracting data...")
-                tar = tarfile.open(str(language_folder / language) + ".tar.gz", "r:gz")
-                # tar.extractall(language_folder,members=[tar.getmember(file_name)])
-                tar.extract(file_name, str(language_folder))
-                tar.close()
+                with tarfile.open(str(language_folder / language) + ".tar.gz", "r:gz") as tar:
+                    tar.extract(file_name, str(language_folder))
                 log.info("...done.")
 
                 # transform data into required format
@@ -3342,9 +3337,10 @@ class NER_MULTI_WIKIANN(MultiCorpus):
         )
 
     def _silver_standard_to_simple_ner_annotation(self, data_file: Union[str, Path]):
-        with open(data_file, encoding="utf-8") as f_read, open(
-            str(data_file) + "_new", "w+", encoding="utf-8"
-        ) as f_write:
+        with (
+            open(data_file, encoding="utf-8") as f_read,
+            open(str(data_file) + "_new", "w+", encoding="utf-8") as f_write,
+        ):
             while True:
                 line = f_read.readline()
                 if line:
@@ -3660,7 +3656,7 @@ class NER_MULTI_WIKIANN(MultiCorpus):
 class NER_MULTI_XTREME(MultiCorpus):
     def __init__(
         self,
-        languages: Union[str, List[str]] = "en",
+        languages: Union[str, list[str]] = "en",
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = False,
         **corpusargs,
@@ -3672,7 +3668,7 @@ class NER_MULTI_XTREME(MultiCorpus):
 
         Parameters
         ----------
-        languages : Union[str, List[str]], optional
+        languages : Union[str, list[str]], optional
             Specify the languages you want to load. Provide an empty list or string to select all languages.
         base_path : Union[str, Path], optional
             Default is None, meaning that corpus gets auto-downloaded and loaded. You can override this to point to a different folder but typically this should not be necessary.
@@ -3743,7 +3739,7 @@ class NER_MULTI_XTREME(MultiCorpus):
         # This list is handed to the multicorpus
 
         # list that contains the columncopora
-        corpora: List[Corpus] = []
+        corpora: list[Corpus] = []
 
         hu_path = "https://nlp.informatik.hu-berlin.de/resources/datasets/panx_dataset"
 
@@ -3765,12 +3761,10 @@ class NER_MULTI_XTREME(MultiCorpus):
 
                 # unzip
                 log.info("Extracting data...")
-                import tarfile
 
-                tar = tarfile.open(str(temp_file), "r:gz")
-                for part in ["train", "test", "dev"]:
-                    tar.extract(part, str(language_folder))
-                tar.close()
+                with tarfile.open(str(temp_file), "r:gz") as tar:
+                    for part in ["train", "test", "dev"]:
+                        tar.extract(part, str(language_folder))
                 log.info("...done.")
 
                 # transform data into required format
@@ -3809,7 +3803,7 @@ class NER_MULTI_XTREME(MultiCorpus):
 class NER_MULTI_WIKINER(MultiCorpus):
     def __init__(
         self,
-        languages: Union[str, List[str]] = "en",
+        languages: Union[str, list[str]] = "en",
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = False,
         **corpusargs,
@@ -3828,7 +3822,7 @@ class NER_MULTI_WIKINER(MultiCorpus):
 
         data_folder = base_path / dataset_name
 
-        corpora: List[Corpus] = []
+        corpora: list[Corpus] = []
         for language in languages:
             language_folder = data_folder / language
 
@@ -3868,11 +3862,14 @@ class NER_MULTI_WIKINER(MultiCorpus):
                 flair.cache_root / "datasets" / dataset_name / f"aij-wikiner-{lc}-wp3.bz2",
                 "rb",
             )
-            with bz_file as f, open(
-                flair.cache_root / "datasets" / dataset_name / f"aij-wikiner-{lc}-wp3.train",
-                "w",
-                encoding="utf-8",
-            ) as out:
+            with (
+                bz_file as f,
+                open(
+                    flair.cache_root / "datasets" / dataset_name / f"aij-wikiner-{lc}-wp3.train",
+                    "w",
+                    encoding="utf-8",
+                ) as out,
+            ):
                 for lineb in f:
                     line = lineb.decode("utf-8")
                     words = line.split(" ")
@@ -4740,7 +4737,7 @@ class NER_ICDAR_EUROPEANA(ColumnCorpus):
 class NER_NERMUD(MultiCorpus):
     def __init__(
         self,
-        domains: Union[str, List[str]] = "all",
+        domains: Union[str, list[str]] = "all",
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = False,
         **corpusargs,
@@ -4779,7 +4776,7 @@ class NER_NERMUD(MultiCorpus):
 
         data_folder = base_path / dataset_name
 
-        corpora: List[Corpus] = []
+        corpora: list[Corpus] = []
 
         github_path = "https://raw.githubusercontent.com/dhfbk/KIND/main/evalita-2023"
 
@@ -4923,7 +4920,7 @@ class NER_ESTONIAN_NOISY(ColumnCorpus):
         return base_path
 
     @classmethod
-    def _load_features(cls, base_path) -> List[List[str]]:
+    def _load_features(cls, base_path) -> list[list[str]]:
         print(base_path)
         unpack_file(cached_path(cls.data_url, base_path), base_path, "zip", False)
         with open(f"{base_path}/estner.cnll", encoding="utf-8") as in_file:
@@ -4932,17 +4929,17 @@ class NER_ESTONIAN_NOISY(ColumnCorpus):
         return features
 
     @classmethod
-    def _process_clean_labels(cls, features) -> List[List[str]]:
+    def _process_clean_labels(cls, features) -> list[list[str]]:
         preinstances = [[instance[0], instance[len(instance) - 1]] for instance in features]
         return preinstances
 
     @classmethod
-    def _rmv_clean_labels(cls, features) -> List[str]:
+    def _rmv_clean_labels(cls, features) -> list[str]:
         rdcd_features = [feature[:-1] for feature in features]
         return rdcd_features
 
     @classmethod
-    def _load_noisy_labels(cls, version, base_path) -> List[str]:
+    def _load_noisy_labels(cls, version, base_path) -> list[str]:
         file_name = f"NoisyNER_labelset{version}.labels"
         cached_path(f"{cls.label_url}/{file_name}", base_path)
         with open(f"{base_path}/{file_name}", encoding="utf-8") as in_file:
@@ -4950,7 +4947,7 @@ class NER_ESTONIAN_NOISY(ColumnCorpus):
         return labels
 
     @classmethod
-    def _process_noisy_labels(cls, rdcd_features, labels) -> List[List[str]]:
+    def _process_noisy_labels(cls, rdcd_features, labels) -> list[list[str]]:
         instances = []
         label_idx = 0
         for feature in rdcd_features:
@@ -4965,7 +4962,7 @@ class NER_ESTONIAN_NOISY(ColumnCorpus):
         return instances
 
     @classmethod
-    def _delete_empty_labels(cls, version, preinstances) -> List[str]:
+    def _delete_empty_labels(cls, version, preinstances) -> list[str]:
         instances = []
         if version == 0:
             for instance in preinstances:
@@ -4978,7 +4975,7 @@ class NER_ESTONIAN_NOISY(ColumnCorpus):
         return instances
 
     @classmethod
-    def _split_data(cls, instances) -> Tuple[List[str], List[str], List[str]]:
+    def _split_data(cls, instances) -> tuple[list[str], list[str], list[str]]:
         train = instances[:185708]
         dev = instances[185708:208922]
         test = instances[208922:]
@@ -4996,7 +4993,7 @@ class NER_ESTONIAN_NOISY(ColumnCorpus):
 class MASAKHA_POS(MultiCorpus):
     def __init__(
         self,
-        languages: Union[str, List[str]] = "bam",
+        languages: Union[str, list[str]] = "bam",
         version: str = "v1",
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = True,
@@ -5063,7 +5060,7 @@ class MASAKHA_POS(MultiCorpus):
         if languages == ["all"]:
             languages = supported_languages
 
-        corpora: List[Corpus] = []
+        corpora: list[Corpus] = []
         for language in languages:
             if language not in supported_languages:
                 log.error(f"Language '{language}' is not in list of supported languages!")

--- a/flair/datasets/text_image.py
+++ b/flair/datasets/text_image.py
@@ -3,7 +3,6 @@ import logging
 import os
 import urllib
 from pathlib import Path
-from typing import List
 
 import numpy as np
 import torch.utils.data.dataloader
@@ -40,13 +39,13 @@ class FeideggerCorpus(Corpus):
 
         feidegger_dataset: Dataset = FeideggerDataset(dataset_info, **kwargs)
 
-        train_indices = list(np.where(np.in1d(feidegger_dataset.split, list(range(8))))[0])  # type: ignore[attr-defined]
+        train_indices = list(np.where(np.isin(feidegger_dataset.split, list(range(8))))[0])  # type: ignore[attr-defined]
         train = torch.utils.data.dataset.Subset(feidegger_dataset, train_indices)
 
-        dev_indices = list(np.where(np.in1d(feidegger_dataset.split, [8]))[0])  # type: ignore[attr-defined]
+        dev_indices = list(np.where(np.isin(feidegger_dataset.split, [8]))[0])  # type: ignore[attr-defined]
         dev = torch.utils.data.dataset.Subset(feidegger_dataset, dev_indices)
 
-        test_indices = list(np.where(np.in1d(feidegger_dataset.split, [9]))[0])  # type: ignore[attr-defined]
+        test_indices = list(np.where(np.isin(feidegger_dataset.split, [9]))[0])  # type: ignore[attr-defined]
         test = torch.utils.data.dataset.Subset(feidegger_dataset, test_indices)
 
         super().__init__(train, dev, test, name="feidegger")
@@ -56,8 +55,8 @@ class FeideggerDataset(FlairDataset):
     def __init__(self, dataset_info, **kwargs) -> None:
         super().__init__()
 
-        self.data_points: List[DataPair] = []
-        self.split: List[int] = []
+        self.data_points: list[DataPair] = []
+        self.split: list[int] = []
 
         def identity(x):
             return x

--- a/flair/datasets/text_text.py
+++ b/flair/datasets/text_text.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import flair
 from flair.data import (
@@ -144,14 +144,15 @@ class ParallelTextDataset(FlairDataset):
         self.total_sentence_count: int = 0
 
         if self.in_memory:
-            self.bi_sentences: List[DataPair] = []
+            self.bi_sentences: list[DataPair] = []
         else:
-            self.source_lines: List[str] = []
-            self.target_lines: List[str] = []
+            self.source_lines: list[str] = []
+            self.target_lines: list[str] = []
 
-        with open(str(path_to_source), encoding="utf-8") as source_file, open(
-            str(path_to_target), encoding="utf-8"
-        ) as target_file:
+        with (
+            open(str(path_to_source), encoding="utf-8") as source_file,
+            open(str(path_to_target), encoding="utf-8") as target_file,
+        ):
             source_line = source_file.readline()
             target_line = target_file.readline()
 
@@ -204,7 +205,7 @@ class DataPairCorpus(Corpus):
     def __init__(
         self,
         data_folder: Union[str, Path],
-        columns: List[int] = [0, 1, 2],
+        columns: list[int] = [0, 1, 2],
         train_file=None,
         test_file=None,
         dev_file=None,
@@ -318,7 +319,7 @@ class DataPairDataset(FlairDataset):
     def __init__(
         self,
         path_to_data: Union[str, Path],
-        columns: List[int] = [0, 1, 2],
+        columns: list[int] = [0, 1, 2],
         max_tokens_per_doc=-1,
         max_chars_per_doc=-1,
         use_tokenizer=True,
@@ -368,11 +369,11 @@ class DataPairDataset(FlairDataset):
         self.total_data_count: int = 0
 
         if self.in_memory:
-            self.data_pairs: List[DataPair] = []
+            self.data_pairs: list[DataPair] = []
         else:
-            self.first_elements: List[str] = []
-            self.second_elements: List[str] = []
-            self.labels: List[Optional[str]] = []
+            self.first_elements: list[str] = []
+            self.second_elements: list[str] = []
+            self.labels: list[Optional[str]] = []
 
         with open(str(path_to_data), encoding=encoding) as source_file:
             source_line = source_file.readline()
@@ -448,7 +449,7 @@ class DataTripleCorpus(Corpus):
     def __init__(
         self,
         data_folder: Union[str, Path],
-        columns: List[int] = [0, 1, 2, 3],
+        columns: list[int] = [0, 1, 2, 3],
         train_file=None,
         test_file=None,
         dev_file=None,
@@ -563,7 +564,7 @@ class DataTripleDataset(FlairDataset):
     def __init__(
         self,
         path_to_data: Union[str, Path],
-        columns: List[int] = [0, 1, 2, 3],
+        columns: list[int] = [0, 1, 2, 3],
         max_tokens_per_doc=-1,
         max_chars_per_doc=-1,
         use_tokenizer=True,
@@ -614,12 +615,12 @@ class DataTripleDataset(FlairDataset):
         self.total_data_count: int = 0
 
         if self.in_memory:
-            self.data_triples: List[DataTriple] = []
+            self.data_triples: list[DataTriple] = []
         else:
-            self.first_elements: List[str] = []
-            self.second_elements: List[str] = []
-            self.third_elements: List[str] = []
-            self.labels: List[Optional[str]] = []
+            self.first_elements: list[str] = []
+            self.second_elements: list[str] = []
+            self.third_elements: list[str] = []
+            self.labels: list[Optional[str]] = []
 
         with open(str(path_to_data), encoding=encoding) as source_file:
             source_line = source_file.readline()
@@ -828,9 +829,10 @@ class GLUE_MNLI(DataPairCorpus):
                     str(data_folder / "MNLI" / temp_file),
                 )
 
-                with open(data_folder / "MNLI" / dev_filename, "a", encoding="utf-8") as out_file, open(
-                    data_folder / "MNLI" / temp_file, encoding="utf-8"
-                ) as in_file:
+                with (
+                    open(data_folder / "MNLI" / dev_filename, "a", encoding="utf-8") as out_file,
+                    open(data_folder / "MNLI" / temp_file, encoding="utf-8") as in_file,
+                ):
                     for line in in_file:
                         fields = line.split("\t")
                         reordered_columns = "\t".join(fields[column_id] for column_id in range(11))

--- a/flair/datasets/treebanks.py
+++ b/flair/datasets/treebanks.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import flair
 from flair.data import Corpus, FlairDataset, Sentence, Token
@@ -82,7 +82,7 @@ class UniversalDependenciesDataset(FlairDataset):
         with open(str(self.path_to_conll_file), encoding="utf-8") as file:
             # option 1: read only sentence boundaries as offset positions
             if not self.in_memory:
-                self.indices: List[int] = []
+                self.indices: list[int] = []
 
                 line = file.readline()
                 position = 0
@@ -97,7 +97,7 @@ class UniversalDependenciesDataset(FlairDataset):
 
             # option 2: keep everything in memory
             if self.in_memory:
-                self.sentences: List[Sentence] = []
+                self.sentences: list[Sentence] = []
 
                 while True:
                     sentence = self._read_next_sentence(file)
@@ -129,7 +129,7 @@ class UniversalDependenciesDataset(FlairDataset):
 
     def _read_next_sentence(self, file) -> Optional[Sentence]:
         line = file.readline()
-        tokens: List[Token] = []
+        tokens: list[Token] = []
 
         # current token ID
         token_idx = 0
@@ -143,7 +143,7 @@ class UniversalDependenciesDataset(FlairDataset):
         newline_reached = False
         while line:
             line = line.strip()
-            fields: List[str] = re.split("\t+", line)
+            fields: list[str] = re.split("\t+", line)
 
             # end of sentence
             if line == "":

--- a/flair/embeddings/base.py
+++ b/flair/embeddings/base.py
@@ -1,7 +1,8 @@
 import inspect
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, Generic, List, Sequence, Type, Union
+from collections.abc import Sequence
+from typing import Any, Generic, Union
 
 import torch
 from torch.nn import Parameter, ParameterList
@@ -37,7 +38,7 @@ class Embeddings(torch.nn.Module, Generic[DT]):
     def embedding_type(self) -> str:
         raise NotImplementedError
 
-    def embed(self, data_points: Union[DT, List[DT]]) -> List[DT]:
+    def embed(self, data_points: Union[DT, list[DT]]) -> list[DT]:
         """Add embeddings to all words in a list of sentences.
 
         If embeddings are already added, updates only if embeddings are non-static.
@@ -55,10 +56,10 @@ class Embeddings(torch.nn.Module, Generic[DT]):
         return all(self.name in data_point._embeddings for data_point in data_points)
 
     @abstractmethod
-    def _add_embeddings_internal(self, sentences: List[DT]):
+    def _add_embeddings_internal(self, sentences: list[DT]):
         """Private method for adding embeddings to all words in a list of sentences."""
 
-    def get_names(self) -> List[str]:
+    def get_names(self) -> list[str]:
         """Returns a list of embedding names.
 
         In most cases, it is just a list with one item, namely the name of
@@ -66,9 +67,6 @@ class Embeddings(torch.nn.Module, Generic[DT]):
         Then, the list contains the names of all embeddings in the stack.
         """
         return [self.name]
-
-    def get_named_embeddings_dict(self) -> Dict:
-        return {self.name: self}
 
     @staticmethod
     def get_instance_parameters(locals: dict) -> dict:
@@ -84,14 +82,14 @@ class Embeddings(torch.nn.Module, Generic[DT]):
         return instance_parameters
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "Embeddings":
+    def from_params(cls, params: dict[str, Any]) -> "Embeddings":
         raise NotImplementedError
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @classmethod
-    def load_embedding(cls, params: Dict[str, Any]):
+    def load_embedding(cls, params: dict[str, Any]):
         state_dict = params.pop("state_dict", None)
 
         embedding = cls.from_params(params)
@@ -155,7 +153,7 @@ class ScalarMix(torch.nn.Module):
             requires_grad=trainable,
         )
 
-    def forward(self, tensors: List[torch.Tensor]) -> torch.Tensor:
+    def forward(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         """Forward pass of scalar mix.
 
         Computes a weighted average of the ``tensors``.  The input tensors an be any shape
@@ -203,7 +201,7 @@ class TokenEmbeddings(Embeddings[Sentence]):
         return True
 
 
-EMBEDDING_CLASSES: Dict[str, Type[Embeddings]] = {}
+EMBEDDING_CLASSES: dict[str, type[Embeddings]] = {}
 
 
 def register_embeddings(*args):
@@ -225,7 +223,7 @@ def register_embeddings(*args):
     return _register
 
 
-def load_embeddings(params: Dict[str, Any]) -> Embeddings:
+def load_embeddings(params: dict[str, Any]) -> Embeddings:
     cls_name = params.pop("__cls__")
     cls = EMBEDDING_CLASSES[cls_name]
     return cls.load_embedding(params)

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 import torch
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -67,7 +67,7 @@ class TransformerDocumentEmbeddings(DocumentEmbeddings, TransformerEmbeddings):
 class DocumentPoolEmbeddings(DocumentEmbeddings):
     def __init__(
         self,
-        embeddings: Union[TokenEmbeddings, List[TokenEmbeddings]],
+        embeddings: Union[TokenEmbeddings, list[TokenEmbeddings]],
         fine_tune_mode: str = "none",
         pooling: str = "mean",
     ) -> None:
@@ -114,7 +114,7 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def embed(self, sentences: Union[List[Sentence], Sentence]):
+    def embed(self, sentences: Union[list[Sentence], Sentence]):
         """Add embeddings to every sentence in the given list of sentences.
 
         If embeddings are already added, updates only if embeddings are non-static.
@@ -146,18 +146,18 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
 
             sentence.set_embedding(self.name, pooled_embedding)
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         pass
 
     def extra_repr(self):
         return f"fine_tune_mode={self.fine_tune_mode}, pooling={self.pooling}"
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "DocumentPoolEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "DocumentPoolEmbeddings":
         embeddings = cast(StackedEmbeddings, load_embeddings(params.pop("embeddings"))).embeddings
         return cls(embeddings=embeddings, **params)
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         return {
             "pooling": self.pooling,
             "fine_tune_mode": self.fine_tune_mode,
@@ -169,7 +169,7 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
 class DocumentTFIDFEmbeddings(DocumentEmbeddings):
     def __init__(
         self,
-        train_dataset: List[Sentence],
+        train_dataset: list[Sentence],
         vectorizer: Optional[TfidfVectorizer] = None,
         **vectorizer_params,
     ) -> None:
@@ -203,7 +203,7 @@ class DocumentTFIDFEmbeddings(DocumentEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def embed(self, sentences: Union[List[Sentence], Sentence]):
+    def embed(self, sentences: Union[list[Sentence], Sentence]):
         """Add embeddings to every sentence in the given list of sentences."""
         # if only one sentence is passed, convert to list of sentence
         if isinstance(sentences, Sentence):
@@ -215,14 +215,14 @@ class DocumentTFIDFEmbeddings(DocumentEmbeddings):
         for sentence_id, sentence in enumerate(sentences):
             sentence.set_embedding(self.name, tfidf_vectors[sentence_id])
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         pass
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "DocumentTFIDFEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "DocumentTFIDFEmbeddings":
         return cls(train_dataset=[], vectorizer=params["vectorizer"])
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         return {
             "vectorizer": self.vectorizer,
         }
@@ -232,7 +232,7 @@ class DocumentTFIDFEmbeddings(DocumentEmbeddings):
 class DocumentRNNEmbeddings(DocumentEmbeddings):
     def __init__(
         self,
-        embeddings: List[TokenEmbeddings],
+        embeddings: list[TokenEmbeddings],
         hidden_size=128,
         rnn_layers=1,
         reproject_words: bool = True,
@@ -317,7 +317,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         """Add embeddings to all sentences in the given list of sentences.
 
         If embeddings are already added, update only if embeddings are non-static.
@@ -332,7 +332,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         # embed words in the sentence
         self.embeddings.embed(sentences)
 
-        lengths: List[int] = [len(sentence.tokens) for sentence in sentences]
+        lengths: list[int] = [len(sentence.tokens) for sentence in sentences]
         longest_token_sequence_in_batch: int = max(lengths)
 
         pre_allocated_zero_tensor = torch.zeros(
@@ -341,7 +341,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
             device=flair.device,
         )
 
-        all_embs: List[torch.Tensor] = []
+        all_embs: list[torch.Tensor] = []
         for sentence in sentences:
             all_embs += [emb for token in sentence for emb in token.get_each_embedding()]
             nb_padding_tokens = longest_token_sequence_in_batch - len(sentence)
@@ -436,7 +436,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         return model_state
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "DocumentRNNEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "DocumentRNNEmbeddings":
         stacked_embeddings = load_embeddings(params["embeddings"])
         assert isinstance(stacked_embeddings, StackedEmbeddings)
         return cls(
@@ -484,7 +484,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
 
 @register_embeddings
 class DocumentLMEmbeddings(DocumentEmbeddings):
-    def __init__(self, flair_embeddings: List[FlairEmbeddings]) -> None:
+    def __init__(self, flair_embeddings: list[FlairEmbeddings]) -> None:
         super().__init__()
 
         self.embeddings = flair_embeddings
@@ -503,7 +503,7 @@ class DocumentLMEmbeddings(DocumentEmbeddings):
     def embedding_length(self) -> int:
         return self._embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         for embedding in self.embeddings:
             embedding.embed(sentences)
 
@@ -520,17 +520,17 @@ class DocumentLMEmbeddings(DocumentEmbeddings):
 
         return sentences
 
-    def get_names(self) -> List[str]:
+    def get_names(self) -> list[str]:
         if "__names" not in self.__dict__:
             self.__names = [name for embedding in self.embeddings for name in embedding.get_names()]
 
         return self.__names
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         return {"flair_embeddings": [embedding.save_embeddings(False) for embedding in self.embeddings]}
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "DocumentLMEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "DocumentLMEmbeddings":
         return cls([cast(FlairEmbeddings, load_embeddings(embedding)) for embedding in params["flair_embeddings"]])
 
 
@@ -566,7 +566,7 @@ class SentenceTransformerDocumentEmbeddings(DocumentEmbeddings):
         self.static_embeddings = True
         self.eval()
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         sentence_batches = [
             sentences[i * self.batch_size : (i + 1) * self.batch_size]
             for i in range((len(sentences) + self.batch_size - 1) // self.batch_size)
@@ -577,7 +577,7 @@ class SentenceTransformerDocumentEmbeddings(DocumentEmbeddings):
 
         return sentences
 
-    def _add_embeddings_to_sentences(self, sentences: List[Sentence]):
+    def _add_embeddings_to_sentences(self, sentences: list[Sentence]):
         # convert to plain strings, embedded in a list for the encode function
         sentences_plain_text = [sentence.to_plain_string() for sentence in sentences]
 
@@ -591,10 +591,10 @@ class SentenceTransformerDocumentEmbeddings(DocumentEmbeddings):
         return self.model.get_sentence_embedding_dimension()
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "SentenceTransformerDocumentEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "SentenceTransformerDocumentEmbeddings":
         return cls(**params)
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         return {
             "model": self.model_name,
             "batch_size": self.batch_size,
@@ -605,7 +605,7 @@ class SentenceTransformerDocumentEmbeddings(DocumentEmbeddings):
 class DocumentCNNEmbeddings(DocumentEmbeddings):
     def __init__(
         self,
-        embeddings: List[TokenEmbeddings],
+        embeddings: list[TokenEmbeddings],
         kernels=((100, 3), (100, 4), (100, 5)),
         reproject_words: bool = True,
         reproject_words_dimension: Optional[int] = None,
@@ -673,7 +673,7 @@ class DocumentCNNEmbeddings(DocumentEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         """Add embeddings to all sentences in the given list of sentences.
 
         If embeddings are already added, update only if embeddings are non-static.
@@ -689,7 +689,7 @@ class DocumentCNNEmbeddings(DocumentEmbeddings):
         # embed words in the sentence
         self.embeddings.embed(sentences)
 
-        lengths: List[int] = [len(sentence.tokens) for sentence in sentences]
+        lengths: list[int] = [len(sentence.tokens) for sentence in sentences]
         padding_length: int = max(max(lengths), self.min_sequence_length)
 
         pre_allocated_zero_tensor = torch.zeros(
@@ -698,7 +698,7 @@ class DocumentCNNEmbeddings(DocumentEmbeddings):
             device=flair.device,
         )
 
-        all_embs: List[torch.Tensor] = []
+        all_embs: list[torch.Tensor] = []
         for sentence in sentences:
             all_embs += [emb for token in sentence for emb in token.get_each_embedding()]
             nb_padding_tokens = padding_length - len(sentence)
@@ -757,11 +757,11 @@ class DocumentCNNEmbeddings(DocumentEmbeddings):
             child_module._apply(fn)
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "DocumentCNNEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "DocumentCNNEmbeddings":
         embeddings = cast(StackedEmbeddings, load_embeddings(params.pop("embeddings"))).embeddings
         return cls(embeddings=embeddings, **params)
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         return {
             "embeddings": self.embeddings.save_embeddings(False),
             "kernels": self.kernels,

--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -371,7 +371,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
             sentence_tensor = self.word_reprojection_map(sentence_tensor)
 
         # push through RNN
-        packed = pack_padded_sequence(sentence_tensor, lengths, enforce_sorted=False, batch_first=True)  # type: ignore[arg-type]
+        packed = pack_padded_sequence(sentence_tensor, lengths, enforce_sorted=False, batch_first=True)
         rnn_out, hidden = self.rnn(packed)
         outputs, output_lengths = pad_packed_sequence(rnn_out, batch_first=True)
 

--- a/flair/embeddings/image.py
+++ b/flair/embeddings/image.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import torch
 import torch.nn.functional as F
@@ -29,12 +29,12 @@ class ImageEmbeddings(Embeddings[Image]):
     def embedding_type(self) -> str:
         return "image-level"
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         # legacy pickle-like saving for image embeddings, as implementation details are not obvious
         return self.__getstate__()
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "Embeddings":
+    def from_params(cls, params: dict[str, Any]) -> "Embeddings":
         # legacy pickle-like loading for image embeddings, as implementation details are not obvious
         embedding = cls.__new__(cls)
         embedding.__setstate__(params)
@@ -53,7 +53,7 @@ class IdentityImageEmbeddings(ImageEmbeddings):
         self.static_embeddings = True
         super().__init__()
 
-    def _add_embeddings_internal(self, images: List[Image]):
+    def _add_embeddings_internal(self, images: list[Image]):
         for image in images:
             image_data = self.PIL.Image.open(image.imageURL)
             image_data.load()
@@ -77,7 +77,7 @@ class PrecomputedImageEmbeddings(ImageEmbeddings):
         self.static_embeddings = True
         super().__init__()
 
-    def _add_embeddings_internal(self, images: List[Image]):
+    def _add_embeddings_internal(self, images: list[Image]):
         for image in images:
             if image.imageURL in self.url2tensor_dict:
                 image.set_embedding(self.name, self.url2tensor_dict[image.imageURL])
@@ -137,7 +137,7 @@ class NetworkImageEmbeddings(ImageEmbeddings):
         else:
             raise Exception(f"Image embeddings {name} not available.")
 
-    def _add_embeddings_internal(self, images: List[Image]):
+    def _add_embeddings_internal(self, images: list[Image]):
         image_tensor = torch.stack([self.transforms(image.data) for image in images])
         image_embeddings = self.features(image_tensor)
         image_embeddings = (
@@ -163,7 +163,7 @@ class ConvTransformNetworkImageEmbeddings(ImageEmbeddings):
 
         adaptive_pool_func_map = {"max": AdaptiveMaxPool2d, "avg": AdaptiveAvgPool2d}
 
-        convnet_arch: List[Any] = [] if convnet_parms["dropout"][0] <= 0 else [Dropout2d(convnet_parms["dropout"][0])]
+        convnet_arch: list[Any] = [] if convnet_parms["dropout"][0] <= 0 else [Dropout2d(convnet_parms["dropout"][0])]
         convnet_arch.extend(
             [
                 Conv2d(
@@ -266,7 +266,7 @@ class ConvTransformNetworkImageEmbeddings(ImageEmbeddings):
 
         return x
 
-    def _add_embeddings_internal(self, images: List[Image]):
+    def _add_embeddings_internal(self, images: list[Image]):
         image_tensor = torch.stack([image.data for image in images])
         image_embeddings = self.forward(image_tensor)
         for image_id, image in enumerate(images):

--- a/flair/embeddings/legacy.py
+++ b/flair/embeddings/legacy.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import torch
 from deprecated.sphinx import deprecated
@@ -110,12 +110,12 @@ class ELMoEmbeddings(TokenEmbeddings):
     def use_layers_average(self, x):
         return torch.mean(torch.stack(x), 0)
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         # ELMoEmbeddings before Release 0.5 did not set self.embedding_mode_fn
         if not getattr(self, "embedding_mode_fn", None):
             self.embedding_mode_fn = self.use_layers_all
 
-        sentence_words: List[List[str]] = []
+        sentence_words: list[list[str]] = []
         for sentence in sentences:
             sentence_words.append([token.text for token in sentence])
 
@@ -394,7 +394,7 @@ class CharLMEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         # if cache is used, try setting embeddings from cache first
         if "cache" in self.__dict__ and self.cache is not None:
             # try populating embeddings from cache
@@ -463,7 +463,7 @@ class DocumentMeanEmbeddings(DocumentEmbeddings):
         version="0.3.1",
         reason="The functionality of this class is moved to 'DocumentPoolEmbeddings'",
     )
-    def __init__(self, token_embeddings: List[TokenEmbeddings]) -> None:
+    def __init__(self, token_embeddings: list[TokenEmbeddings]) -> None:
         """The constructor takes a list of embeddings to be combined."""
         super().__init__()
 
@@ -478,7 +478,7 @@ class DocumentMeanEmbeddings(DocumentEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def embed(self, sentences: Union[List[Sentence], Sentence]):
+    def embed(self, sentences: Union[list[Sentence], Sentence]):
         """Add embeddings to every sentence in the given list of sentences. If embeddings are already added, updates
         only if embeddings are non-static.
         """
@@ -506,7 +506,7 @@ class DocumentMeanEmbeddings(DocumentEmbeddings):
 
                 sentence.set_embedding(self.name, mean_embedding)
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         pass
 
 
@@ -517,7 +517,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
     )
     def __init__(
         self,
-        embeddings: List[TokenEmbeddings],
+        embeddings: list[TokenEmbeddings],
         hidden_size=128,
         rnn_layers=1,
         reproject_words: bool = True,
@@ -587,7 +587,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def embed(self, sentences: Union[List[Sentence], Sentence]):
+    def embed(self, sentences: Union[list[Sentence], Sentence]):
         """Add embeddings to all sentences in the given list of sentences. If embeddings are already added, update
         only if embeddings are non-static.
         """
@@ -604,7 +604,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
         longest_token_sequence_in_batch: int = len(sentences[0])
 
         all_sentence_tensors = []
-        lengths: List[int] = []
+        lengths: list[int] = []
 
         # go through each sentence in batch
         for _i, sentence in enumerate(sentences):
@@ -669,5 +669,5 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
             sentence = sentences[sentence_no]
             sentence.set_embedding(self.name, embedding)
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         pass

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -4,7 +4,7 @@ import re
 import tempfile
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import torch
@@ -64,7 +64,7 @@ class TransformerWordEmbeddings(TokenEmbeddings, TransformerEmbeddings):
 class StackedEmbeddings(TokenEmbeddings):
     """A stack of embeddings, used if you need to combine several different embedding types."""
 
-    def __init__(self, embeddings: List[TokenEmbeddings], overwrite_names: bool = True) -> None:
+    def __init__(self, embeddings: list[TokenEmbeddings], overwrite_names: bool = True) -> None:
         """The constructor takes a list of embeddings to be combined."""
         super().__init__()
 
@@ -88,7 +88,7 @@ class StackedEmbeddings(TokenEmbeddings):
             self.__embedding_length += embedding.embedding_length
         self.eval()
 
-    def embed(self, sentences: Union[Sentence, List[Sentence]], static_embeddings: bool = True):
+    def embed(self, sentences: Union[Sentence, list[Sentence]], static_embeddings: bool = True):
         # if only one sentence is passed, convert to list of sentence
         if type(sentences) is Sentence:
             sentences = [sentences]
@@ -104,7 +104,7 @@ class StackedEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         for embedding in self.embeddings:
             embedding._add_embeddings_internal(sentences)
 
@@ -113,7 +113,7 @@ class StackedEmbeddings(TokenEmbeddings):
     def __str__(self) -> str:
         return f'StackedEmbeddings [{",".join([str(e) for e in self.embeddings])}]'
 
-    def get_names(self) -> List[str]:
+    def get_names(self) -> list[str]:
         """Returns a list of embedding names.
 
         In most cases, it is just a list with one item, namely the name of this embedding. But in some cases, the
@@ -125,13 +125,6 @@ class StackedEmbeddings(TokenEmbeddings):
             self.__names = [name for embedding in self.embeddings for name in embedding.get_names()]
 
         return self.__names
-
-    def get_named_embeddings_dict(self) -> Dict:
-        named_embeddings_dict = {}
-        for embedding in self.embeddings:
-            named_embeddings_dict.update(embedding.get_named_embeddings_dict())
-
-        return named_embeddings_dict
 
     @classmethod
     def from_params(cls, params):
@@ -154,7 +147,7 @@ class WordEmbeddings(TokenEmbeddings):
         force_cpu: bool = True,
         stable: bool = False,
         no_header: bool = False,
-        vocab: Optional[Dict[str, int]] = None,
+        vocab: Optional[dict[str, int]] = None,
         embedding_length: Optional[int] = None,
         name: Optional[str] = None,
     ) -> None:
@@ -334,10 +327,10 @@ class WordEmbeddings(TokenEmbeddings):
         else:
             return len(self.vocab)  # <unk> token
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         tokens = [token for sentence in sentences for token in sentence.tokens]
 
-        word_indices: List[int] = []
+        word_indices: list[int] = []
         for token in tokens:
             word = token.text if self.field is None else token.get_label(self.field).value
             word_indices.append(self.get_cached_token_index(word))
@@ -386,7 +379,7 @@ class WordEmbeddings(TokenEmbeddings):
             return None
         return super().__getattribute__(item)
 
-    def __setstate__(self, state: Dict[str, Any]):
+    def __setstate__(self, state: dict[str, Any]):
         state.pop("get_cached_vec", None)
         state.setdefault("embeddings", state["name"])
         state.setdefault("force_cpu", True)
@@ -416,10 +409,10 @@ class WordEmbeddings(TokenEmbeddings):
         super().__setstate__(state)
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "WordEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "WordEmbeddings":
         return cls(embeddings=None, **params)
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         return {
             "vocab": self.vocab,
             "stable": self.stable,
@@ -487,7 +480,7 @@ class CharacterEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         for sentence in sentences:
             tokens_char_indices = []
 
@@ -544,10 +537,10 @@ class CharacterEmbeddings(TokenEmbeddings):
         return self.name
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "CharacterEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "CharacterEmbeddings":
         return cls(**params)
 
-    def to_params(self) -> Dict[str, Any]:
+    def to_params(self) -> dict[str, Any]:
         return {
             "path_to_char_dict": self.char_dictionary,
             "char_embedding_dim": self.char_embedding_dim,
@@ -793,7 +786,7 @@ class FlairEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         # gradients are enable if fine-tuning is enabled
         gradient_context = torch.enable_grad() if self.fine_tune else torch.no_grad()
 
@@ -885,7 +878,7 @@ class FlairEmbeddings(TokenEmbeddings):
         lm = LanguageModel(**model_params)
         return cls(lm, **params)
 
-    def __setstate__(self, d: Dict[str, Any]):
+    def __setstate__(self, d: dict[str, Any]):
         # make compatible with old models
         d.setdefault("fine_tune", False)
         d.setdefault("chars_per_chunk", 512)
@@ -920,8 +913,8 @@ class PooledFlairEmbeddings(TokenEmbeddings):
         self.name = self.context_embeddings.name + "-context"
 
         # these fields are for the embedding memory
-        self.word_embeddings: Dict[str, torch.Tensor] = {}
-        self.word_count: Dict[str, int] = {}
+        self.word_embeddings: dict[str, torch.Tensor] = {}
+        self.word_count: dict[str, int] = {}
 
         # whether to add only capitalized words to memory (faster runtime and lower memory consumption)
         self.only_capitalized = only_capitalized
@@ -940,7 +933,7 @@ class PooledFlairEmbeddings(TokenEmbeddings):
             self.word_embeddings = {}
             self.word_count = {}
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         self.context_embeddings.embed(sentences)
 
         # if we keep a pooling, it needs to be updated continuously
@@ -989,10 +982,10 @@ class PooledFlairEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def get_names(self) -> List[str]:
+    def get_names(self) -> list[str]:
         return [self.name, self.context_embeddings.name]
 
-    def __setstate__(self, d: Dict[str, Any]):
+    def __setstate__(self, d: dict[str, Any]):
         super().__setstate__(d)
 
         if flair.device.type != "cpu":
@@ -1073,7 +1066,7 @@ class FastTextEmbeddings(TokenEmbeddings):
         word_embedding = torch.tensor(word_embedding.tolist(), device=flair.device, dtype=torch.float)
         return word_embedding
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         for sentence in sentences:
             for token in sentence.tokens:
                 word = token.text if self.field is None else token.get_label(self.field).value
@@ -1152,7 +1145,7 @@ class OneHotEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         tokens = [t for sentence in sentences for t in sentence.tokens]
 
         if self.field == "text":
@@ -1240,7 +1233,7 @@ class HashEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         def get_idx_for_item(text):
             hash_function = hashlib.new(self.__hash_method)
             hash_function.update(bytes(str(text), "utf-8"))
@@ -1282,7 +1275,7 @@ class MuseCrosslingualEmbeddings(TokenEmbeddings):
         self.name: str = "muse-crosslingual"
         self.static_embeddings = True
         self.__embedding_length: int = 300
-        self.language_embeddings: Dict[str, Any] = {}
+        self.language_embeddings: dict[str, Any] = {}
         (KeyedVectors,) = lazy_import("word-embeddings", "gensim.models", "KeyedVectors")
         self.kv = KeyedVectors
         super().__init__()
@@ -1304,7 +1297,7 @@ class MuseCrosslingualEmbeddings(TokenEmbeddings):
         word_embedding = torch.tensor(word_embedding, device=flair.device, dtype=torch.float)
         return word_embedding
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         for _i, sentence in enumerate(sentences):
             language_code = sentence.get_language_code()
             supported = [
@@ -1465,10 +1458,10 @@ class BytePairEmbeddings(TokenEmbeddings):
     def embedding_length(self) -> int:
         return self.__embedding_length
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+    def _add_embeddings_internal(self, sentences: list[Sentence]) -> list[Sentence]:
         tokens = [token for sentence in sentences for token in sentence.tokens]
 
-        word_indices: List[List[int]] = []
+        word_indices: list[list[int]] = []
         for token in tokens:
             word = token.text if self.field is None else token.get_label(self.field).value
 
@@ -1601,13 +1594,13 @@ class NILCEmbeddings(WordEmbeddings):
         else:
             embeddings_path = embeddings
 
-        log.info("Reading embeddings from %s" % embeddings_path)
+        log.info("Reading embeddings from %s", embeddings_path)
         super().__init__(
             embeddings=str(extract_single_zip_file(embeddings_path, cache_dir=cache_dir)), name="NILC-" + embeddings
         )
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "WordEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "WordEmbeddings":
         #  no need to recreate as NILCEmbeddings
         return WordEmbeddings(embeddings=None, **params)
 

--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -513,7 +513,7 @@ class CharacterEmbeddings(TokenEmbeddings):
 
             character_embeddings = self.char_embedding(chars).transpose(0, 1)
 
-            packed = torch.nn.utils.rnn.pack_padded_sequence(character_embeddings, chars2_length)  # type: ignore[arg-type]
+            packed = torch.nn.utils.rnn.pack_padded_sequence(character_embeddings, chars2_length)
 
             lstm_out, self.hidden = self.char_rnn(packed)
 

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -1353,6 +1353,11 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
 
     def to_params(self):
         config_dict = self.model.config.to_dict()
+
+        # do not switch the attention implementation upon reload.
+        config_dict["attn_implementation"] = self.model.config._attn_implementation
+        del config_dict["_attn_implementation_autoset"]
+
         super_params = super().to_params()
 
         # those parameters are only from the super class and will be recreated in the constructor.

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -8,7 +8,7 @@ import zipfile
 from abc import abstractmethod
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, cast
+from typing import Any, Literal, Optional, Union, cast
 
 import torch
 import transformers
@@ -44,7 +44,7 @@ SENTENCE_BOUNDARY_TAG: str = "[FLERT]"
 
 
 @torch.jit.script_if_tracing
-def pad_sequence_embeddings(all_hidden_states: List[torch.Tensor]) -> torch.Tensor:
+def pad_sequence_embeddings(all_hidden_states: list[torch.Tensor]) -> torch.Tensor:
     embedding_length = all_hidden_states[0].shape[1]
     longest_token_sequence_in_batch = 0
     for hidden_states in all_hidden_states:
@@ -218,13 +218,13 @@ def document_max_pooling(sentence_hidden_states: torch.Tensor, sentence_lengths:
 
 
 def _legacy_reconstruct_word_ids(
-    embedding: "TransformerBaseEmbeddings", flair_tokens: List[List[str]]
-) -> List[List[Optional[int]]]:
+    embedding: "TransformerBaseEmbeddings", flair_tokens: list[list[str]]
+) -> list[list[Optional[int]]]:
     word_ids_list = []
     max_len = 0
     for tokens in flair_tokens:
         token_texts = embedding.tokenizer.tokenize(" ".join(tokens), is_split_into_words=True)
-        token_ids = cast(List[int], embedding.tokenizer.convert_tokens_to_ids(token_texts))
+        token_ids = cast(list[int], embedding.tokenizer.convert_tokens_to_ids(token_texts))
         expanded_token_ids = embedding.tokenizer.build_inputs_with_special_tokens(token_ids)
         j = 0
         for _i, token_id in enumerate(token_ids):
@@ -264,10 +264,10 @@ def _get_processed_token_text(tokenizer, token: str) -> str:
     return token_text.strip()
 
 
-def _reconstruct_word_ids_from_subtokens(embedding, tokens: List[str], subtokens: List[str]):
+def _reconstruct_word_ids_from_subtokens(embedding, tokens: list[str], subtokens: list[str]):
     word_iterator = iter(enumerate(_get_processed_token_text(embedding.tokenizer, token) for token in tokens))
     token_id, token_text = next(word_iterator)
-    word_ids: List[Optional[int]] = []
+    word_ids: list[Optional[int]] = []
     reconstructed_token = ""
     subtoken_count = 0
     processed_first_token = False
@@ -504,10 +504,10 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         return "word-level" if self.token_embedding else "sentence-level"
 
     @abstractmethod
-    def _forward_tensors(self, tensors) -> Dict[str, torch.Tensor]:
+    def _forward_tensors(self, tensors) -> dict[str, torch.Tensor]:
         return self(**tensors)
 
-    def prepare_tensors(self, sentences: List[Sentence], device: Optional[torch.device] = None):
+    def prepare_tensors(self, sentences: list[Sentence], device: Optional[torch.device] = None):
         if device is None:
             device = flair.device
         flair_tokens, offsets, lengths = self.__gather_flair_tokens(sentences)
@@ -535,13 +535,13 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
 
     def __build_transformer_model_inputs(
         self,
-        sentences: List[Sentence],
-        offsets: List[int],
-        sentence_lengths: List[int],
-        flair_tokens: List[List[Token]],
+        sentences: list[Sentence],
+        offsets: list[int],
+        sentence_lengths: list[int],
+        flair_tokens: list[list[Token]],
         device: torch.device,
     ):
-        tokenizer_kwargs: Dict[str, Any] = {}
+        tokenizer_kwargs: dict[str, Any] = {}
         if self.tokenizer_needs_ocr_boxes:
             tokenizer_kwargs["boxes"] = [[t.get_metadata("bbox") for t in tokens] for tokens in flair_tokens]
         else:
@@ -662,7 +662,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
 
         return model_kwargs
 
-    def __gather_flair_tokens(self, sentences: List[Sentence]) -> Tuple[List[List[Token]], List[int], List[int]]:
+    def __gather_flair_tokens(self, sentences: list[Sentence]) -> tuple[list[list[Token]], list[int], list[int]]:
         offsets = []
         lengths = []
         if self.context_length > 0:
@@ -686,7 +686,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
             lengths.append(len(sentence))
         return sentence_tokens, offsets, lengths
 
-    def _expand_sentence_with_context(self, sentence) -> Tuple[List[Token], int]:
+    def _expand_sentence_with_context(self, sentence) -> tuple[list[Token], int]:
         # fields to store left and right context
         left_context = []
         right_context = []
@@ -722,7 +722,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
             for token_embedding, token in zip(token_embeddings, sentence):
                 token.set_embedding(self.name, token_embedding)
 
-    def _add_embeddings_internal(self, sentences: List[Sentence]):
+    def _add_embeddings_internal(self, sentences: list[Sentence]):
         tensors = self.prepare_tensors(sentences, device=self.force_device)
         gradient_context = torch.enable_grad() if (self.fine_tune and self.training) else torch.no_grad()
         with gradient_context:
@@ -739,7 +739,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
 
 @register_embeddings
 class TransformerOnnxEmbeddings(TransformerBaseEmbeddings):
-    def __init__(self, onnx_model: str, providers: List = [], session_options: Optional[Dict] = None, **kwargs) -> None:
+    def __init__(self, onnx_model: str, providers: list = [], session_options: Optional[dict] = None, **kwargs) -> None:
         # onnx prepares numpy arrays, no mather if it runs on gpu or cpu, the input is on cpu first.
         super().__init__(**kwargs, force_device=torch.device("cpu"))
         self.onnx_model = onnx_model
@@ -756,7 +756,7 @@ class TransformerOnnxEmbeddings(TransformerBaseEmbeddings):
         return params
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "TransformerOnnxEmbeddings":
+    def from_params(cls, params: dict[str, Any]) -> "TransformerOnnxEmbeddings":
         params["tokenizer"] = cls._tokenizer_from_bytes(params.pop("tokenizer_data"))
         params["feature_extractor"] = cls._feature_extractor_from_bytes(params.pop("feature_extractor_data", None))
         return cls(**params)
@@ -812,7 +812,7 @@ class TransformerOnnxEmbeddings(TransformerBaseEmbeddings):
         self.onnx_model = quantize_model_path
         self.create_session()
 
-    def _forward_tensors(self, tensors) -> Dict[str, torch.Tensor]:
+    def _forward_tensors(self, tensors) -> dict[str, torch.Tensor]:
         input_array = {k: v.numpy() for k, v in tensors.items()}
         embeddings = self.session.run([], input_array)
 
@@ -854,9 +854,9 @@ class TransformerOnnxEmbeddings(TransformerBaseEmbeddings):
         cls,
         path: Union[str, Path],
         embedding: "TransformerEmbeddings",
-        example_sentences: List[Sentence],
+        example_sentences: list[Sentence],
         opset_version: int = 14,
-        providers: Optional[List] = None,
+        providers: Optional[list] = None,
         session_options: Optional[dict] = None,
     ):
         path = str(path)
@@ -903,7 +903,7 @@ class TransformerOnnxEmbeddings(TransformerBaseEmbeddings):
 
 @register_embeddings
 class TransformerJitEmbeddings(TransformerBaseEmbeddings):
-    def __init__(self, jit_model: Union[bytes, ScriptModule], param_names: List[str], **kwargs) -> None:
+    def __init__(self, jit_model: Union[bytes, ScriptModule], param_names: list[str], **kwargs) -> None:
         super().__init__(**kwargs)
         if isinstance(jit_model, bytes):
             buffer = BytesIO(jit_model)
@@ -925,12 +925,12 @@ class TransformerJitEmbeddings(TransformerBaseEmbeddings):
         return state
 
     @classmethod
-    def from_params(cls, params: Dict[str, Any]) -> "Embeddings":
+    def from_params(cls, params: dict[str, Any]) -> "Embeddings":
         params["tokenizer"] = cls._tokenizer_from_bytes(params.pop("tokenizer_data"))
         params["feature_extractor"] = cls._feature_extractor_from_bytes(params.pop("feature_extractor_data", None))
         return cls(**params)
 
-    def _forward_tensors(self, tensors) -> Dict[str, torch.Tensor]:
+    def _forward_tensors(self, tensors) -> dict[str, torch.Tensor]:
         parameters = []
         for param in self.param_names:
             parameters.append(tensors[param])
@@ -945,13 +945,13 @@ class TransformerJitEmbeddings(TransformerBaseEmbeddings):
             raise ValueError("either 'token_embedding' or 'document_embedding' needs to be set.")
 
     @classmethod
-    def create_from_embedding(cls, module: ScriptModule, embedding: "TransformerEmbeddings", param_names: List[str]):
+    def create_from_embedding(cls, module: ScriptModule, embedding: "TransformerEmbeddings", param_names: list[str]):
         return cls(jit_model=module, param_names=param_names, **embedding.to_args())
 
     @classmethod
     def parameter_to_list(
-        cls, embedding: "TransformerEmbeddings", wrapper: torch.nn.Module, sentences: List[Sentence]
-    ) -> Tuple[List[str], List[torch.Tensor]]:
+        cls, embedding: "TransformerEmbeddings", wrapper: torch.nn.Module, sentences: list[Sentence]
+    ) -> tuple[list[str], list[torch.Tensor]]:
         tensors = embedding.prepare_tensors(sentences)
         param_names = list(inspect.signature(wrapper.forward).parameters.keys())
         params = []
@@ -998,7 +998,7 @@ class TransformerOnnxDocumentEmbeddings(DocumentEmbeddings, TransformerOnnxEmbed
 
 @register_embeddings
 class TransformerEmbeddings(TransformerBaseEmbeddings):
-    onnx_cls: Type[TransformerOnnxEmbeddings] = TransformerOnnxEmbeddings
+    onnx_cls: type[TransformerOnnxEmbeddings] = TransformerOnnxEmbeddings
 
     def __init__(
         self,
@@ -1021,11 +1021,11 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         force_max_length: bool = False,
         needs_manual_ocr: Optional[bool] = None,
         use_context_separator: bool = True,
-        transformers_tokenizer_kwargs: Dict[str, Any] = {},
-        transformers_config_kwargs: Dict[str, Any] = {},
-        transformers_model_kwargs: Dict[str, Any] = {},
+        transformers_tokenizer_kwargs: dict[str, Any] = {},
+        transformers_config_kwargs: dict[str, Any] = {},
+        transformers_model_kwargs: dict[str, Any] = {},
         peft_config=None,
-        peft_gradient_checkpointing_kwargs: Optional[Dict[str, Any]] = {},
+        peft_gradient_checkpointing_kwargs: Optional[dict[str, Any]] = {},
         **kwargs,
     ) -> None:
         """Instantiate transformers embeddings.
@@ -1503,11 +1503,11 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
             result["token_embeddings"] = all_token_embeddings
         return result
 
-    def _forward_tensors(self, tensors) -> Dict[str, torch.Tensor]:
+    def _forward_tensors(self, tensors) -> dict[str, torch.Tensor]:
         return self.forward(**tensors)
 
     def export_onnx(
-        self, path: Union[str, Path], example_sentences: List[Sentence], **kwargs
+        self, path: Union[str, Path], example_sentences: list[Sentence], **kwargs
     ) -> TransformerOnnxEmbeddings:
         """Export TransformerEmbeddings to OnnxFormat.
 

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -12,8 +12,9 @@ import tempfile
 import typing
 import warnings
 import zipfile
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Sequence, Tuple, Union, cast
+from typing import Optional, Union, cast
 from urllib.parse import urlparse
 
 import boto3
@@ -28,10 +29,10 @@ import flair
 
 logger = logging.getLogger("flair")
 
-url_proxies: Optional[typing.Dict[str, str]] = None
+url_proxies: Optional[dict[str, str]] = None
 
 
-def set_proxies(proxies: typing.Dict[str, str]) -> None:
+def set_proxies(proxies: dict[str, str]) -> None:
     r"""Allows for data downloaded from urls to be forwarded to a proxy.
 
     see https://requests.readthedocs.io/en/latest/user/advanced/#proxies
@@ -74,7 +75,7 @@ def url_to_filename(url: str, etag: Optional[str] = None) -> str:
         return decoded
 
 
-def filename_to_url(filename: str) -> Tuple[str, Optional[str]]:
+def filename_to_url(filename: str) -> tuple[str, Optional[str]]:
     """Recovers the the url from the encoded filename.
 
     Returns it and the ETag (which may be ``None``)
@@ -374,7 +375,7 @@ def instance_lru_cache(*cache_args, **cache_kwargs):
     return decorator
 
 
-def load_torch_state(model_file: str) -> typing.Dict[str, typing.Any]:
+def load_torch_state(model_file: str) -> dict[str, typing.Any]:
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
         # load_big_file is a workaround byhttps://github.com/highway11git

--- a/flair/inference_utils.py
+++ b/flair/inference_utils.py
@@ -126,7 +126,7 @@ class WordEmbeddingsStore:
         Also deletes the original vectors to save memory.
         """
         for embedding in WordEmbeddingsStore._word_embeddings(model):
-            if type(embedding) == WordEmbeddings:
+            if isinstance(embedding, WordEmbeddings):
                 WordEmbeddingsStore(embedding, backend)
                 del embedding.precomputed_word_embeddings
 
@@ -135,7 +135,7 @@ class WordEmbeddingsStore:
         """Loads the db versions of all word embeddings in the model."""
         embeds = WordEmbeddingsStore._word_embeddings(model)
         for i, embedding in enumerate(embeds):
-            if type(embedding) == WordEmbeddings:
+            if isinstance(embedding, WordEmbeddings):
                 embeds[i] = WordEmbeddingsStore(embedding, backend)
 
     @staticmethod

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -1,6 +1,6 @@
 import math
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 from torch import logsumexp, nn
@@ -111,7 +111,7 @@ class LanguageModel(nn.Module):
 
     def get_representation(
         self,
-        strings: List[str],
+        strings: list[str],
         start_marker: str,
         end_marker: str,
         chars_per_chunk: int = 512,
@@ -119,7 +119,7 @@ class LanguageModel(nn.Module):
         len_longest_str: int = len(max(strings, key=len))
 
         # pad strings with whitespaces to longest sentence
-        padded_strings: List[str] = []
+        padded_strings: list[str] = []
 
         for string in strings:
             if not self.is_forward_lm:
@@ -141,11 +141,11 @@ class LanguageModel(nn.Module):
 
         padding_char_index = self.dictionary.get_idx_for_item(" ")
 
-        batches: List[torch.Tensor] = []
+        batches: list[torch.Tensor] = []
         # push each chunk through the RNN language model
         for chunk in chunks:
             len_longest_chunk: int = len(max(chunk, key=len))
-            sequences_as_char_indices: List[List[int]] = []
+            sequences_as_char_indices: list[list[int]] = []
             for string in chunk:
                 char_indices = self.dictionary.get_idx_for_items(list(string))
                 char_indices += [padding_char_index] * (len_longest_chunk - len(string))
@@ -176,7 +176,7 @@ class LanguageModel(nn.Module):
 
     def repackage_hidden(self, h):
         """Wraps hidden states in new Variables, to detach them from their history."""
-        if type(h) == torch.Tensor:
+        if isinstance(h, torch.Tensor):
             return h.clone().detach()
         else:
             return tuple(self.repackage_hidden(v) for v in h)
@@ -296,7 +296,7 @@ class LanguageModel(nn.Module):
         number_of_characters: int = 1000,
         temperature: float = 1.0,
         break_on_suffix=None,
-    ) -> Tuple[str, float]:
+    ) -> tuple[str, float]:
         if prefix == "":
             prefix = "\n"
 

--- a/flair/models/pairwise_classification_model.py
+++ b/flair/models/pairwise_classification_model.py
@@ -1,5 +1,4 @@
 import typing
-from typing import List
 
 import torch
 
@@ -69,7 +68,7 @@ class TextPairClassifier(flair.nn.DefaultClassifier[TextPair, TextPair]):
     def label_type(self):
         return self._label_type
 
-    def _get_data_points_from_sentence(self, sentence: TextPair) -> List[TextPair]:
+    def _get_data_points_from_sentence(self, sentence: TextPair) -> list[TextPair]:
         return [sentence]
 
     def _get_embedding_for_data_point(self, prediction_data_point: TextPair) -> torch.Tensor:
@@ -119,7 +118,7 @@ class TextPairClassifier(flair.nn.DefaultClassifier[TextPair, TextPair]):
 
     def get_used_tokens(
         self, corpus: Corpus, context_length: int = 0, respect_document_boundaries: bool = True
-    ) -> typing.Iterable[List[str]]:
+    ) -> typing.Iterable[list[str]]:
         for sentence_pair in _iter_dataset(corpus.get_all_sentences()):
             yield [t.text for t in sentence_pair.first]
             yield [t.text for t in sentence_pair.first.left_context(context_length, respect_document_boundaries)]

--- a/flair/models/regexp_tagger.py
+++ b/flair/models/regexp_tagger.py
@@ -1,7 +1,7 @@
 import re
 import typing
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Union
+from typing import Union
 
 from flair.data import Sentence, Span, Token
 
@@ -15,8 +15,8 @@ class TokenCollection:
     """
 
     sentence: Sentence
-    __tokens_start_pos: List[int] = field(init=False, default_factory=list)
-    __tokens_end_pos: List[int] = field(init=False, default_factory=list)
+    __tokens_start_pos: list[int] = field(init=False, default_factory=list)
+    __tokens_end_pos: list[int] = field(init=False, default_factory=list)
 
     def __post_init__(self):
         for token in self.tokens:
@@ -24,10 +24,10 @@ class TokenCollection:
             self.__tokens_end_pos.append(token.end_position)
 
     @property
-    def tokens(self) -> List[Token]:
+    def tokens(self) -> list[Token]:
         return list(self.sentence)
 
-    def get_token_span(self, span: Tuple[int, int]) -> Span:
+    def get_token_span(self, span: tuple[int, int]) -> Span:
         """Find a span by the token character positions.
 
         Given an interval specified with start and end pos as tuple, this function returns a Span object
@@ -45,7 +45,7 @@ class TokenCollection:
 
 
 class RegexpTagger:
-    def __init__(self, mapping: Union[List[Tuple[str, str]], Tuple[str, str]]) -> None:
+    def __init__(self, mapping: Union[list[tuple[str, str]], tuple[str, str]]) -> None:
         r"""This tagger is capable of tagging sentence objects with given regexp -> label mappings.
 
         I.e: The tuple (r'(["\'])(?:(?=(\\?))\2.)*?\1', 'QUOTE') maps every match of the regexp to
@@ -58,14 +58,14 @@ class RegexpTagger:
         Args:
             mapping: A list of tuples or a single tuple representing a mapping as regexp -> label
         """
-        self._regexp_mapping: Dict[str, typing.Pattern] = {}
+        self._regexp_mapping: dict[str, typing.Pattern] = {}
         self.register_labels(mapping=mapping)
 
     @property
     def registered_labels(self):
         return self._regexp_mapping
 
-    def register_labels(self, mapping: Union[List[Tuple[str, str]], Tuple[str, str]]):
+    def register_labels(self, mapping: Union[list[tuple[str, str]], tuple[str, str]]):
         """Register a regexp -> label mapping.
 
         Args:
@@ -81,7 +81,7 @@ class RegexpTagger:
                     f"Couldn't compile regexp '{regexp}' for label '{label}'. Aborted with error: '{err.msg}'"
                 )
 
-    def remove_labels(self, labels: Union[List[str], str]):
+    def remove_labels(self, labels: Union[list[str], str]):
         """Remove a registered regexp -> label mapping given by label.
 
         Args:
@@ -101,7 +101,7 @@ class RegexpTagger:
         else:
             return element
 
-    def predict(self, sentences: Union[List[Sentence], Sentence]) -> List[Sentence]:
+    def predict(self, sentences: Union[list[Sentence], Sentence]) -> list[Sentence]:
         """Predict the given sentences according to the registered mappings."""
         if not isinstance(sentences, list):
             sentences = [sentences]
@@ -122,7 +122,7 @@ class RegexpTagger:
 
         for label, pattern in self._regexp_mapping.items():
             for match in pattern.finditer(sentence.to_original_text()):
-                span: Tuple[int, int] = match.span()
+                span: tuple[int, int] = match.span()
                 try:
                     token_span = collection.get_token_span(span)
                 except ValueError:

--- a/flair/models/relation_extractor_model.py
+++ b/flair/models/relation_extractor_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import torch
 
@@ -18,7 +18,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
         embeddings: flair.embeddings.TokenEmbeddings,
         label_type: str,
         entity_label_type: str,
-        entity_pair_filters: Optional[List[Tuple[str, str]]] = None,
+        entity_pair_filters: Optional[list[tuple[str, str]]] = None,
         pooling_operation: str = "first_last",
         train_on_gold_pairs_only: bool = False,
         **classifierargs,
@@ -56,13 +56,13 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
 
         # whether to use gold entity pairs, and whether to filter entity pairs by type
         if entity_pair_filters is not None:
-            self.entity_pair_filters: Optional[Set[Tuple[str, str]]] = set(entity_pair_filters)
+            self.entity_pair_filters: Optional[set[tuple[str, str]]] = set(entity_pair_filters)
         else:
             self.entity_pair_filters = None
 
         self.to(flair.device)
 
-    def _get_data_points_from_sentence(self, sentence: Sentence) -> List[Relation]:
+    def _get_data_points_from_sentence(self, sentence: Sentence) -> list[Relation]:
         entity_pairs = []
         entity_spans = sentence.get_spans(self.entity_label_type)
 
@@ -172,7 +172,7 @@ class RelationExtractor(flair.nn.DefaultClassifier[Sentence, Relation]):
         return model_name
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "RelationExtractor":
+    def load(cls, model_path: Union[str, Path, dict[str, Any]]) -> "RelationExtractor":
         from typing import cast
 
         return cast("RelationExtractor", super().load(model_path=model_path))

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -1,7 +1,7 @@
 import logging
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
 
 import torch
 import torch.nn
@@ -40,7 +40,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         word_dropout: float = 0.05,
         locked_dropout: float = 0.5,
         train_initial_hidden_state: bool = False,
-        loss_weights: Optional[Dict[str, float]] = None,
+        loss_weights: Optional[dict[str, float]] = None,
         init_from_state_dict: bool = False,
         allow_unk_predictions: bool = False,
     ) -> None:
@@ -204,7 +204,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
     def label_type(self):
         return self.tag_type
 
-    def _init_loss_weights(self, loss_weights: Dict[str, float]) -> torch.Tensor:
+    def _init_loss_weights(self, loss_weights: dict[str, float]) -> torch.Tensor:
         """Initializes the loss weights based on given dictionary.
 
         Args:
@@ -267,7 +267,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
         return RNN
 
-    def forward_loss(self, sentences: List[Sentence]) -> Tuple[torch.Tensor, int]:
+    def forward_loss(self, sentences: list[Sentence]) -> tuple[torch.Tensor, int]:
         # if there are no sentences, there is no loss
         if len(sentences) == 0:
             return torch.tensor(0.0, dtype=torch.float, device=flair.device, requires_grad=True), 0
@@ -281,7 +281,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         # calculate loss given scores and labels
         return self._calculate_loss(scores, gold_labels)
 
-    def _prepare_tensors(self, data_points: Union[List[Sentence], Sentence]) -> Tuple[torch.Tensor, torch.LongTensor]:
+    def _prepare_tensors(self, data_points: Union[list[Sentence], Sentence]) -> tuple[torch.Tensor, torch.LongTensor]:
         sentences = [data_points] if not isinstance(data_points, list) else data_points
         self.embeddings.embed(sentences)
 
@@ -331,15 +331,15 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
         return scores
 
-    def _calculate_loss(self, scores: torch.Tensor, labels: torch.LongTensor) -> Tuple[torch.Tensor, int]:
+    def _calculate_loss(self, scores: torch.Tensor, labels: torch.LongTensor) -> tuple[torch.Tensor, int]:
         if labels.size(0) == 0:
             return torch.tensor(0.0, requires_grad=True, device=flair.device), 1
 
         return self.loss_function(scores, labels), len(labels)
 
-    def _make_padded_tensor_for_batch(self, sentences: List[Sentence]) -> Tuple[torch.LongTensor, torch.Tensor]:
+    def _make_padded_tensor_for_batch(self, sentences: list[Sentence]) -> tuple[torch.LongTensor, torch.Tensor]:
         names = self.embeddings.get_names()
-        lengths: List[int] = [len(sentence.tokens) for sentence in sentences]
+        lengths: list[int] = [len(sentence.tokens) for sentence in sentences]
         longest_token_sequence_in_batch: int = max(lengths)
         pre_allocated_zero_tensor = torch.zeros(
             self.embeddings.embedding_length * longest_token_sequence_in_batch,
@@ -382,7 +382,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
         return scores
 
-    def _get_gold_labels(self, sentences: List[Sentence]) -> List[str]:
+    def _get_gold_labels(self, sentences: list[Sentence]) -> list[str]:
         """Extracts gold labels from each sentence.
 
         Args:
@@ -419,7 +419,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
         return labels
 
-    def _prepare_label_tensor(self, sentences: List[Sentence]):
+    def _prepare_label_tensor(self, sentences: list[Sentence]):
         gold_labels = self._get_gold_labels(sentences)
         labels = torch.tensor(
             [self.label_dictionary.get_idx_for_item(label) for label in gold_labels],
@@ -430,7 +430,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
     def predict(
         self,
-        sentences: Union[List[Sentence], Sentence],
+        sentences: Union[list[Sentence], Sentence],
         mini_batch_size: int = 32,
         return_probabilities_for_all_classes: bool = False,
         verbose: bool = False,
@@ -462,7 +462,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
             if not isinstance(sentences, list) and not isinstance(sentences, flair.data.Dataset):
                 sentences = [sentences]
 
-            Sentence.set_context_for_sentences(cast(List[Sentence], sentences))
+            Sentence.set_context_for_sentences(cast(list[Sentence], sentences))
 
             # filter empty sentences
             sentences = [sentence for sentence in sentences if len(sentence) > 0]
@@ -542,7 +542,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
                 return overall_loss, label_count
             return None
 
-    def _standard_inference(self, features: torch.Tensor, batch: List[Sentence], probabilities_for_all_classes: bool):
+    def _standard_inference(self, features: torch.Tensor, batch: list[Sentence], probabilities_for_all_classes: bool):
         """Softmax over emission scores from forward propagation.
 
         Args:
@@ -573,7 +573,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
 
         return predictions, all_tags
 
-    def _all_scores_for_token(self, sentences: List[Sentence], score_tensor: torch.Tensor, lengths: List[int]):
+    def _all_scores_for_token(self, sentences: list[Sentence], score_tensor: torch.Tensor, lengths: list[int]):
         """Returns all scores for each tag in tag dictionary."""
         scores = score_tensor.numpy()
         tokens = [token for sentence in sentences for token in sentence]
@@ -861,7 +861,7 @@ for entity in sentence.get_spans('ner'):
             return repo_url
 
     @staticmethod
-    def _filter_empty_sentences(sentences: List[Sentence]) -> List[Sentence]:
+    def _filter_empty_sentences(sentences: list[Sentence]) -> list[Sentence]:
         filtered_sentences = [sentence for sentence in sentences if sentence.tokens]
         if len(sentences) != len(filtered_sentences):
             log.warning(f"Ignore {len(sentences) - len(filtered_sentences)} sentence(s) with no tokens.")
@@ -919,7 +919,7 @@ for entity in sentence.get_spans('ner'):
         return lines
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "SequenceTagger":
+    def load(cls, model_path: Union[str, Path, dict[str, Any]]) -> "SequenceTagger":
         from typing import cast
 
         return cast("SequenceTagger", super().load(model_path=model_path))

--- a/flair/models/sequence_tagger_utils/viterbi.py
+++ b/flair/models/sequence_tagger_utils/viterbi.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import numpy as np
 import torch
 import torch.nn
@@ -7,7 +5,7 @@ from torch.nn.functional import softmax
 from torch.nn.utils.rnn import pack_padded_sequence
 
 import flair
-from flair.data import Dictionary, Label, List, Sentence
+from flair.data import Dictionary, Label, Sentence
 
 START_TAG: str = "<START>"
 STOP_TAG: str = "<STOP>"
@@ -141,8 +139,8 @@ class ViterbiDecoder:
         self.stop_tag = tag_dictionary.get_idx_for_item(STOP_TAG)
 
     def decode(
-        self, features_tuple: tuple, probabilities_for_all_classes: bool, sentences: List[Sentence]
-    ) -> Tuple[List, List]:
+        self, features_tuple: tuple, probabilities_for_all_classes: bool, sentences: list[Sentence]
+    ) -> tuple[list[list[tuple[str, float]]], list[list[list[Label]]]]:
         """Decoding function returning the most likely sequence of tags.
 
         Args:
@@ -211,7 +209,7 @@ class ViterbiDecoder:
         scores = softmax(scores_upto_t, dim=2)
         confidences = torch.max(scores, dim=2)
 
-        tags = []
+        tags: list[list[tuple[str, float]]] = []
         for tag_seq, tag_seq_conf, length_seq in zip(decoded, confidences.values, lengths):
             tags.append(
                 [
@@ -230,7 +228,7 @@ class ViterbiDecoder:
         score_tensor: torch.Tensor,
         tag_sequences: torch.Tensor,
         lengths: torch.IntTensor,
-        sentences: List[Sentence],
+        sentences: list[Sentence],
     ):
         """Returns all scores for each tag in tag dictionary."""
         scores = score_tensor.numpy()

--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -3,7 +3,7 @@ import typing
 from abc import ABC
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import torch
@@ -30,14 +30,14 @@ log = logging.getLogger("flair")
 class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
     def __init__(self) -> None:
         self._current_task = None
-        self._task_specific_attributes: Dict[str, Dict[str, Any]] = {}
+        self._task_specific_attributes: dict[str, dict[str, Any]] = {}
         self.label_nearest_map = None
         self.tars_model: flair.nn.Classifier[Sentence]
         self.separator: str
 
         super().__init__()
 
-    def forward_loss(self, data_points: Union[List[Sentence], Sentence]) -> Tuple[torch.Tensor, int]:
+    def forward_loss(self, data_points: Union[list[Sentence], Sentence]) -> tuple[torch.Tensor, int]:
         if not isinstance(data_points, list):
             data_points = [data_points]
 
@@ -54,7 +54,7 @@ class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
     def _get_tars_formatted_sentence(self, label, sentence):
         raise NotImplementedError
 
-    def _get_tars_formatted_sentences(self, sentences: List[Sentence]):
+    def _get_tars_formatted_sentences(self, sentences: list[Sentence]):
         label_text_pairs = []
         all_labels = [label.decode("utf-8") for label in self.get_current_label_dictionary().idx2item]
         for sentence in sentences:
@@ -173,7 +173,7 @@ class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
     def add_and_switch_to_new_task(
         self,
         task_name: str,
-        label_dictionary: Union[List, Set, Dictionary, str],
+        label_dictionary: Union[list, set, Dictionary, str],
         label_type: str,
         multi_label: bool = True,
         force_switch: bool = False,
@@ -219,7 +219,7 @@ class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
 
         self.switch_to_task(task_name)
 
-    def list_existing_tasks(self) -> Set[str]:
+    def list_existing_tasks(self) -> set[str]:
         """Lists existing tasks in the loaded TARS model on the console."""
         return set(self._task_specific_attributes.keys())
 
@@ -246,7 +246,7 @@ class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
             log.warning("No task exists with the name `%s`.", task_name)
 
     @staticmethod
-    def _filter_empty_sentences(sentences: List[Sentence]) -> List[Sentence]:
+    def _filter_empty_sentences(sentences: list[Sentence]) -> list[Sentence]:
         filtered_sentences = [sentence for sentence in sentences if sentence.tokens]
         if len(sentences) != len(filtered_sentences):
             log.warning(f"Ignore {len(sentences) - len(filtered_sentences)} sentence(s) with no tokens.")
@@ -258,8 +258,8 @@ class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
 
     def predict_zero_shot(
         self,
-        sentences: Union[List[Sentence], Sentence],
-        candidate_label_set: Union[List[str], Set[str], str],
+        sentences: Union[list[Sentence], Sentence],
+        candidate_label_set: Union[list[str], set[str], str],
         multi_label: bool = True,
     ):
         """Make zero shot predictions from the TARS model.
@@ -307,14 +307,14 @@ class FewshotClassifier(flair.nn.Classifier[Sentence], ABC):
 
     def get_used_tokens(
         self, corpus: Corpus, context_length: int = 0, respect_document_boundaries: bool = True
-    ) -> typing.Iterable[List[str]]:
+    ) -> typing.Iterable[list[str]]:
         yield from super().get_used_tokens(corpus, context_length, respect_document_boundaries)
         for label in self.get_current_label_dictionary().idx2item:
             yield [label.decode("utf-8")]
         yield [self.separator]
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "FewshotClassifier":
+    def load(cls, model_path: Union[str, Path, dict[str, Any]]) -> "FewshotClassifier":
         from typing import cast
 
         return cast("FewshotClassifier", super().load(model_path=model_path))
@@ -472,7 +472,7 @@ class TARSTagger(FewshotClassifier):
 
     def predict(
         self,
-        sentences: Union[List[Sentence], Sentence],
+        sentences: Union[list[Sentence], Sentence],
         mini_batch_size=32,
         return_probabilities_for_all_classes: bool = False,
         verbose: bool = False,
@@ -532,12 +532,12 @@ class TARSTagger(FewshotClassifier):
                 if not batch:
                     continue
 
-                tars_sentences: List[Sentence] = []
-                all_labels_to_sentence: List[Dict[str, Sentence]] = []
+                tars_sentences: list[Sentence] = []
+                all_labels_to_sentence: list[dict[str, Sentence]] = []
                 for sentence in batch:
                     # always remove tags first
                     sentence.remove_labels(label_name)
-                    labels_to_sentence: Dict[str, Sentence] = {}
+                    labels_to_sentence: dict[str, Sentence] = {}
                     for label in all_labels:
                         tars_sentence = self._get_tars_formatted_sentence(label, sentence)
                         tars_sentences.append(tars_sentence)
@@ -570,7 +570,7 @@ class TARSTagger(FewshotClassifier):
                     if most_probable_first:
                         import operator
 
-                        already_set_indices: List[int] = []
+                        already_set_indices: list[int] = []
 
                         sorted_x = sorted(all_detected.items(), key=operator.itemgetter(1))
                         sorted_x.reverse()
@@ -648,7 +648,7 @@ class TARSTagger(FewshotClassifier):
         return lines
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TARSTagger":
+    def load(cls, model_path: Union[str, Path, dict[str, Any]]) -> "TARSTagger":
         from typing import cast
 
         return cast("TARSTagger", super().load(model_path=model_path))
@@ -832,7 +832,7 @@ class TARSClassifier(FewshotClassifier):
 
     def predict(
         self,
-        sentences: Union[List[Sentence], Sentence],
+        sentences: Union[list[Sentence], Sentence],
         mini_batch_size=32,
         return_probabilities_for_all_classes: bool = False,
         verbose: bool = False,
@@ -907,12 +907,12 @@ class TARSClassifier(FewshotClassifier):
                 if not batch:
                     continue
 
-                tars_sentences: List[Sentence] = []
-                all_labels_to_sentence: List[Dict[str, Sentence]] = []
+                tars_sentences: list[Sentence] = []
+                all_labels_to_sentence: list[dict[str, Sentence]] = []
                 for sentence in batch:
                     # always remove tags first
                     sentence.remove_labels(label_name)
-                    labels_to_sentence: Dict[str, Sentence] = {}
+                    labels_to_sentence: dict[str, Sentence] = {}
                     for label in all_labels:
                         tars_sentence = self._get_tars_formatted_sentence(label, sentence)
                         tars_sentences.append(tars_sentence)
@@ -972,7 +972,7 @@ class TARSClassifier(FewshotClassifier):
         return None
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TARSClassifier":
+    def load(cls, model_path: Union[str, Path, dict[str, Any]]) -> "TARSClassifier":
         from typing import cast
 
         return cast("TARSClassifier", super().load(model_path=model_path))

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import torch
 
@@ -56,7 +56,7 @@ class TextClassifier(flair.nn.DefaultClassifier[Sentence, Sentence]):
         embedding_names = self.embeddings.get_names()
         return prediction_data_point.get_embedding(embedding_names)
 
-    def _get_data_points_from_sentence(self, sentence: Sentence) -> List[Sentence]:
+    def _get_data_points_from_sentence(self, sentence: Sentence) -> list[Sentence]:
         return [sentence]
 
     def _get_state_dict(self):
@@ -133,7 +133,7 @@ class TextClassifier(flair.nn.DefaultClassifier[Sentence, Sentence]):
         return self._label_type
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TextClassifier":
+    def load(cls, model_path: Union[str, Path, dict[str, Any]]) -> "TextClassifier":
         from typing import cast
 
         return cast("TextClassifier", super().load(model_path=model_path))

--- a/flair/models/triple_classification_model.py
+++ b/flair/models/triple_classification_model.py
@@ -1,5 +1,4 @@
 import typing
-from typing import List
 
 import torch
 
@@ -69,7 +68,7 @@ class TextTripleClassifier(flair.nn.DefaultClassifier[TextTriple, TextTriple]):
     def label_type(self):
         return self._label_type
 
-    def _get_data_points_from_sentence(self, sentence: TextTriple) -> List[TextTriple]:
+    def _get_data_points_from_sentence(self, sentence: TextTriple) -> list[TextTriple]:
         return [sentence]
 
     def _get_embedding_for_data_point(self, prediction_data_point: TextTriple) -> torch.Tensor:
@@ -121,7 +120,7 @@ class TextTripleClassifier(flair.nn.DefaultClassifier[TextTriple, TextTriple]):
 
     def get_used_tokens(
         self, corpus: Corpus, context_length: int = 0, respect_document_boundaries: bool = True
-    ) -> typing.Iterable[List[str]]:
+    ) -> typing.Iterable[list[str]]:
         for sentence_pair in _iter_dataset(corpus.get_all_sentences()):
             yield [t.text for t in sentence_pair.first]
             yield [t.text for t in sentence_pair.first.left_context(context_length, respect_document_boundaries)]

--- a/flair/models/word_tagger_model.py
+++ b/flair/models/word_tagger_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import torch
 from deprecated.sphinx import deprecated
@@ -99,7 +99,7 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
         names = self.embeddings.get_names()
         return prediction_data_point.get_embedding(names)
 
-    def _get_data_points_from_sentence(self, sentence: Sentence) -> List[Token]:
+    def _get_data_points_from_sentence(self, sentence: Sentence) -> list[Token]:
         # special handling during training if this is a span prediction problem
         if self.training and self.span_prediction_problem:
             for token in sentence.tokens:
@@ -125,7 +125,7 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
             for sentence in batch:
                 # internal variables
                 previous_tag = "O-"
-                current_span: List[Token] = []
+                current_span: list[Token] = []
 
                 for token in sentence:
                     bioes_tag = token.get_label(label_name).value
@@ -222,7 +222,7 @@ class TokenClassifier(flair.nn.DefaultClassifier[Sentence, Token]):
         return lines
 
     @classmethod
-    def load(cls, model_path: Union[str, Path, Dict[str, Any]]) -> "TokenClassifier":
+    def load(cls, model_path: Union[str, Path, dict[str, Any]]) -> "TokenClassifier":
         from typing import cast
 
         return cast("TokenClassifier", super().load(model_path=model_path))

--- a/flair/nn/decoder.py
+++ b/flair/nn/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
 import torch
 
@@ -151,11 +151,11 @@ class LabelVerbalizerDecoder(torch.nn.Module):
     def __init__(self, label_embedding: Embeddings, label_dictionary: Dictionary):
         super().__init__()
         self.label_embedding = label_embedding
-        self.verbalized_labels: List[Sentence] = self.verbalize_labels(label_dictionary)
+        self.verbalized_labels: list[Sentence] = self.verbalize_labels(label_dictionary)
         self.to(flair.device)
 
     @staticmethod
-    def verbalize_labels(label_dictionary: Dictionary) -> List[Sentence]:
+    def verbalize_labels(label_dictionary: Dictionary) -> list[Sentence]:
         """Takes a label dictionary and returns a list of sentences with verbalized labels.
 
         Args:

--- a/flair/nn/multitask.py
+++ b/flair/nn/multitask.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Tuple, Union
+from collections.abc import Iterable
+from typing import Union
 
 from flair.data import Corpus, MultiCorpus
 from flair.models import MultitaskModel
@@ -6,18 +7,18 @@ from flair.nn import Classifier, Model
 
 
 def make_multitask_model_and_corpus(
-    mapping: Iterable[Union[Tuple[Classifier, Corpus], Tuple[Classifier, Corpus, float]]]
-) -> Tuple[Model, Corpus]:
+    mapping: Iterable[Union[tuple[Classifier, Corpus], tuple[Classifier, Corpus, float]]]
+) -> tuple[Model, Corpus]:
     models = []
     corpora = []
     loss_factors = []
     ids = []
 
-    for task_id, map in enumerate(mapping):
-        models.append(map[0])
-        corpora.append(map[1])
-        if len(map) == 3:
-            loss_factors.append(map[2])
+    for task_id, _map in enumerate(mapping):
+        models.append(_map[0])
+        corpora.append(_map[1])
+        if len(_map) == 3:
+            loss_factors.append(_map[2])
         else:
             loss_factors.append(1.0)
 

--- a/flair/samplers.py
+++ b/flair/samplers.py
@@ -1,7 +1,6 @@
 import logging
 import random
 from collections import defaultdict
-from typing import Dict
 
 import torch
 from torch.utils.data.sampler import Sampler
@@ -36,7 +35,7 @@ class ImbalancedClassificationDatasetSampler(FlairSampler):
         self.indices = list(range(len(data_source)))
 
         # first determine the distribution of classes in the dataset
-        label_count: Dict[str, int] = defaultdict(int)
+        label_count: dict[str, int] = defaultdict(int)
         for sentence in data_source:
             for label in sentence.labels:
                 label_count[label.value] += 1

--- a/flair/splitter.py
+++ b/flair/splitter.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from segtok.segmenter import split_multi
 
@@ -25,7 +25,7 @@ class SentenceSplitter(ABC):
     the sentence splitter's configuration.
     """
 
-    def split(self, text: str, link_sentences: Optional[bool] = True) -> List[Sentence]:
+    def split(self, text: str, link_sentences: Optional[bool] = True) -> list[Sentence]:
         sentences = self._perform_split(text)
         if not link_sentences:
             return sentences
@@ -34,7 +34,7 @@ class SentenceSplitter(ABC):
         return sentences
 
     @abstractmethod
-    def _perform_split(self, text: str) -> List[Sentence]:
+    def _perform_split(self, text: str) -> list[Sentence]:
         raise NotImplementedError
 
     @property
@@ -62,11 +62,11 @@ class SegtokSentenceSplitter(SentenceSplitter):
         super().__init__()
         self._tokenizer = tokenizer
 
-    def _perform_split(self, text: str) -> List[Sentence]:
-        plain_sentences: List[str] = split_multi(text)
+    def _perform_split(self, text: str) -> list[Sentence]:
+        plain_sentences: list[str] = split_multi(text)
         sentence_offset = 0
 
-        sentences: List[Sentence] = []
+        sentences: list[Sentence] = []
         for sentence in plain_sentences:
             try:
                 sentence_offset = text.index(sentence, sentence_offset)
@@ -133,7 +133,7 @@ class SpacySentenceSplitter(SentenceSplitter):
         else:
             self._tokenizer = tokenizer
 
-    def _perform_split(self, text: str) -> List[Sentence]:
+    def _perform_split(self, text: str) -> list[Sentence]:
         document = self.model(text)
 
         sentences = [
@@ -192,7 +192,7 @@ class TagSentenceSplitter(SentenceSplitter):
         self._tokenizer = tokenizer
         self.tag = tag
 
-    def _perform_split(self, text: str) -> List[Sentence]:
+    def _perform_split(self, text: str) -> list[Sentence]:
         plain_sentences = text.split(self.tag)
 
         sentences = []
@@ -252,7 +252,7 @@ class NoSentenceSplitter(SentenceSplitter):
         super().__init__()
         self._tokenizer = tokenizer
 
-    def _perform_split(self, text: str) -> List[Sentence]:
+    def _perform_split(self, text: str) -> list[Sentence]:
         return [Sentence(text=text, use_tokenizer=self._tokenizer, start_position=0)]
 
     @property

--- a/flair/tokenization.py
+++ b/flair/tokenization.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from abc import ABC, abstractmethod
-from typing import Callable, List
+from typing import Callable
 
 from segtok.segmenter import split_single
 from segtok.tokenizer import split_contractions, word_tokenizer
@@ -20,7 +20,7 @@ class Tokenizer(ABC):
     """
 
     @abstractmethod
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> list[str]:
         raise NotImplementedError
 
     @property
@@ -57,11 +57,11 @@ class SpacyTokenizer(Tokenizer):
                 "spacy model or the name of the model to load."
             )
 
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> list[str]:
         from spacy.tokens.doc import Doc
 
         doc: Doc = self.model.make_doc(text)
-        words: List[str] = []
+        words: list[str] = []
         for word in doc:
             if len(word.text.strip()) == 0:
                 continue
@@ -82,12 +82,12 @@ class SegtokTokenizer(Tokenizer):
     def __init__(self) -> None:
         super().__init__()
 
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> list[str]:
         return SegtokTokenizer.run_tokenize(text)
 
     @staticmethod
-    def run_tokenize(text: str) -> List[str]:
-        words: List[str] = []
+    def run_tokenize(text: str) -> list[str]:
+        words: list[str] = []
 
         sentences = split_single(text)
         for sentence in sentences:
@@ -105,12 +105,12 @@ class SpaceTokenizer(Tokenizer):
     def __init__(self) -> None:
         super().__init__()
 
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> list[str]:
         return SpaceTokenizer.run_tokenize(text)
 
     @staticmethod
-    def run_tokenize(text: str) -> List[str]:
-        tokens: List[str] = []
+    def run_tokenize(text: str) -> list[str]:
+        tokens: list[str] = []
         word = ""
         index = -1
         for index, char in enumerate(text):
@@ -166,8 +166,8 @@ class JapaneseTokenizer(Tokenizer):
         self.sentence_tokenizer = konoha.SentenceTokenizer()
         self.word_tokenizer = konoha.WordTokenizer(tokenizer, mode=sudachi_mode)
 
-    def tokenize(self, text: str) -> List[str]:
-        words: List[str] = []
+    def tokenize(self, text: str) -> list[str]:
+        words: list[str] = []
 
         sentences = self.sentence_tokenizer.tokenize(text)
         for sentence in sentences:
@@ -184,11 +184,11 @@ class JapaneseTokenizer(Tokenizer):
 class TokenizerWrapper(Tokenizer):
     """Helper class to wrap tokenizer functions to the class-based tokenizer interface."""
 
-    def __init__(self, tokenizer_func: Callable[[str], List[str]]) -> None:
+    def __init__(self, tokenizer_func: Callable[[str], list[str]]) -> None:
         super().__init__()
         self.tokenizer_func = tokenizer_func
 
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> list[str]:
         return self.tokenizer_func(text)
 
     @property
@@ -225,7 +225,7 @@ class SciSpacyTokenizer(Tokenizer):
                 "  Note that the scispacy version and the version of the model must match to work properly!"
             )
 
-        def combined_rule_prefixes() -> List[str]:
+        def combined_rule_prefixes() -> list[str]:
             """Helper function that returns the prefix pattern for the tokenizer.
 
             It is a helper function to accommodate spacy tests that only test prefixes.
@@ -270,9 +270,9 @@ class SciSpacyTokenizer(Tokenizer):
         self.model.tokenizer.prefix_search = prefix_re.search
         self.model.tokenizer.infix_finditer = infix_re.finditer
 
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> list[str]:
         sentence = self.model(text)
-        words: List[str] = []
+        words: list[str] = []
         for word in sentence:
             words.append(word.text)
         return words

--- a/flair/trainers/language_model_trainer.py
+++ b/flair/trainers/language_model_trainer.py
@@ -3,8 +3,9 @@ import logging
 import math
 import random
 import time
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Type, Union
+from typing import Any, Optional, Union
 
 import torch
 from torch import cuda
@@ -155,16 +156,16 @@ class LanguageModelTrainer:
         self,
         model: LanguageModel,
         corpus: TextCorpus,
-        optimizer: Type[Optimizer] = SGD,
+        optimizer: type[Optimizer] = SGD,
         test_mode: bool = False,
         epoch: int = 0,
         split: int = 0,
         loss: float = 10000,
-        optimizer_state: Optional[Dict[str, Any]] = None,
-        scaler_state: Optional[Dict[str, Any]] = None,
+        optimizer_state: Optional[dict[str, Any]] = None,
+        scaler_state: Optional[dict[str, Any]] = None,
     ) -> None:
         self.model: LanguageModel = model
-        self.optimizer: Type[Optimizer] = optimizer
+        self.optimizer: type[Optimizer] = optimizer
         self.corpus: TextCorpus = corpus
         self.test_mode: bool = test_mode
 
@@ -362,7 +363,7 @@ class LanguageModelTrainer:
                     )
 
                     with open(loss_txt, "a") as myfile:
-                        myfile.write("%s\n" % summary)
+                        myfile.write(f"{summary}\n")
 
                     log.info(summary)
                     log.info("-" * 89)
@@ -386,7 +387,7 @@ class LanguageModelTrainer:
 
         summary = f"TEST: valid loss {test_loss:5.4f} | valid ppl {math.exp(test_loss):8.4f}"
         with open(loss_txt, "a") as myfile:
-            myfile.write("%s\n" % summary)
+            myfile.write(f"{summary}\n")
 
         log.info(summary)
         log.info("-" * 89)
@@ -440,7 +441,7 @@ class LanguageModelTrainer:
     def load_checkpoint(
         checkpoint_file: Union[str, Path],
         corpus: TextCorpus,
-        optimizer: Type[Optimizer] = SGD,
+        optimizer: type[Optimizer] = SGD,
     ):
         if isinstance(checkpoint_file, str):
             checkpoint_file = Path(checkpoint_file)

--- a/flair/trainers/plugins/base.py
+++ b/flair/trainers/plugins/base.py
@@ -1,19 +1,14 @@
 import logging
 from collections import defaultdict
+from collections.abc import Iterator, Sequence
 from inspect import isclass, signature
 from itertools import count
 from queue import Queue
 from typing import (
     Any,
     Callable,
-    Dict,
-    Iterator,
-    List,
     NewType,
     Optional,
-    Sequence,
-    Set,
-    Type,
     Union,
     cast,
 )
@@ -21,7 +16,7 @@ from typing import (
 log = logging.getLogger("flair")
 
 
-PluginArgument = Union["BasePlugin", Type["BasePlugin"]]
+PluginArgument = Union["BasePlugin", type["BasePlugin"]]
 HookHandleId = NewType("HookHandleId", int)
 
 EventIdenifier = str
@@ -34,7 +29,7 @@ class TrainingInterrupt(Exception):
 class Pluggable:
     """Dispatches events which attached plugins can react to."""
 
-    valid_events: Optional[Set[EventIdenifier]] = None
+    valid_events: Optional[set[EventIdenifier]] = None
 
     def __init__(self, *, plugins: Sequence[PluginArgument] = []) -> None:
         """Initialize a `Pluggable`.
@@ -42,11 +37,11 @@ class Pluggable:
         Args:
             plugins: Plugins which should be attached to this `Pluggable`.
         """
-        self._hook_handles: Dict[EventIdenifier, Dict[HookHandleId, HookHandle]] = defaultdict(dict)
+        self._hook_handles: dict[EventIdenifier, dict[HookHandleId, HookHandle]] = defaultdict(dict)
 
         self._hook_handle_id_counter = count()
 
-        self._plugins: List[BasePlugin] = []
+        self._plugins: list[BasePlugin] = []
 
         # This flag tracks, whether an event is currently being processed (otherwise it is added to the queue)
         self._processing_events = False
@@ -181,7 +176,7 @@ class BasePlugin:
 
     def __init__(self) -> None:
         """Initialize the base plugin."""
-        self._hook_handles: List[HookHandle] = []
+        self._hook_handles: list[HookHandle] = []
         self._pluggable: Optional[Pluggable] = None
 
     def attach_to(self, pluggable: Pluggable):
@@ -260,7 +255,7 @@ class BasePlugin:
     def __str__(self) -> str:
         return self.__class__.__name__
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {"__cls__": f"{self.__module__}.{self.__class__.__name__}"}
 
 

--- a/flair/trainers/plugins/functional/anneal_on_plateau.py
+++ b/flair/trainers/plugins/functional/anneal_on_plateau.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict
+from typing import Any
 
 from flair.trainers.plugins.base import TrainerPlugin, TrainingInterrupt
 from flair.trainers.plugins.metric_records import MetricRecord
@@ -108,7 +108,7 @@ class AnnealingPlugin(TrainerPlugin):
             f"min_learning_rate: '{self.min_learning_rate}'"
         )
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "base_path": str(self.base_path),

--- a/flair/trainers/plugins/functional/checkpoints.py
+++ b/flair/trainers/plugins/functional/checkpoints.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from flair.trainers.plugins.base import TrainerPlugin
 
@@ -29,7 +29,7 @@ class CheckpointPlugin(TrainerPlugin):
             model_name = "model_epoch_" + str(epoch) + ".pt"
             self.model.save(self.base_path / model_name, checkpoint=self.save_optimizer_state)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "base_path": str(self.base_path),

--- a/flair/trainers/plugins/functional/linear_scheduler.py
+++ b/flair/trainers/plugins/functional/linear_scheduler.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from flair.optim import LinearSchedulerWithWarmup
 from flair.trainers.plugins.base import TrainerPlugin
@@ -62,7 +62,7 @@ class LinearSchedulerPlugin(TrainerPlugin):
     def __str__(self) -> str:
         return f"LinearScheduler | warmup_fraction: '{self.warmup_fraction}'"
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "warmup_fraction": self.warmup_fraction,

--- a/flair/trainers/plugins/functional/reduce_transformer_vocab.py
+++ b/flair/trainers/plugins/functional/reduce_transformer_vocab.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import List
 
 from transformer_smaller_training_vocab import reduce_train_vocab
 
@@ -57,7 +56,7 @@ class ReduceTransformerVocabPlugin(TrainerPlugin):
             self.model.save(self.base_path / "final-model.pt", checkpoint=self.save_optimizer_state)
 
 
-def get_transformer_embeddings(model: Model) -> List[TransformerEmbeddings]:
+def get_transformer_embeddings(model: Model) -> list[TransformerEmbeddings]:
     embeddings = model.tars_embeddings if isinstance(model, FewshotClassifier) else getattr(model, "embeddings", None)
 
     if embeddings is None:

--- a/flair/trainers/plugins/functional/weight_extractor.py
+++ b/flair/trainers/plugins/functional/weight_extractor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from flair.trainers.plugins.base import TrainerPlugin
 from flair.training_utils import WeightExtractor
@@ -21,7 +21,7 @@ class WeightExtractorPlugin(TrainerPlugin):
         if (iteration + 1) % modulo == 0:
             self.weight_extractor.extract_weights(self.model.state_dict(), iteration)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "base_path": str(self.base_path),

--- a/flair/trainers/plugins/loggers/log_file.py
+++ b/flair/trainers/plugins/loggers/log_file.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from flair.trainers.plugins.base import TrainerPlugin
 from flair.training_utils import add_file_handler
@@ -21,5 +21,5 @@ class LogFilePlugin(TrainerPlugin):
         self.log_handler.close()
         log.removeHandler(self.log_handler)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {**super().get_state(), "base_path": str(self.base_path)}

--- a/flair/trainers/plugins/loggers/loss_file.py
+++ b/flair/trainers/plugins/loggers/loss_file.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from flair.trainers.plugins.base import TrainerPlugin
 from flair.trainers.plugins.metric_records import MetricName
@@ -10,7 +10,7 @@ class LossFilePlugin(TrainerPlugin):
     """Plugin that manages the loss.tsv file output."""
 
     def __init__(
-        self, base_path, epoch: int, metrics_to_collect: Optional[Dict[Union[Tuple, str], str]] = None
+        self, base_path, epoch: int, metrics_to_collect: Optional[dict[Union[tuple, str], str]] = None
     ) -> None:
         super().__init__()
 
@@ -56,9 +56,9 @@ class LossFilePlugin(TrainerPlugin):
                 self.headers[metric_name] = f"{prefix.upper()}_{header}"
 
         # initialize the first log line
-        self.current_row: Optional[Dict[MetricName, str]] = None
+        self.current_row: Optional[dict[MetricName, str]] = None
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "base_path": str(self.base_path),

--- a/flair/trainers/plugins/loggers/metric_history.py
+++ b/flair/trainers/plugins/loggers/metric_history.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Dict, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from flair.trainers.plugins.base import TrainerPlugin
 
@@ -17,7 +18,7 @@ class MetricHistoryPlugin(TrainerPlugin):
     def __init__(self, metrics_to_collect: Mapping = default_metrics_to_collect) -> None:
         super().__init__()
 
-        self.metric_history: Dict[str, list] = {}
+        self.metric_history: dict[str, list] = {}
         self.metrics_to_collect: Mapping = metrics_to_collect
         for target in self.metrics_to_collect.values():
             self.metric_history[target] = []
@@ -33,7 +34,7 @@ class MetricHistoryPlugin(TrainerPlugin):
         """Returns metric history."""
         self.trainer.return_values.update(self.metric_history)
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "metrics_to_collect": dict(self.metrics_to_collect),

--- a/flair/trainers/plugins/loggers/tensorboard.py
+++ b/flair/trainers/plugins/loggers/tensorboard.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict
+from typing import Any
 
 from flair.trainers.plugins.base import TrainerPlugin
 from flair.training_utils import log_line
@@ -59,7 +59,7 @@ class TensorboardLogger(TrainerPlugin):
         assert self.writer is not None
         self.writer.close()
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "log_dir": str(self.log_dir) if self.log_dir is not None else None,

--- a/flair/trainers/plugins/loggers/wandb.py
+++ b/flair/trainers/plugins/loggers/wandb.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from flair.trainers.plugins.base import TrainerPlugin
 
@@ -72,7 +72,7 @@ class WandbLogger(TrainerPlugin):
     def _training_finally(self, **kw):
         self.writer.close()
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         return {
             **super().get_state(),
             "emit_alerts": self.emit_alerts,

--- a/flair/trainers/plugins/metric_records.py
+++ b/flair/trainers/plugins/metric_records.py
@@ -1,14 +1,15 @@
 import time
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterable, Iterator, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 RecordType = Enum("RecordType", ["scalar", "image", "histogram", "string", "scalar_list"])
 
 
 class MetricName:
     def __init__(self, name) -> None:
-        self.parts: Tuple[str, ...]
+        self.parts: tuple[str, ...]
 
         if isinstance(name, str):
             self.parts = tuple(name.split("/"))

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from inspect import signature
 from pathlib import Path
-from typing import List, Optional, Tuple, Type, Union
+from typing import Optional, Union
 
 import torch
 from torch.optim.sgd import SGD
@@ -128,7 +128,7 @@ class ModelTrainer(Pluggable):
         base_path,
         anneal_factor: float = 0.5,
         patience: int = 3,
-        min_learning_rate: Union[float, List[float]] = 0.0001,
+        min_learning_rate: Union[float, list[float]] = 0.0001,
         initial_extra_patience: int = 0,
         anneal_with_restarts: bool = False,
         learning_rate: float = 0.1,
@@ -137,17 +137,17 @@ class ModelTrainer(Pluggable):
         eval_batch_size: int = 64,
         mini_batch_chunk_size: Optional[int] = None,
         max_epochs: int = 100,
-        optimizer: Type[torch.optim.Optimizer] = torch.optim.SGD,
+        optimizer: type[torch.optim.Optimizer] = torch.optim.SGD,
         train_with_dev: bool = False,
         train_with_test: bool = False,
         reduce_transformer_vocab: bool = False,
         # evaluation and monitoring
-        main_evaluation_metric: Tuple[str, str] = ("micro avg", "f1-score"),
+        main_evaluation_metric: tuple[str, str] = ("micro avg", "f1-score"),
         monitor_test: bool = False,
         monitor_train_sample: float = 0.0,
         use_final_model_for_eval: bool = False,
         gold_label_dictionary_for_eval: Optional[Dictionary] = None,
-        exclude_labels: Optional[List[str]] = None,
+        exclude_labels: Optional[list[str]] = None,
         # sampling and shuffling
         sampler=None,
         shuffle: bool = True,
@@ -164,7 +164,7 @@ class ModelTrainer(Pluggable):
         create_loss_file: bool = True,
         write_weights: bool = False,
         # plugins
-        plugins: Optional[List[TrainerPlugin]] = None,
+        plugins: Optional[list[TrainerPlugin]] = None,
         attach_default_scheduler: bool = True,
         **kwargs,
     ):
@@ -211,17 +211,17 @@ class ModelTrainer(Pluggable):
         eval_batch_size: int = 16,
         mini_batch_chunk_size: Optional[int] = None,
         max_epochs: int = 10,
-        optimizer: Type[torch.optim.Optimizer] = torch.optim.AdamW,
+        optimizer: type[torch.optim.Optimizer] = torch.optim.AdamW,
         train_with_dev: bool = False,
         train_with_test: bool = False,
         reduce_transformer_vocab: bool = False,
         # evaluation and monitoring
-        main_evaluation_metric: Tuple[str, str] = ("micro avg", "f1-score"),
+        main_evaluation_metric: tuple[str, str] = ("micro avg", "f1-score"),
         monitor_test: bool = False,
         monitor_train_sample: float = 0.0,
         use_final_model_for_eval: bool = True,
         gold_label_dictionary_for_eval: Optional[Dictionary] = None,
-        exclude_labels: Optional[List[str]] = None,
+        exclude_labels: Optional[list[str]] = None,
         # sampling and shuffling
         sampler=None,
         shuffle: bool = True,
@@ -240,7 +240,7 @@ class ModelTrainer(Pluggable):
         # amp
         use_amp: bool = False,
         # plugins
-        plugins: Optional[List[TrainerPlugin]] = None,
+        plugins: Optional[list[TrainerPlugin]] = None,
         attach_default_scheduler: bool = True,
         **kwargs,
     ):
@@ -304,20 +304,20 @@ class ModelTrainer(Pluggable):
         eval_batch_size: int = 64,
         mini_batch_chunk_size: Optional[int] = None,
         max_epochs: int = 100,
-        optimizer: Type[torch.optim.Optimizer] = SGD,
+        optimizer: type[torch.optim.Optimizer] = SGD,
         train_with_dev: bool = False,
         train_with_test: bool = False,
         max_grad_norm: Optional[float] = 5.0,
         reduce_transformer_vocab: bool = False,
         # evaluation and monitoring
-        main_evaluation_metric: Tuple[str, str] = ("micro avg", "f1-score"),
+        main_evaluation_metric: tuple[str, str] = ("micro avg", "f1-score"),
         monitor_test: bool = False,
         monitor_train_sample: float = 0.0,
         use_final_model_for_eval: bool = False,
         gold_label_dictionary_for_eval: Optional[Dictionary] = None,
-        exclude_labels: Optional[List[str]] = None,
+        exclude_labels: Optional[list[str]] = None,
         # sampling and shuffling
-        sampler: Optional[FlairSampler] = None,
+        sampler: Optional[Union[FlairSampler, type[FlairSampler]]] = None,
         shuffle: bool = True,
         shuffle_first_epoch: bool = True,
         # evaluation and monitoring
@@ -334,7 +334,7 @@ class ModelTrainer(Pluggable):
         # amp
         use_amp: bool = False,
         # plugins
-        plugins: Optional[List[TrainerPlugin]] = None,
+        plugins: Optional[list[TrainerPlugin]] = None,
         **kwargs,
     ) -> dict:
         """Trains any class that implements the flair.nn.Model interface.
@@ -475,7 +475,7 @@ class ModelTrainer(Pluggable):
         # initialize sampler if provided
         if sampler is not None:
             # init with default values if only class is provided
-            if inspect.isclass(sampler):
+            if isinstance(sampler, type):
                 sampler = sampler()
             # set dataset to sample from
             sampler.set_dataset(train_data)

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -5,7 +5,7 @@ from enum import Enum
 from functools import reduce
 from math import inf
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import mean_absolute_error, mean_squared_error
@@ -25,7 +25,7 @@ class Result:
         main_score: float,
         detailed_results: str,
         classification_report: Optional[dict] = None,
-        scores: Optional[Dict] = None,
+        scores: Optional[dict] = None,
     ) -> None:
         classification_report = classification_report if classification_report is not None else {}
         assert scores is not None and "loss" in scores, "No loss provided."
@@ -47,8 +47,8 @@ class MetricRegression:
     def __init__(self, name) -> None:
         self.name = name
 
-        self.true: List[float] = []
-        self.pred: List[float] = []
+        self.true: list[float] = []
+        self.pred: list[float] = []
 
     def mean_squared_error(self):
         return mean_squared_error(self.true, self.pred)
@@ -98,7 +98,7 @@ class WeightExtractor:
         if isinstance(directory, str):
             directory = Path(directory)
         self.weights_file = init_output_file(directory, "weights.txt")
-        self.weights_dict: Dict[str, Dict[int, List[float]]] = defaultdict(lambda: defaultdict(list))
+        self.weights_dict: dict[str, dict[int, list[float]]] = defaultdict(lambda: defaultdict(list))
         self.number_of_weights = number_of_weights
 
     def extract_weights(self, state_dict, iteration):
@@ -338,7 +338,7 @@ def init_output_file(base_path: Union[str, Path], file_name: str) -> Path:
     return file
 
 
-def convert_labels_to_one_hot(label_list: List[List[str]], label_dict: Dictionary) -> List[List[int]]:
+def convert_labels_to_one_hot(label_list: list[list[str]], label_dict: Dictionary) -> list[list[int]]:
     """Convert list of labels to a one hot list.
 
     Args:
@@ -365,9 +365,9 @@ def add_file_handler(log, output_file):
 
 
 def store_embeddings(
-    data_points: Union[List[DT], Dataset],
+    data_points: Union[list[DT], Dataset],
     storage_mode: EmbeddingStorageMode,
-    dynamic_embeddings: Optional[List[str]] = None,
+    dynamic_embeddings: Optional[list[str]] = None,
 ):
     if isinstance(data_points, Dataset):
         data_points = list(_iter_dataset(data_points))
@@ -391,7 +391,7 @@ def store_embeddings(
             data_point.to("cpu", pin_memory=pin_memory)
 
 
-def identify_dynamic_embeddings(data_points: List[DT]) -> Optional[List]:
+def identify_dynamic_embeddings(data_points: list[DT]) -> Optional[list[str]]:
     dynamic_embeddings = []
     all_embeddings = []
     for data_point in data_points:

--- a/flair/visual/ner_html.py
+++ b/flair/visual/ner_html.py
@@ -1,5 +1,5 @@
 import html
-from typing import List, Union
+from typing import Union
 
 from flair.data import Sentence
 
@@ -41,7 +41,7 @@ def split_to_spans(s: Sentence, label_name="ner"):
 
 
 def render_ner_html(
-    sentences: Union[List[Sentence], Sentence],
+    sentences: Union[list[Sentence], Sentence],
     title: str = "Flair",
     colors={
         "PER": "#F7FF53",

--- a/flair/visual/training_curves.py
+++ b/flair/visual/training_curves.py
@@ -3,7 +3,7 @@ import logging
 import math
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -27,7 +27,7 @@ class Plotter:
     def _extract_evaluation_data(file_name: Union[str, Path], score: str = "F1") -> dict:
         file_name = Path(file_name)
 
-        training_curves: Dict[str, Dict[str, List[float]]] = {
+        training_curves: dict[str, dict[str, list[float]]] = {
             "train": {"loss": [], "score": []},
             "test": {"loss": [], "score": []},
             "dev": {"loss": [], "score": []},
@@ -70,7 +70,7 @@ class Plotter:
         if isinstance(file_name, str):
             file_name = Path(file_name)
 
-        weights: Dict[str, Dict[str, List[float]]] = defaultdict(lambda: defaultdict(list))
+        weights: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
 
         with open(file_name) as f:
             tsvin = csv.reader(f, delimiter="\t")
@@ -151,7 +151,7 @@ class Plotter:
         log.info(f"Weights plots are saved in {path}")  # to let user know the path of the save plots
         plt.close(fig)
 
-    def plot_training_curves(self, file_name: Union[str, Path], plot_values: List[str] = ["loss", "F1"]):
+    def plot_training_curves(self, file_name: Union[str, Path], plot_values: list[str] = ["loss", "F1"]):
         file_name = Path(file_name)
 
         fig = plt.figure(figsize=(15, 10))

--- a/flair/visual/tree_printer.py
+++ b/flair/visual/tree_printer.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pptree import print_tree
 
 from flair.data import Sentence, Token
@@ -9,7 +7,7 @@ class NodeToken:
     def __init__(self, token: Token, tag_type: str) -> None:
         self.token: Token = token
         self.tag_type: str = tag_type
-        self.children: List[NodeToken] = []
+        self.children: list[NodeToken] = []
 
     def set_haed(self, parent):
         parent.children.append(self)
@@ -19,7 +17,7 @@ class NodeToken:
 
 
 def tree_printer(sentence: Sentence, tag_type: str):
-    tree: List[NodeToken] = [NodeToken(token, tag_type) for token in sentence]
+    tree: list[NodeToken] = [NodeToken(token, tag_type) for token in sentence]
     for x in tree:
         if x.token.head_id != 0:
             head_token = x.token.get_head()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ filterwarnings = [
     'ignore:`resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.',  # transformers calls deprecated hf_hub
     "ignore:`torch.cuda.amp.GradScaler",  # GradScaler changes in torch 2.3.0 but we want to be backwards compatible.
     "ignore:`clean_up_tokenization_spaces` was not set",  # Default behavior changes in transformers v4.45, raising irrelevant FutureWarning for serialized models.
+    "ignore:1Torch was not compiled with flash attention",  # You might want to install flash attention, but you don't have to.
 ]
 markers = [
     "integration",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = ['py39']
 exclude = '''
 (
   /(
@@ -49,7 +49,7 @@ ignore_errors = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 #select = ["ALL"]    # Uncommit to autofix all the things

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest-black-ng==0.4.*
 pytest-github-actions-annotate-failures>=0.1.8
 pytest-mypy>=0.10.3
 pytest-ruff==0.3.*
-ruff==0.3.*
+ruff==0.7.*
 types-dataclasses>=0.6.6
 types-Deprecated>=1.2.9.2
 types-requests>=2.28.11.17

--- a/resources/docs/EXPERIMENTS.md
+++ b/resources/docs/EXPERIMENTS.md
@@ -55,7 +55,7 @@ tag_type = 'ner'
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 
 # initialize embeddings
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
 
     # GloVe embeddings
     WordEmbeddings('glove'),
@@ -124,7 +124,7 @@ tag_type = 'ner'
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 
 # initialize embeddings
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
     WordEmbeddings('de'),
     PooledFlairEmbeddings('german-forward'),
     PooledFlairEmbeddings('german-backward'),
@@ -225,7 +225,7 @@ tag_type = 'ner'
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 
 # initialize embeddings
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
     WordEmbeddings('crawl'),
     WordEmbeddings('twitter'),
     FlairEmbeddings('news-forward'),
@@ -292,7 +292,7 @@ tag_type = 'ner'
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 
 # initialize embeddings
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
     WordEmbeddings('crawl'),
     FlairEmbeddings('news-forward'),
     FlairEmbeddings('news-backward'),
@@ -361,7 +361,7 @@ tag_type = 'pos'
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 
 # initialize embeddings
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
     WordEmbeddings('extvec'),
     FlairEmbeddings('news-forward'),
     FlairEmbeddings('news-backward'),
@@ -416,7 +416,7 @@ tag_type = 'np'
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)
 
 # initialize embeddings
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
     WordEmbeddings('extvec'),
     FlairEmbeddings('news-forward'),
     FlairEmbeddings('news-backward'),

--- a/resources/docs/HUNFLAIR2.md
+++ b/resources/docs/HUNFLAIR2.md
@@ -14,7 +14,7 @@ NER tools on unseen corpora.
 ## Quick Start
 
 #### Requirements and Installation
-*HunFlair2* is based on Flair 0.14+ and Python 3.8+. If you do not have Python 3.8, install it first.
+*HunFlair2* is based on Flair 0.14+ and Python 3.9+. If you do not have Python 3.9, install it first.
 Then, in your favorite virtual environment, simply do:
 ```
 pip install flair

--- a/resources/docs/KOR_docs/TUTORIAL_7_TRAINING_A_MODEL.md
+++ b/resources/docs/KOR_docs/TUTORIAL_7_TRAINING_A_MODEL.md
@@ -313,7 +313,7 @@ label_type = 'ner'
 # 3. 말뭉치에서 레이블 사전 만들기
 label_dict = corpus.make_label_dictionary(label_type=label_type, add_unk=False)
 # 4. 임베딩 초기화하기
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
     WordEmbeddings('glove')
 ]
 embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)

--- a/resources/docs/KOR_docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
+++ b/resources/docs/KOR_docs/TUTORIAL_8_MODEL_OPTIMIZATION.md
@@ -95,7 +95,7 @@ tag_type = 'ner'
 tag_dictionary = corpus.make_label_dictionary(label_type=tag_type, add_unk=False)
 print(tag_dictionary.idx2item)
 # 4. 임베딩 초기화하기
-embedding_types: List[TokenEmbeddings] = [
+embedding_types: list[TokenEmbeddings] = [
     WordEmbeddings('glove'),
 ]
 embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         "word-embeddings": ["gensim>=4.2.0", "bpemb>=0.3.5"],
     },
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/tests/embedding_test_utils.py
+++ b/tests/embedding_test_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Optional
 
 import pytest
 import torch
@@ -9,15 +9,15 @@ from flair.embeddings.base import load_embeddings
 
 
 class BaseEmbeddingsTest:
-    embedding_cls: Type[Embeddings[Sentence]]
+    embedding_cls: type[Embeddings[Sentence]]
     is_token_embedding: bool
     is_document_embedding: bool
-    default_args: Dict[str, Any]
-    valid_args: List[Dict[str, Any]] = []
-    invalid_args: List[Dict[str, Any]] = []
-    invalid_names: List[str] = []
+    default_args: dict[str, Any]
+    valid_args: list[dict[str, Any]] = []
+    invalid_args: list[dict[str, Any]] = []
+    invalid_names: list[str] = []
     name_field: Optional[str] = None
-    weired_texts: List[str] = [
+    weired_texts: list[str] = [
         "Hybrid mesons , qq ̄ states with an admixture",
         "typical proportionalities of \u223C 1nmV \u2212 1 [ 3,4 ] .",
         "🤟 🤟  🤟 hüllo",
@@ -33,7 +33,7 @@ class BaseEmbeddingsTest:
         kwargs.pop(self.name_field)
         return self.embedding_cls(name, **kwargs)  # type: ignore[call-arg]
 
-    def create_embedding_with_args(self, args: Dict[str, Any]):
+    def create_embedding_with_args(self, args: dict[str, Any]):
         kwargs = dict(self.default_args)
         for k, v in args.items():
             kwargs[k] = v

--- a/tests/embeddings/test_document_transform_word_embeddings.py
+++ b/tests/embeddings/test_document_transform_word_embeddings.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from flair.embeddings import (
     DocumentCNNEmbeddings,
@@ -19,7 +19,7 @@ flair_embedding_back: TokenEmbeddings = FlairEmbeddings("news-backward-fast")
 class BaseDocumentsViaWordEmbeddingsTest(BaseEmbeddingsTest):
     is_document_embedding = True
     is_token_embedding = False
-    base_embeddings: List[TokenEmbeddings] = [word, flair_embedding]
+    base_embeddings: list[TokenEmbeddings] = [word, flair_embedding]
 
     def create_embedding_from_name(self, name: str):
         """Overwrite this method if it is more complex to load an embedding by name."""
@@ -28,7 +28,7 @@ class BaseDocumentsViaWordEmbeddingsTest(BaseEmbeddingsTest):
         kwargs.pop(self.name_field)
         return self.embedding_cls(name, **kwargs)  # type: ignore[call-arg]
 
-    def create_embedding_with_args(self, args: Dict[str, Any]):
+    def create_embedding_with_args(self, args: dict[str, Any]):
         kwargs = dict(self.default_args)
         for k, v in args.items():
             kwargs[k] = v
@@ -63,4 +63,4 @@ class TestDocumentCNNEmbeddings(BaseDocumentsViaWordEmbeddingsTest):
 class TestDocumentLMEmbeddings(BaseDocumentsViaWordEmbeddingsTest):
     embedding_cls = DocumentLMEmbeddings
     base_embeddings = [flair_embedding, flair_embedding_back]
-    default_args: Dict[str, Any] = {}
+    default_args: dict[str, Any] = {}

--- a/tests/embeddings/test_word_embeddings.py
+++ b/tests/embeddings/test_word_embeddings.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from flair.embeddings import MuseCrosslingualEmbeddings, NILCEmbeddings, WordEmbeddings
 from tests.embedding_test_utils import BaseEmbeddingsTest
@@ -18,7 +18,7 @@ class TestMuseCrosslingualEmbeddings(BaseEmbeddingsTest):
     embedding_cls = MuseCrosslingualEmbeddings
     is_token_embedding = True
     is_document_embedding = False
-    default_args: Dict[str, Any] = {}
+    default_args: dict[str, Any] = {}
 
 
 class TestNILCEmbeddings(BaseEmbeddingsTest):

--- a/tests/model_test_utils.py
+++ b/tests/model_test_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Optional
 
 import pytest
 
@@ -11,13 +11,13 @@ from flair.trainers import ModelTrainer
 
 
 class BaseModelTest:
-    model_cls: Type[Model]
+    model_cls: type[Model]
     pretrained_model: Optional[str] = None
     empty_sentence = Sentence("       ")
     train_label_type: str
-    multiclass_prediction_labels: List[str]
-    model_args: Dict[str, Any] = {}
-    training_args: Dict[str, Any] = {}
+    multiclass_prediction_labels: list[str]
+    model_args: dict[str, Any] = {}
+    training_args: dict[str, Any] = {}
     finetune_instead_of_train: bool = False
 
     @pytest.fixture()

--- a/tests/models/test_relation_classifier.py
+++ b/tests/models/test_relation_classifier.py
@@ -1,5 +1,5 @@
 from operator import itemgetter
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 import pytest
 from torch.utils.data import Dataset
@@ -20,7 +20,7 @@ from flair.models.relation_classifier_model import (
 )
 from tests.model_test_utils import BaseModelTest
 
-encoding_strategies: Dict[EncodingStrategy, List[Tuple[str, str]]] = {
+encoding_strategies: dict[EncodingStrategy, list[tuple[str, str]]] = {
     EntityMask(): [("[HEAD]", "[TAIL]") for _ in range(7)],
     TypedEntityMask(): [
         ("[HEAD-ORG]", "[TAIL-PER]"),
@@ -140,7 +140,7 @@ class TestRelationClassifier(BaseModelTest):
         return sentence
 
     def assert_training_example(self, predicted_training_example):
-        relations: List[Relation] = predicted_training_example.get_relations("relation")
+        relations: list[Relation] = predicted_training_example.get_relations("relation")
         assert len(relations) == 2
 
         # Intel ----founded_by---> Gordon Moore
@@ -164,7 +164,7 @@ class TestRelationClassifier(BaseModelTest):
     @staticmethod
     def check_transformation_correctness(
         split: Optional[Dataset],
-        ground_truth: Set[Tuple[str, Tuple[str, ...]]],
+        ground_truth: set[tuple[str, tuple[str, ...]]],
     ) -> None:
         # Ground truth is a set of tuples of (<Sentence Text>, <Relation Label Values>)
         assert split is not None
@@ -190,7 +190,7 @@ class TestRelationClassifier(BaseModelTest):
         embeddings: TransformerDocumentEmbeddings,
         cross_augmentation: bool,
         encoding_strategy: EncodingStrategy,
-        encoded_entity_pairs: List[Tuple[str, str]],
+        encoded_entity_pairs: list[tuple[str, str]],
     ) -> None:
         label_dictionary = corpus.make_label_dictionary("relation")
         model: RelationClassifier = self.build_model(
@@ -200,7 +200,7 @@ class TestRelationClassifier(BaseModelTest):
 
         # Check sentence masking and relation label annotation on
         # training, validation and test dataset (in this test the splits are the same)
-        ground_truth: Set[Tuple[str, Tuple[str, ...]]] = {
+        ground_truth: set[tuple[str, tuple[str, ...]]] = {
             # Entity pair permutations of: "Larry Page and Sergey Brin founded Google ."
             (f"{encoded_entity_pairs[0][1]} and Sergey Brin founded {encoded_entity_pairs[0][0]} .", ("founded_by",)),
             (f"Larry Page and {encoded_entity_pairs[1][1]} founded {encoded_entity_pairs[1][0]} .", ("founded_by",)),

--- a/tests/test_datasets_biomedical.py
+++ b/tests/test_datasets_biomedical.py
@@ -2,7 +2,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from flair.datasets.biomedical import (
     CoNLLWriter,
@@ -84,7 +84,7 @@ def test_conll_writer_one_token_multiple_entities2():
 
 def assert_conll_writer_output(
     dataset: InternalBioNerDataset,
-    expected_output: List[str],
+    expected_output: list[str],
     sentence_splitter: Optional[SentenceSplitter] = None,
 ):
     fd, outfile_path = tempfile.mkstemp()

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from flair.data import Label, Relation, Sentence, Span
 
 
@@ -14,7 +12,7 @@ def test_token_tags():
     sentence[0].add_label("pos", "pronoun")
 
     # check if there are three POS labels with correct text and values
-    labels: List[Label] = sentence.get_labels("pos")
+    labels: list[Label] = sentence.get_labels("pos")
     assert len(labels) == 3
     assert labels[0].data_point.text == "I"
     assert labels[0].value == "pronoun"
@@ -24,7 +22,7 @@ def test_token_tags():
     assert labels[2].value == "proper noun"
 
     # check if there are is one SENTIMENT label with correct text and values
-    labels: List[Label] = sentence.get_labels("sentiment")
+    labels: list[Label] = sentence.get_labels("sentiment")
     assert len(labels) == 1
     assert labels[0].data_point.text == "love"
     assert labels[0].value == "positive"
@@ -45,7 +43,7 @@ def test_token_tags():
     # remove the pos label from the last word
     sentence[2].remove_labels("pos")
     # there should be 2 POS labels left
-    labels: List[Label] = sentence.get_labels("pos")
+    labels: list[Label] = sentence.get_labels("pos")
     assert len(labels) == 2
     assert len(sentence[0].get_labels("pos")) == 1
     assert len(sentence[1].get_labels("pos")) == 1
@@ -72,7 +70,7 @@ def test_span_tags():
     sentence[7:8].add_label("ner", "City")
 
     # check if there are three labels with correct text and values
-    labels: List[Label] = sentence.get_labels("ner")
+    labels: list[Label] = sentence.get_labels("ner")
     assert len(labels) == 3
     assert labels[0].data_point.text == "Humboldt Universität zu Berlin"
     assert labels[0].value == "Organization"
@@ -82,7 +80,7 @@ def test_span_tags():
     assert labels[2].value == "City"
 
     # check if there are two spans with correct text and values
-    spans: List[Span] = sentence.get_spans("ner")
+    spans: list[Span] = sentence.get_spans("ner")
     assert len(spans) == 2
     assert spans[0].text == "Humboldt Universität zu Berlin"
     assert len(spans[0].get_labels("ner")) == 2
@@ -92,12 +90,12 @@ def test_span_tags():
     # now delete the NER tags of "Humboldt-Universität zu Berlin"
     sentence[0:4].remove_labels("ner")
     # should be only one NER label left
-    labels: List[Label] = sentence.get_labels("ner")
+    labels: list[Label] = sentence.get_labels("ner")
     assert len(labels) == 1
     assert labels[0].data_point.text == "Berlin"
     assert labels[0].value == "City"
     # and only one NER span
-    spans: List[Span] = sentence.get_spans("ner")
+    spans: list[Span] = sentence.get_spans("ner")
     assert len(spans) == 1
     assert spans[0].text == "Berlin"
     assert spans[0].get_label("ner").value == "City"
@@ -111,7 +109,7 @@ def test_different_span_tags():
     sentence[7:8].add_label("ner", "City")
 
     # check if there are three labels with correct text and values
-    labels: List[Label] = sentence.get_labels("ner")
+    labels: list[Label] = sentence.get_labels("ner")
     assert len(labels) == 2
     assert labels[0].data_point.text == "Humboldt Universität zu Berlin"
     assert labels[0].value == "Organization"
@@ -119,7 +117,7 @@ def test_different_span_tags():
     assert labels[1].value == "City"
 
     # check if there are two spans with correct text and values
-    spans: List[Span] = sentence.get_spans("ner")
+    spans: list[Span] = sentence.get_spans("ner")
     assert len(spans) == 2
     assert spans[0].text == "Humboldt Universität zu Berlin"
     assert spans[0].get_label("ner").value == "Organization"
@@ -131,22 +129,22 @@ def test_different_span_tags():
     # now delete the NER tags of "Humboldt-Universität zu Berlin"
     sentence[0:4].remove_labels("ner")
     # should be only one NER label left
-    labels: List[Label] = sentence.get_labels("ner")
+    labels: list[Label] = sentence.get_labels("ner")
     assert len(labels) == 1
     assert labels[0].data_point.text == "Berlin"
     assert labels[0].value == "City"
     # and only one NER span
-    spans: List[Span] = sentence.get_spans("ner")
+    spans: list[Span] = sentence.get_spans("ner")
     assert len(spans) == 1
     assert spans[0].text == "Berlin"
     assert spans[0].get_label("ner").value == "City"
     # but there is also one orgtype span and label
-    labels: List[Label] = sentence.get_labels("orgtype")
+    labels: list[Label] = sentence.get_labels("orgtype")
     assert len(labels) == 1
     assert labels[0].data_point.text == "Humboldt Universität zu Berlin"
     assert labels[0].value == "University"
     # and only one NER span
-    spans: List[Span] = sentence.get_spans("orgtype")
+    spans: list[Span] = sentence.get_spans("orgtype")
     assert len(spans) == 1
     assert spans[0].text == "Humboldt Universität zu Berlin"
     assert spans[0].get_label("orgtype").value == "University"
@@ -154,7 +152,7 @@ def test_different_span_tags():
     # let's add the NER tag back
     sentence[0:4].add_label("ner", "Organization")
     # check if there are three labels with correct text and values
-    labels: List[Label] = sentence.get_labels("ner")
+    labels: list[Label] = sentence.get_labels("ner")
     print(labels)
     assert len(labels) == 2
     assert labels[0].data_point.text == "Humboldt Universität zu Berlin"
@@ -163,7 +161,7 @@ def test_different_span_tags():
     assert labels[1].value == "City"
 
     # check if there are two spans with correct text and values
-    spans: List[Span] = sentence.get_spans("ner")
+    spans: list[Span] = sentence.get_spans("ner")
     assert len(spans) == 2
     assert spans[0].text == "Humboldt Universität zu Berlin"
     assert spans[0].get_label("ner").value == "Organization"
@@ -194,17 +192,17 @@ def test_relation_tags():
     Relation(sentence[0:2], sentence[3:4]).add_label("syntactic", "apposition")
 
     # there should be two relation labels
-    labels: List[Label] = sentence.get_labels("rel")
+    labels: list[Label] = sentence.get_labels("rel")
     assert len(labels) == 2
     assert labels[0].value == "located in"
     assert labels[1].value == "university of"
 
     # there should be one syntactic labels
-    labels: List[Label] = sentence.get_labels("syntactic")
+    labels: list[Label] = sentence.get_labels("syntactic")
     assert len(labels) == 1
 
     # there should be two relations, one with two and one with one label
-    relations: List[Relation] = sentence.get_relations("rel")
+    relations: list[Relation] = sentence.get_relations("rel")
     assert len(relations) == 2
     assert len(relations[0].labels) == 1
     assert len(relations[1].labels) == 2

--- a/tests/test_tokenize_sentence.py
+++ b/tests/test_tokenize_sentence.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 import flair
@@ -492,5 +490,5 @@ def test_line_separator_is_ignored():
     assert Sentence(with_separator).to_original_text() == Sentence(without_separator).to_original_text()
 
 
-def no_op_tokenizer(text: str) -> List[str]:
+def no_op_tokenizer(text: str) -> list[str]:
     return [text]


### PR DESCRIPTION
Since python3.8 is no longer supported, we can now drop it and use python3.9 features in our code, especially improving typing.

This pr does:
* increase the minimum python version to 3.9 and uses it in gh-actions
* update ruff to version 0.7 & fixes new linting errors
* uses the python3.9 typing features
* removes some methods that aren't used since longer
* ensure that transformer embeddings will stay with the attention implementation that were saved, preventing precision issues after reloading.