### PR TITLE
Fix bug saving embeddings

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -1356,7 +1356,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
 
         # do not switch the attention implementation upon reload.
         config_dict["attn_implementation"] = self.model.config._attn_implementation
-        del config_dict["_attn_implementation_autoset"]
+        config_dict.pop("_attn_implementation_autoset", None)
 
         super_params = super().to_params()
 


### PR DESCRIPTION
Hi! I have a one-liner fix suggestion.

I get the following error when running relatively straightforward scripts:
```
    embeddings.save_embeddings(use_state_dict=False)
  File "/code/flair/flair/embeddings/base.py", line 101, in save_embeddings
    params = self.to_params()
             ^^^^^^^^^^^^^^^^
  File "/code/flair/flair/embeddings/transformer.py", line 1359, in to_params
    del config_dict["_attn_implementation_autoset"]
        ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: '_attn_implementation_autoset'
```

Here's a minimal reproduction of the bug:
```python
from flair.embeddings import TransformerDocumentEmbeddings
embeddings = TransformerDocumentEmbeddings(model="distilbert-base-uncased")
embeddings.save_embeddings()
```
This fails on master but succeeds on this branch.

I think this accidentally came in from this recent [PR](https://github.com/flairNLP/flair/pull/3560).