### PR TITLE
fixes https://github.com/flairNLP/flair/issues/3623: save PEFT config…

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -1128,6 +1128,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
             if "Please use the model as it is" not in str(e):
                 raise e
 
+        self.peft_config = peft_config
         if peft_config is not None:
             # add adapters for finetuning
             try:
@@ -1376,6 +1377,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
             "subtoken_pooling": self.subtoken_pooling,
             "cls_pooling": self.cls_pooling,
             "config_state_dict": config_dict,
+            "peft_config": self.peft_config,
         }
 
         return model_state


### PR DESCRIPTION
Fixes Flair bug: https://github.com/flairNLP/flair/issues/3623

This simply saves the PEFT config to the transformer embeddings object and exports it as a parameter so it is saved with the model file and loaded when instantiating the embeddings.