### PR TITLE
fix: update scipy .A to toarray()

### DIFF
--- a/flair/embeddings/document.py
+++ b/flair/embeddings/document.py
@@ -210,7 +210,7 @@ class DocumentTFIDFEmbeddings(DocumentEmbeddings):
             sentences = [sentences]
 
         raw_sentences = [s.to_original_text() for s in sentences]
-        tfidf_vectors = torch.from_numpy(self.vectorizer.transform(raw_sentences).A)
+        tfidf_vectors = torch.from_numpy(self.vectorizer.transform(raw_sentences).toarray())
 
         for sentence_id, sentence in enumerate(sentences):
             sentence.set_embedding(self.name, tfidf_vectors[sentence_id])


### PR DESCRIPTION
scipy has removed support for the .A method in sparse arrays (https://github.com/scipy/scipy/issues/21049). Replaced this with .toarray().