### PR TITLE
Lazy Tokenization in Flair

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -847,7 +847,7 @@ class Sentence(DataPoint):
         else:
             # if list of strings or tokens is passed, create tokens directly
             self._tokens = []
-            
+
             # First construct the text from tokens to ensure proper text reconstruction
             if len(text) > 0:
                 if isinstance(text[0], Token):
@@ -906,7 +906,7 @@ class Sentence(DataPoint):
                 else:
                     token.sentence.annotation_layers[typename].append(Label(token, label.value, label.score))
 
-    @property 
+    @property
     def tokens(self) -> list[Token]:
         """Gets the tokens of this sentence. Automatically triggers tokenization if not yet tokenized."""
         if self._tokens is None:

--- a/flair/datasets/base.py
+++ b/flair/datasets/base.py
@@ -207,7 +207,7 @@ class MongoDataset(FlairDataset):
                 sentence.add_label(self.tag_type, label)
 
             if self.max_tokens_per_doc > 0:
-                sentence.tokens = sentence.tokens[: min(len(sentence), self.max_tokens_per_doc)]
+                sentence.truncate(self.max_tokens_per_doc)
 
             return sentence
         return None

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -270,7 +270,7 @@ class ClassificationDataset(FlairDataset):
 
             if 0 < self.truncate_to_max_tokens < len(sentence):
                 # Create new sentence with truncated text
-                truncated_text = " ".join(token.text for token in sentence.tokens[:self.truncate_to_max_tokens])
+                truncated_text = " ".join(token.text for token in sentence.tokens[: self.truncate_to_max_tokens])
                 sentence = Sentence(truncated_text, use_tokenizer=tokenizer)
 
             # Add the labels

--- a/flair/datasets/document_classification.py
+++ b/flair/datasets/document_classification.py
@@ -268,11 +268,14 @@ class ClassificationDataset(FlairDataset):
         if text and (labels or self.allow_examples_without_labels):
             sentence = Sentence(text, use_tokenizer=tokenizer)
 
+            if 0 < self.truncate_to_max_tokens < len(sentence):
+                # Create new sentence with truncated text
+                truncated_text = " ".join(token.text for token in sentence.tokens[:self.truncate_to_max_tokens])
+                sentence = Sentence(truncated_text, use_tokenizer=tokenizer)
+
+            # Add the labels
             for label in labels:
                 sentence.add_label(self.label_type, label)
-
-            if sentence is not None and 0 < self.truncate_to_max_tokens < len(sentence):
-                sentence.tokens = sentence.tokens[: self.truncate_to_max_tokens]
 
             return sentence
         return None

--- a/flair/datasets/text_text.py
+++ b/flair/datasets/text_text.py
@@ -183,8 +183,8 @@ class ParallelTextDataset(FlairDataset):
         target_sentence = Sentence(target_line, use_tokenizer=self.use_tokenizer)
 
         if self.max_tokens_per_doc > 0:
-            source_sentence.tokens = source_sentence.tokens[: self.max_tokens_per_doc]
-            target_sentence.tokens = target_sentence.tokens[: self.max_tokens_per_doc]
+            source_sentence.truncate(self.max_tokens_per_doc)
+            target_sentence.truncate(self.max_tokens_per_doc)
 
         return TextPair(source_sentence, target_sentence)
 
@@ -415,8 +415,8 @@ class DataPairDataset(FlairDataset):
         second_sentence = Sentence(second_element, use_tokenizer=self.use_tokenizer)
 
         if self.max_tokens_per_doc > 0:
-            first_sentence.tokens = first_sentence.tokens[: self.max_tokens_per_doc]
-            second_sentence.tokens = second_sentence.tokens[: self.max_tokens_per_doc]
+            first_sentence.truncate(self.max_tokens_per_doc)
+            second_sentence.truncate(self.max_tokens_per_doc)
 
         data_pair = TextPair(first_sentence, second_sentence)
 
@@ -668,9 +668,9 @@ class DataTripleDataset(FlairDataset):
         third_sentence = Sentence(third_element, use_tokenizer=self.use_tokenizer)
 
         if self.max_tokens_per_doc > 0:
-            first_sentence.tokens = first_sentence.tokens[: self.max_tokens_per_doc]
-            second_sentence.tokens = second_sentence.tokens[: self.max_tokens_per_doc]
-            third_sentence.tokens = third_sentence.tokens[: self.max_tokens_per_doc]
+            first_sentence.truncate(self.max_tokens_per_doc)
+            second_sentence.truncate(self.max_tokens_per_doc)
+            third_sentence.truncate(self.max_tokens_per_doc)
 
         data_triple = TextTriple(first_sentence, second_sentence, third_sentence)
 

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -523,6 +523,26 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
 
         # For token embeddings, proceed with full tokenization
         flair_tokens, offsets, lengths = self.__gather_flair_tokens(sentences)
+
+        # random check some tokens to save performance.
+        if (self.needs_manual_ocr or self.tokenizer_needs_ocr_boxes) and not all(
+            [
+                flair_tokens[0][0].has_metadata("bbox"),
+                flair_tokens[0][-1].has_metadata("bbox"),
+                flair_tokens[-1][0].has_metadata("bbox"),
+                flair_tokens[-1][-1].has_metadata("bbox"),
+            ]
+        ):
+            raise ValueError(f"The embedding '{self.name}' requires the ocr 'bbox' set as metadata on all tokens.")
+
+        if self.feature_extractor is not None and not all(
+            [
+                sentences[0].has_metadata("image"),
+                sentences[-1].has_metadata("image"),
+            ]
+        ):
+            raise ValueError(f"The embedding '{self.name}' requires the 'image' set as metadata for all sentences.")
+
         return self.__build_transformer_model_inputs(sentences, offsets, lengths, flair_tokens, device)
 
     def __build_transformer_model_inputs(

--- a/flair/models/relation_classifier_model.py
+++ b/flair/models/relation_classifier_model.py
@@ -716,6 +716,10 @@ class RelationClassifier(flair.nn.DefaultClassifier[EncodedSentence, EncodedSent
                 itertools.chain.from_iterable(self._encode_sentence_for_inference(sentence) for sentence in sentences)
             )
 
+            # Add check for empty sentences_with_relation_reference
+            if not sentences_with_relation_reference:
+                return None if return_loss else None
+
             encoded_sentences = [x[0] for x in sentences_with_relation_reference]
             loss = super().predict(
                 encoded_sentences,

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -851,8 +851,6 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
             if not isinstance(sentences, list):
                 sentences = [sentences]
 
-            print("sentences", sentences)
-
             if isinstance(sentences[0], Sentence):
                 Sentence.set_context_for_sentences(typing.cast(list[Sentence], sentences))
 

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -679,11 +679,11 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
     def _filter_data_point(self, data_point: DT) -> bool:
         """Specify if a data point should be kept.
 
-        That way you can remove for example empty texts. Per default all datapoints that have length zero
+        That way you can remove for example empty texts. Per default all datapoints that have empty text
         will be removed.
         Return true if the data point should be kept and false if it should be removed.
         """
-        return len(data_point) > 0
+        return bool(data_point.text.strip())
 
     @abstractmethod
     def _get_embedding_for_data_point(self, prediction_data_point: DT2) -> torch.Tensor:
@@ -814,10 +814,10 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
             return data_points
 
         # filter empty sentences
-        sentences = [sentence for sentence in typing.cast(list[Sentence], data_points) if len(sentence) > 0]
+        sentences = [sentence for sentence in typing.cast(list[Sentence], data_points) if sentence.text.strip()]
 
-        # reverse sort all sequences by their length
-        reordered_sentences = sorted(sentences, key=len, reverse=True)
+        # sort by text length (characters) instead of token length
+        reordered_sentences = sorted(sentences, key=lambda s: len(s.text), reverse=True)
 
         return typing.cast(list[DT], reordered_sentences)
 
@@ -847,8 +847,6 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
             label_name = self.label_type if self.label_type is not None else "label"
 
         with torch.no_grad():
-            if not sentences:
-                return sentences
 
             if not isinstance(sentences, list):
                 sentences = [sentences]
@@ -882,7 +880,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
                 batch = [dp for dp in batch if self._filter_data_point(dp)]
 
                 # stop if all sentences are empty
-                if not batch:
+                if len(batch) == 0:
                     continue
 
                 data_points = self._get_data_points_for_batch(batch)
@@ -896,7 +894,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
                 scores = self._mask_scores(scores, data_points)
 
                 # if anything could possibly be predicted
-                if len(data_points) > 0:
+                if data_points:
                     # remove previously predicted labels of this type
                     for sentence in data_points:
                         sentence.remove_labels(label_name)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -851,6 +851,8 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
             if not isinstance(sentences, list):
                 sentences = [sentences]
 
+            print("sentences", sentences)
+
             if isinstance(sentences[0], Sentence):
                 Sentence.set_context_for_sentences(typing.cast(list[Sentence], sentences))
 

--- a/tests/test_tokenize_sentence.py
+++ b/tests/test_tokenize_sentence.py
@@ -555,3 +555,24 @@ def test_embeddings_tokenization():
     assert sentence_doc._tokens is None
     doc_embeddings.embed(sentence_doc)
     assert sentence_doc._tokens is None
+
+
+def test_remove_labels_keeps_untokenized():
+    # Create a sentence without triggering tokenization
+    sentence = Sentence("The quick brown fox jumps over the lazy dog")
+    sentence.add_label("pos", "ADJ")
+    assert not sentence._is_tokenized()  # Verify sentence starts untokenized
+
+    # Remove labels should not trigger tokenization
+    sentence.remove_labels("pos")
+    assert not sentence._is_tokenized()  # Sentence should still be untokenized
+
+
+def test_clear_embeddings_keeps_untokenized():
+    # Create a sentence without triggering tokenization
+    sentence = Sentence("The quick brown fox jumps over the lazy dog")
+    assert not sentence._is_tokenized()  # Verify sentence starts untokenized
+
+    # Clear embeddings should not trigger tokenization
+    sentence.clear_embeddings()
+    assert not sentence._is_tokenized()  # Sentence should still be untokenized


### PR DESCRIPTION
Closes #3635

Flair previously always tokenized sentences. However, for some tasks, such as text classification using transformers, tokenization is not necessary, causing memory overheads and speed bottlenecks. 

This PR implements lazy tokenization for Flair sentences to improve efficiency, particularly for long texts. Sentences are now only tokenized when necessary, rather than immediately upon creation. 

Key Changes:
- Added `_is_tokenized()` method to check tokenization state
- Modified transformer embeddings to preserve lazy tokenization state
- Added tests to verify tokenization behavior
- Improved code clarity around tokenization states
- Adds a new `.truncate()` method to `Sentence` that allows an existing sentence to be shortened to a maximum number of tokens.

Example to illustrate how lazy tokenization works:

```python
from flair.data import Sentence

# Create a sentence - no tokenization happens yet
sentence = Sentence("This is a long text that won't be tokenized immediately")
print(sentence) # Printing a sentence does not require tokenization
print(sentence._is_tokenized())  # Output: False

# Tokenization happens only when needed
len(sentence)  # This triggers tokenization since length is computed using the number of tokens
print(sentence._is_tokenized())  # Output: True
```

This gives speed improvements when, for example, predicting sentiment over many long texts. The script used to test: 

```python
from flair.models import TextClassifier
from flair.data import Sentence
import time

# Load classifier once
classifier = TextClassifier.load("sentiment")

# Test data
text = "a " * 500
n_sentences = 5000

# Test 1: Without forced tokenization
start_time = time.time()
sentences_1 = [Sentence(text) for _ in range(n_sentences)]
assert all(not s._is_tokenized() for s in sentences_1), "Sentences should not be tokenized initially"
for sentence in sentences_1:
    classifier.predict(sentence)
time_1 = time.time() - start_time
print(f"Time without forced tokenization: {time_1:.2f} seconds")
assert all(not s._is_tokenized() for s in sentences_1), "Sentences should NOT be tokenized after prediction"


# Test 2: With forced tokenization
start_time = time.time()
sentences_2 = [Sentence(text) for _ in range(n_sentences)]
for sentence in sentences_2:
    sentence._tokenize()  # Force tokenization
assert all(s._is_tokenized() for s in sentences_2), "Sentences should be tokenized after len()"
for sentence in sentences_2:
    classifier.predict(sentence)
time_2 = time.time() - start_time
print(f"Time with forced tokenization: {time_2:.2f} seconds")
assert all(s._is_tokenized() for s in sentences_2), "Sentences should still be tokenized after prediction"


print(f"Difference: {abs(time_1 - time_2):.2f} seconds")
print(f"Relative speed difference: {((time_1 - time_2) / time_1 * 100):.1f}%")
```

Which prints: 

```console
Time without forced tokenization: 26.40 seconds
Time with forced tokenization: 40.02 seconds
Difference: 13.62 seconds
Relative speed difference: -51.6%
```
