### PR TITLE
GH-3561: Update SECURITY.md with current contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,4 @@
 We acknowledge that every line of code that we write may potentially contain security issues.
 We are trying to deal with it responsibly and provide patches as quickly as possible.
 
-We host our bug bounty program on HackerOne, it is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this form:
-
-https://corporate.zalando.com/en/services-and-contact#security-form
-
-You can also send you report via this form if you do not want to join our bug bounty program and just want to report a vulnerability or security issue.
+Please report any issues to [Alan Akbik](http://alanakbik.github.io/).


### PR DESCRIPTION
This PR removes the old Zalando address for reporting vulnerabilities. 

A second PR will add a list (currently being created) where vulnerabilities can be reported. 

Closes #3561  