### PR TITLE
Multigpu: Fix gradient accumulation and learning rate aggregation

### DIFF
--- a/flair/trainers/plugins/functional/checkpoints.py
+++ b/flair/trainers/plugins/functional/checkpoints.py
@@ -30,8 +30,6 @@ class CheckpointPlugin(TrainerPlugin):
             )
             model_name = "model_epoch_" + str(epoch) + ".pt"
             self.model.save(self.base_path / model_name, checkpoint=self.save_optimizer_state)
-            if torch.distributed.is_initialized():
-                torch.distributed.barrier()  # Prevent any process from loading a model until writing is complete
 
     @property
     def attach_to_all_processes(self) -> bool:

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -656,33 +656,36 @@ class ModelTrainer(Pluggable):
                         batch_steps = self.get_batch_steps(batch, mini_batch_chunk_size=mini_batch_chunk_size)
 
                         # forward and backward for batch
-                        for batch_step in batch_steps:
-                            # forward pass
-                            with torch.autocast(device_type=flair.device.type, enabled=use_amp):
-                                if multi_gpu:
-                                    # We need to __call__ ddp_model() because this triggers hooks that sync gradients.
-                                    # But that calls forward rather than forward_loss. So we patch forward to redirect
-                                    # to forward_loss. Then undo the patch in case forward_loss itself calls forward.
-                                    def wrapped_forward_loss(*args, **kwargs2):
-                                        self.model.forward = original_forward
-                                        return self.model.forward_loss(*args, **kwargs2)
+                        for batch_step_no, batch_step in enumerate(batch_steps):
+                            skip_sync = multi_gpu and batch_step_no < len(batch_steps) - 1
+                            gradient_sync = contextlib.nullcontext() if skip_sync else self.ddp_model.no_sync()
+                            with gradient_sync:
+                                # forward pass
+                                with torch.autocast(device_type=flair.device.type, enabled=use_amp):
+                                    if multi_gpu:
+                                        # We need to __call__ ddp_model() because this triggers hooks that sync gradients.
+                                        # But that calls forward rather than forward_loss. So we patch forward to redirect
+                                        # to forward_loss. Then undo the patch in case forward_loss itself calls forward.
+                                        def wrapped_forward_loss(*args, **kwargs2):
+                                            self.model.forward = original_forward
+                                            return self.model.forward_loss(*args, **kwargs2)
 
-                                    self.model.forward = wrapped_forward_loss
-                                    loss, datapoint_count = self.ddp_model(batch_step)
-                                else:
-                                    loss, datapoint_count = self.model.forward_loss(batch_step)
+                                        self.model.forward = wrapped_forward_loss
+                                        loss, datapoint_count = self.ddp_model(batch_step)
+                                    else:
+                                        loss, datapoint_count = self.model.forward_loss(batch_step)
 
-                            batch_train_samples += datapoint_count
-                            batch_train_loss += loss.item()
+                                batch_train_samples += datapoint_count
+                                batch_train_loss += loss.item()
 
-                            self._backward(scaler.scale(loss))
+                                self._backward(scaler.scale(loss))
 
-                            # identify dynamic embeddings (always deleted) on first sentence
-                            if dynamic_embeddings is None:
-                                dynamic_embeddings = identify_dynamic_embeddings(batch)
+                                # identify dynamic embeddings (always deleted) on first sentence
+                                if dynamic_embeddings is None:
+                                    dynamic_embeddings = identify_dynamic_embeddings(batch)
 
-                            # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                            store_embeddings(batch_step, embeddings_storage_mode, dynamic_embeddings)
+                                # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+                                store_embeddings(batch_step, embeddings_storage_mode, dynamic_embeddings)
 
                         self.dispatch("before_training_optimizer_step", **batch_kw)
 


### PR DESCRIPTION
Hi! This PR fixes 3 bugs with multi-gpu training:
- When using gradient accumulation (mini_batch_chunk_size), this PR disables gradient syncing for allforward/backward passes except the last one before the step. These intermediate syncs are unnecessary and add communication that decreases efficiency. In my experience, this effect was significant enough to go from multi_gpu not giving any speedup, to a 80%-of-linear speedup (mini_batch_chunk_size ~= 4, sentence_length ~= 500, model=xlm-roberta-base, gpu_memory ~= 24g). This is similar to what's done [here](https://discuss.pytorch.org/t/gradient-accumulation-with-ddp-no-sync-interface/169593).
- Sums rather than averages gradients from multiple processes. Flair tracks losses / grads as the sum of the whole batch. However, Torch DDP averages the whole batch when aggregating multiple processes. This led to the effective learning rate being 1 / n_gpus smaller when using `multi_gpu=True`, but ideally it should stay the same to let knobs be turned independently, and this PR does that.
- Fixes a deadlock in the checkpoint plugin. When using `multi_gpu=True` and `save_model_each_k_epochs>0` training will freeze. Currently the plugin runs `barrier` which waits for other processes to catchup, but the plugin is only run on the main process, so they never will.