### PR TITLE
Add options to load full documents as Sentence objects

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -521,6 +521,12 @@ class ColumnDataset(FlairDataset):
         self.default_whitespace_after = default_whitespace_after
         self.documents_as_sentences = documents_as_sentences
 
+        if documents_as_sentences and not document_separator_token:
+            log.error(
+                "document_as_sentences was set to True, but no document_separator_token was provided. Please set"
+                "a value for document_separator_token in order to enable the document_as_sentence functionality."
+            )
+
         # store either Sentence objects in memory, or only file offsets
         self.in_memory = in_memory
 
@@ -834,7 +840,7 @@ class ColumnDataset(FlairDataset):
 
     def __line_completes_sentence(self, line: str) -> bool:
 
-        if self.documents_as_sentences:
+        if self.documents_as_sentences and self.document_separator_token:
             if line.startswith(self.document_separator_token):
                 return True
             else:

--- a/tests/resources/tasks/trivial/trivial_bioes_with_boundaries/dev.txt
+++ b/tests/resources/tasks/trivial/trivial_bioes_with_boundaries/dev.txt
@@ -1,0 +1,37 @@
+this O
+is O
+New B-LOC
+York I-LOC
+
+here O
+is O
+New B-LOC
+York I-LOC
+
+I O
+like O
+New B-LOC
+York I-LOC
+
+we O
+like O
+New B-LOC
+York I-LOC
+
+-DOCSTART-
+
+this O
+is O
+Berlin B-LOC
+
+here O
+is O
+Berlin B-LOC
+
+I O
+like O
+Berlin B-LOC
+
+we O
+like O
+Berlin B-LOC

--- a/tests/resources/tasks/trivial/trivial_bioes_with_boundaries/test.txt
+++ b/tests/resources/tasks/trivial/trivial_bioes_with_boundaries/test.txt
@@ -1,0 +1,39 @@
+this O
+is O
+New B-LOC
+York I-LOC
+
+here O
+is O
+New B-LOC
+York I-LOC
+
+I O
+like O
+New B-LOC
+York I-LOC
+
+we O
+like O
+New B-LOC
+York I-LOC
+
+-DOCSTART-
+
+this O
+is O
+Berlin B-LOC
+
+here O
+is O
+Berlin B-LOC
+
+I O
+like O
+Berlin B-LOC
+
+we O
+like O
+Berlin B-LOC
+
+-DOCSTART-

--- a/tests/resources/tasks/trivial/trivial_bioes_with_boundaries/train.txt
+++ b/tests/resources/tasks/trivial/trivial_bioes_with_boundaries/train.txt
@@ -1,0 +1,59 @@
+this O
+is O
+New B-LOC
+York I-LOC
+
+here O
+is O
+New B-LOC
+York I-LOC
+
+I O
+like O
+New B-LOC
+York I-LOC
+
+we O
+like O
+New B-LOC
+York I-LOC
+
+-DOCSTART-
+
+this O
+is O
+Berlin B-LOC
+
+here O
+is O
+Berlin B-LOC
+
+I O
+like O
+Berlin B-LOC
+
+we O
+like O
+Berlin B-LOC
+
+-DOCSTART-
+
+this O
+is O
+New B-LOC
+York I-LOC
+
+here O
+is O
+New B-LOC
+York I-LOC
+
+I O
+like O
+New B-LOC
+York I-LOC
+
+we O
+like O
+New B-LOC
+York I-LOC

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -75,6 +75,54 @@ def test_load_sequence_labeling_data(tasks_base_path):
     assert len(corpus.test) == 1
 
 
+def test_load_sequence_labeling_data_with_boundaries(tasks_base_path):
+    # get training, test and dev data
+    corpus = flair.datasets.ColumnCorpus(
+        tasks_base_path / "trivial" / "trivial_bioes_with_boundaries", column_format={0: "text", 1: "ner"}
+    )
+
+    assert len(corpus.train) == 14
+    assert len(corpus.dev) == 9
+    assert len(corpus.test) == 10
+
+    # now exclude -DOCSTART- sentences
+    corpus = flair.datasets.ColumnCorpus(
+        tasks_base_path / "trivial" / "trivial_bioes_with_boundaries",
+        column_format={0: "text", 1: "ner"},
+        banned_sentences=["-DOCSTART-"],
+    )
+
+    assert len(corpus.train) == 12
+    assert len(corpus.dev) == 8
+    assert len(corpus.test) == 8
+
+    assert len(corpus.train[0].right_context(5)) == 5
+
+    # now load whole documents as sentences
+    corpus = flair.datasets.ColumnCorpus(
+        tasks_base_path / "trivial" / "trivial_bioes_with_boundaries",
+        column_format={0: "text", 1: "ner"},
+        document_separator_token="-DOCSTART-",
+        documents_as_sentences=True,
+    )
+
+    assert len(corpus.train) == 3
+    assert len(corpus.dev) == 2
+    assert len(corpus.test) == 2
+
+    assert len(corpus.train[0].right_context(5)) == 0
+
+    # ban each boundary but set each sentence to be independent
+    corpus = flair.datasets.ColumnCorpus(
+        tasks_base_path / "trivial" / "trivial_bioes_with_boundaries",
+        column_format={0: "text", 1: "ner"},
+        banned_sentences=["-DOCSTART-"],
+        every_sentence_is_independent=True,
+    )
+
+    assert len(corpus.train[0].right_context(5)) == 0
+
+
 def test_load_sequence_labeling_whitespace_after(tasks_base_path):
     # get training, test and dev data
     corpus = flair.datasets.ColumnCorpus(


### PR DESCRIPTION
This PR adds two new parameters to `ColumnCorpus `and `ColumnDataset `to enable more customization in handling document boundaries. 

`documents_as_sentences`: If set to `True` and a `document_separator_token `is also set, the corpus will create one sentence object not for each sentence, but for each document in the corpus. 

`every_sentence_is_independent`: If set to `True`, the corpus will consider each sentence independent. This means that loaded sentences cannot expand their context beyond the sentence boundary. This is useful for corpora that store independent sentences, like tweets. 

