### PR TITLE
Add Staccato tokenizer and retokenize method

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -224,7 +224,7 @@ class Label:
         self._score = score
         self.metadata = metadata
         # Add a new attribute to store the typename
-        self._typename = None
+        self._typename: Optional[str] = None
         super().__init__()
 
     def set_value(self, value: str, score: float = 1.0):
@@ -277,7 +277,7 @@ class Label:
         return f"{self.data_point.unlabeled_identifier}"
 
     @property
-    def typename(self) -> str:
+    def typename(self) -> Optional[str]:
         """
         Returns the label type name this label belongs to.
         This is determined by looking up the label in the data point's label dictionary.
@@ -286,8 +286,9 @@ class Label:
             return self._typename
 
         # Find the typename by checking which label type this label belongs to
+        # Note: this should rarely if ever be triggered, as labels are usually added via the DataPoint.add_label() method
         if self.data_point is not None:
-            for type_name, labels in self.data_point._labels.items():
+            for type_name, labels in self.data_point.annotation_layers.items():
                 if self in labels:
                     self._typename = type_name
                     return type_name

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -328,6 +328,7 @@ class MultiFileColumnCorpus(Corpus):
         default_whitespace_after: int = 1,
         every_sentence_is_independent: bool = False,
         documents_as_sentences: bool = False,
+        use_tokenizer: Union[bool, Tokenizer] = None,  # New parameter
         **corpusargs,
     ) -> None:
         r"""Instantiates a Corpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
@@ -347,6 +348,7 @@ class MultiFileColumnCorpus(Corpus):
             label_name_map: Optionally map tag names to different schema.
             banned_sentences: Optionally remove sentences from the corpus. Works only if `in_memory` is true
         """
+
         # get train data
         train: Optional[Dataset] = (
             ConcatDataset(
@@ -439,6 +441,7 @@ class ColumnCorpus(MultiFileColumnCorpus):
         autofind_splits: bool = True,
         name: Optional[str] = None,
         comment_symbol="# ",
+        use_tokenizer: Union[bool, Tokenizer] = None,  # New parameter
         **corpusargs,
     ) -> None:
         r"""Instantiates a Corpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
@@ -468,6 +471,7 @@ class ColumnCorpus(MultiFileColumnCorpus):
             test_files=[test_file] if test_file else [],
             name=name if data_folder is None else str(data_folder),
             comment_symbol=comment_symbol,
+            use_tokenizer=use_tokenizer,  # Pass the tokenizer
             **corpusargs,
         )
 
@@ -511,7 +515,6 @@ class ColumnDataset(FlairDataset):
         """
         path_to_column_file = Path(path_to_column_file)
         assert path_to_column_file.exists()
-        self.path_to_column_file = path_to_column_file
         self.column_delimiter = re.compile(column_delimiter)
         self.comment_symbol = comment_symbol
         self.document_separator_token = document_separator_token
@@ -521,11 +524,18 @@ class ColumnDataset(FlairDataset):
         self.default_whitespace_after = default_whitespace_after
         self.documents_as_sentences = documents_as_sentences
 
+        # all these are newly added to make the reloading for re-tokenized files work
+        self.column_name_map = column_name_map
+        self.skip_first_line = skip_first_line
+        self.encoding = encoding
+
         if documents_as_sentences and not document_separator_token:
             log.error(
                 "document_as_sentences was set to True, but no document_separator_token was provided. Please set"
                 "a value for document_separator_token in order to enable the document_as_sentence functionality."
             )
+
+        self.path_to_column_file = path_to_column_file
 
         # store either Sentence objects in memory, or only file offsets
         self.in_memory = in_memory
@@ -1455,6 +1465,7 @@ class CLEANCONLL(ColumnCorpus):
         self,
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = True,
+        use_tokenizer: Union[bool, Tokenizer] = None,  # New parameter
         **corpusargs,
     ) -> None:
         """Initialize the CleanCoNLL corpus.
@@ -1494,6 +1505,7 @@ class CLEANCONLL(ColumnCorpus):
             encoding="utf-8",
             in_memory=in_memory,
             document_separator_token="-DOCSTART-",
+            use_tokenizer=use_tokenizer,  # Pass the tokenizer
             **corpusargs,
         )
 

--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -328,7 +328,6 @@ class MultiFileColumnCorpus(Corpus):
         default_whitespace_after: int = 1,
         every_sentence_is_independent: bool = False,
         documents_as_sentences: bool = False,
-        use_tokenizer: Union[bool, Tokenizer] = None,  # New parameter
         **corpusargs,
     ) -> None:
         r"""Instantiates a Corpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
@@ -348,7 +347,6 @@ class MultiFileColumnCorpus(Corpus):
             label_name_map: Optionally map tag names to different schema.
             banned_sentences: Optionally remove sentences from the corpus. Works only if `in_memory` is true
         """
-
         # get train data
         train: Optional[Dataset] = (
             ConcatDataset(
@@ -441,7 +439,6 @@ class ColumnCorpus(MultiFileColumnCorpus):
         autofind_splits: bool = True,
         name: Optional[str] = None,
         comment_symbol="# ",
-        use_tokenizer: Union[bool, Tokenizer] = None,  # New parameter
         **corpusargs,
     ) -> None:
         r"""Instantiates a Corpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
@@ -471,7 +468,6 @@ class ColumnCorpus(MultiFileColumnCorpus):
             test_files=[test_file] if test_file else [],
             name=name if data_folder is None else str(data_folder),
             comment_symbol=comment_symbol,
-            use_tokenizer=use_tokenizer,  # Pass the tokenizer
             **corpusargs,
         )
 
@@ -515,6 +511,7 @@ class ColumnDataset(FlairDataset):
         """
         path_to_column_file = Path(path_to_column_file)
         assert path_to_column_file.exists()
+        self.path_to_column_file = path_to_column_file
         self.column_delimiter = re.compile(column_delimiter)
         self.comment_symbol = comment_symbol
         self.document_separator_token = document_separator_token
@@ -524,18 +521,11 @@ class ColumnDataset(FlairDataset):
         self.default_whitespace_after = default_whitespace_after
         self.documents_as_sentences = documents_as_sentences
 
-        # all these are newly added to make the reloading for re-tokenized files work
-        self.column_name_map = column_name_map
-        self.skip_first_line = skip_first_line
-        self.encoding = encoding
-
         if documents_as_sentences and not document_separator_token:
             log.error(
                 "document_as_sentences was set to True, but no document_separator_token was provided. Please set"
                 "a value for document_separator_token in order to enable the document_as_sentence functionality."
             )
-
-        self.path_to_column_file = path_to_column_file
 
         # store either Sentence objects in memory, or only file offsets
         self.in_memory = in_memory
@@ -1465,7 +1455,6 @@ class CLEANCONLL(ColumnCorpus):
         self,
         base_path: Optional[Union[str, Path]] = None,
         in_memory: bool = True,
-        use_tokenizer: Union[bool, Tokenizer] = None,  # New parameter
         **corpusargs,
     ) -> None:
         """Initialize the CleanCoNLL corpus.
@@ -1505,7 +1494,6 @@ class CLEANCONLL(ColumnCorpus):
             encoding="utf-8",
             in_memory=in_memory,
             document_separator_token="-DOCSTART-",
-            use_tokenizer=use_tokenizer,  # Pass the tokenizer
             **corpusargs,
         )
 

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -274,3 +274,36 @@ def test_data_point_equality():
     assert span_ner_label.data_point == span_other_label.data_point
     assert ner_label.data_point != span_other_label.data_point
     assert other_label.data_point != span_ner_label.data_point
+
+
+def test_label_typename():
+    """Test the typename property of the Label class to ensure it correctly
+    identifies and returns the label type."""
+    # Create a sentence with various types of labels
+    sentence = Sentence("George Washington went to Washington.")
+
+    # Add labels of different types to various parts of the sentence
+    sentence.add_label("sentiment", "positive")
+    sentence[0:2].add_label("ner", "PER")
+    sentence[4].add_label("pos", "PROPN")
+
+    # Get labels of each type
+    sentiment_label = sentence.get_label("sentiment")
+    ner_label = sentence.get_label("ner")
+    pos_label = sentence.get_label("pos")
+
+    # Test that typename property returns the correct type for each label
+    assert sentiment_label.typename == "sentiment"
+    assert ner_label.typename == "ner"
+    assert pos_label.typename == "pos"
+
+    # Test that the typename is set correctly when creating the label
+    new_label = Label(sentence, "test_value")
+    assert new_label.typename is None  # Should be None initially
+
+    new_label.typename = "test_type"
+    assert new_label.typename == "test_type"  # Should be set by the setter
+
+    # Test that when a label isn't associated with any layer, the typename is None
+    detached_label = Label(sentence, "detached")
+    assert detached_label.typename is None


### PR DESCRIPTION
This PR adds a new tokenizer following the ideas outlined in #3631. 

The tokenizer works like any other, but is intended to give a reasonable, if somewhat trigger-happy tokenization of any language. Some illustration of how this works for different languages: 

```python
# English sentence tokenized with Staccato tokenizer
print("Testing English with numbers and punctuation:")
sentence = Sentence("It's 03-16-2025", use_tokenizer=StaccatoTokenizer())
desired_tokenization = ["It", "'", "s", "03", "-", "16", "-", "2025"]

for token, desired_token in zip(sentence, desired_tokenization):
    print(f"Got: '{token.text}', Expected: '{desired_token}'")
    assert token.text == desired_token
print("✓ English test passed")


# Test for Cyrillic (Russian)
print("\nTesting Cyrillic (Russian):")
russian_sentence = Sentence("Привет, мир! Это тест 123.", use_tokenizer=StaccatoTokenizer())
russian_desired = ["Привет", ",", "мир", "!", "Это", "тест", "123", "."]

for token, desired_token in zip(russian_sentence, russian_desired):
    print(f"Got: '{token.text}', Expected: '{desired_token}'")
    assert token.text == desired_token
print("✓ Russian test passed")


# Test for Chinese with Kanji/Hanzi
print("\nTesting Chinese with Kanji/Hanzi:")
chinese_sentence = Sentence("你好，世界！123", use_tokenizer=StaccatoTokenizer())
chinese_desired = ["你", "好", "，", "世", "界", "！", "123"]

for token, desired_token in zip(chinese_sentence, chinese_desired):
    print(f"Got: '{token.text}', Expected: '{desired_token}'")
    assert token.text == desired_token
print("✓ Chinese test passed")


# Test for Japanese (mix of Kanji, Hiragana, Katakana)
print("\nTesting Japanese (mixed scripts):")
japanese_sentence = Sentence("こんにちは世界！テスト123", use_tokenizer=StaccatoTokenizer())
japanese_desired = ["こんにちは", "世", "界", "！", "テスト", "123"]

for token, desired_token in zip(japanese_sentence, japanese_desired):
    print(f"Got: '{token.text}', Expected: '{desired_token}'")
    assert token.text == desired_token
print("✓ Japanese test passed")


# Test for Arabic
print("\nTesting Arabic:")
arabic_sentence = Sentence("مرحبا بالعالم! 123", use_tokenizer=StaccatoTokenizer())
arabic_desired = ["مرحبا", "بالعالم", "!", "123"]

for token, desired_token in zip(arabic_sentence, arabic_desired):
    print(f"Got: '{token.text}', Expected: '{desired_token}'")
    assert token.text == desired_token
print("✓ Arabic test passed")
```

To test this tokenizer, this PR also adds a `retokenize` method for the `Sentence` object. Use it like this: 

```python
# Create a sentence with default tokenization
from flair.data import Sentence
from flair.tokenization import StaccatoTokenizer

sentence = Sentence("01-03-2025 New York")

# Add span labels
sentence.get_span(1, 3).add_label('ner', "LOC")
sentence.get_span(0, 1).add_label('ner', "DATE")

# Retokenize with a different tokenizer while preserving labels
sentence.retokenize(StaccatoTokenizer())
```

Further, it adds a `typename` property for convenience to Label, to allow us to directly access the label type name.

