### PR TITLE
Gh 3400 whitespace offsets

### DIFF
--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -221,6 +221,58 @@ def document_max_pooling(sentence_hidden_states: torch.Tensor, sentence_lengths:
     return result
 
 
+def map_tokens_to_subtokens(subtoken_offsets, token_offsets, verbose: bool = False, subtokens=None, tokens=None):
+
+    mapping = []
+    for subtoken_id, subtoken in enumerate(subtoken_offsets):
+
+        # subtokens of length 0 should not be mapped to anything
+        if subtoken[0] == subtoken[1]:
+            mapping.append(None)
+            continue
+
+        mapping_found = False
+
+        if verbose and subtokens:
+            print(f"trying to match {subtokens[subtoken_id]} ({subtoken})")
+
+        # check if the subtoken is wholly contained within a token. If so, it should be mapped to this token
+        for token_id, token in enumerate(token_offsets):
+
+            if verbose and tokens:
+                print(f" ... does {tokens[token_id]} (#{token_id}, {token}) match?")
+
+            if token[0] - 1 <= subtoken[0] and token[1] >= subtoken[1]:
+                if verbose:
+                    print(" ... yes!")
+                mapping.append(token_id)
+                mapping_found = True
+                break
+
+        if mapping_found:
+            continue
+
+        # if the subtoken is not wholly contained within a token, it may be partially contained
+        # in this case, take the first token in which it is partially contained
+        for token_id, token in enumerate(token_offsets):
+            if verbose and tokens:
+                print(f" ... does {tokens[token_id]} (#{token_id}, {token}) partially match?")
+            if token[0] >= subtoken[0]:
+                if verbose:
+                    print(" ... yes!")
+                mapping.append(token_id)
+                mapping_found = True
+                break
+
+        if mapping_found:
+            continue
+
+        # if a subtoken cannot be mapped, the mapping is None
+        mapping.append(None)
+
+    return mapping
+
+
 def _legacy_reconstruct_word_ids(
     embedding: "TransformerBaseEmbeddings", flair_tokens: list[list[str]]
 ) -> list[list[Optional[int]]]:
@@ -353,6 +405,8 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         feature_extractor: Optional[FeatureExtractionMixin] = None,
         needs_manual_ocr: Optional[bool] = None,
         use_context_separator: bool = True,
+        use_raw_text_as_input: bool = False,
+        **kwargs,
     ) -> None:
         self.name = name
         super().__init__()
@@ -373,6 +427,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         self.feature_extractor = feature_extractor
         self.use_context_separator = use_context_separator
         self.cls_pooling = cls_pooling
+        self.use_raw_text_as_input = use_raw_text_as_input
 
         tokenizer_params = list(inspect.signature(self.tokenizer.__call__).parameters.keys())
         self.tokenizer_needs_ocr_boxes = "boxes" in tokenizer_params
@@ -416,6 +471,7 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
             "feature_extractor": self.feature_extractor,
             "use_context_separator": self.use_context_separator,
             "cls_pooling": self.cls_pooling,
+            "use_raw_text_as_input": self.use_raw_text_as_input,
         }
         if hasattr(self, "needs_manual_ocr"):
             args["needs_manual_ocr"] = self.needs_manual_ocr
@@ -567,6 +623,17 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
                 tokenizer_kwargs["is_split_into_words"] = True
             tokenizer_kwargs["text"] = [[t.text for t in tokens] for tokens in flair_tokens]
 
+            # if we use raw text as input #TODO: explain
+            if self.use_raw_text_as_input:
+                tokenizer_kwargs["is_split_into_words"] = False
+                tokenizer_kwargs["return_offsets_mapping"] = True
+
+                # reconstruct text of sentences and preserve whitespace_after information
+                tokenizer_kwargs["text"] = [
+                    "".join([t.text if t.whitespace_after == 0 else t.text + " " * t.whitespace_after for t in tokens])
+                    for tokens in flair_tokens
+                ]
+
         batch_encoding = self.tokenizer(
             **tokenizer_kwargs,
             stride=self.stride,
@@ -626,12 +693,54 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
         if "bbox" in batch_encoding:
             model_kwargs["bbox"] = batch_encoding["bbox"].to(device, non_blocking=True)
 
+        # If we need a token-level embedding, we need to derive mappings between subtokens and flair tokens
         if self.token_embedding or self.needs_manual_ocr:
             assert sentence_lengths is not None  # for type checking
             model_kwargs["token_lengths"] = torch.tensor(sentence_lengths, device=device)
 
             if self.tokenizer.is_fast:
-                word_ids_list = [batch_encoding.word_ids(i) for i in range(input_ids.size()[0])]
+
+                if self.use_raw_text_as_input:
+                    word_ids_list = []
+                    for sentence_no, sentence_tokens in enumerate(flair_tokens):
+                        tokens = [t.text for t in sentence_tokens]
+
+                        subtoken_offsets = batch_encoding["offset_mapping"][sentence_no]
+
+                        offset = 0
+                        token_offsets = []
+                        for token in sentence_tokens:
+                            token_offsets.append((offset, offset + len(token.text)))
+                            offset += len(token.text) + token.whitespace_after
+
+                        verbose = True
+                        subtokens = []
+                        if verbose:
+                            subtokens = self.tokenizer.convert_ids_to_tokens(input_ids.tolist()[sentence_no])
+                            # old_mapping = batch_encoding.word_ids(sentence_no)
+
+                        mapping = map_tokens_to_subtokens(
+                            subtoken_offsets=subtoken_offsets,
+                            token_offsets=token_offsets,
+                            subtokens=subtokens,
+                            tokens=tokens,
+                            verbose=verbose,
+                        )
+
+                        word_ids_list.append(mapping)
+
+                        # we need to find other causes of divergence - other causes?
+                        if mapping.count(None) > 2 or True:
+                            print("---")
+                            print("tokens = ", tokens)
+                            print("subtokens = ", subtokens)
+                            print("subtoken_offsets = ", subtoken_offsets)
+                            print("token_offsets = ", token_offsets)
+                            print(mapping)
+                            # print(old_mapping)  # why is the old mapping incorrect?
+                            print("---")
+                else:
+                    word_ids_list = [batch_encoding.word_ids(i) for i in range(input_ids.size()[0])]
             else:
                 word_ids_list = _legacy_reconstruct_word_ids(
                     self,
@@ -1050,6 +1159,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         transformers_model_kwargs: dict[str, Any] = {},
         peft_config=None,
         peft_gradient_checkpointing_kwargs: Optional[dict[str, Any]] = {},
+        use_raw_text_as_input: bool = False,
         **kwargs,
     ) -> None:
         """Instantiate transformers embeddings.
@@ -1096,6 +1206,7 @@ class TransformerEmbeddings(TransformerBaseEmbeddings):
         logging.set_verbosity_error()
 
         self.tokenizer: PreTrainedTokenizer
+        self.use_raw_text_as_input = use_raw_text_as_input
         self.feature_extractor: Optional[FeatureExtractionMixin]
 
         if tokenizer_data is None:

--- a/flair/embeddings/transformer.py
+++ b/flair/embeddings/transformer.py
@@ -703,7 +703,6 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
                 if self.use_raw_text_as_input:
                     word_ids_list = []
                     for sentence_no, sentence_tokens in enumerate(flair_tokens):
-                        tokens = [t.text for t in sentence_tokens]
 
                         subtoken_offsets = batch_encoding["offset_mapping"][sentence_no]
 
@@ -713,32 +712,13 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
                             token_offsets.append((offset, offset + len(token.text)))
                             offset += len(token.text) + token.whitespace_after
 
-                        verbose = True
-                        subtokens = []
-                        if verbose:
-                            subtokens = self.tokenizer.convert_ids_to_tokens(input_ids.tolist()[sentence_no])
-                            # old_mapping = batch_encoding.word_ids(sentence_no)
-
                         mapping = map_tokens_to_subtokens(
                             subtoken_offsets=subtoken_offsets,
                             token_offsets=token_offsets,
-                            subtokens=subtokens,
-                            tokens=tokens,
-                            verbose=verbose,
                         )
 
                         word_ids_list.append(mapping)
 
-                        # we need to find other causes of divergence - other causes?
-                        if mapping.count(None) > 2 or True:
-                            print("---")
-                            print("tokens = ", tokens)
-                            print("subtokens = ", subtokens)
-                            print("subtoken_offsets = ", subtoken_offsets)
-                            print("token_offsets = ", token_offsets)
-                            print(mapping)
-                            # print(old_mapping)  # why is the old mapping incorrect?
-                            print("---")
                 else:
                     word_ids_list = [batch_encoding.word_ids(i) for i in range(input_ids.size()[0])]
             else:
@@ -748,6 +728,8 @@ class TransformerBaseEmbeddings(Embeddings[Sentence]):
                 )
                 # word_ids is only supported for fast rust tokenizers. Some models like "xlm-mlm-ende-1024" do not have
                 # a fast tokenizer implementation, hence we need to fall back to our own reconstruction of word_ids.
+
+            # print(word_ids_list)
 
             if self.token_embedding:
                 assert offsets is not None  # for type checking

--- a/tests/embeddings/test_transformer_word_embeddings.py
+++ b/tests/embeddings/test_transformer_word_embeddings.py
@@ -4,10 +4,12 @@ import warnings
 import pytest
 import torch
 from PIL import Image
+from torch import tensor
 from transformers.utils import is_detectron2_available
 
 from flair.data import BoundingBox, Dictionary, Sentence
 from flair.embeddings import TransformerJitWordEmbeddings, TransformerWordEmbeddings
+from flair.embeddings.transformer import map_tokens_to_subtokens
 from flair.models import SequenceTagger
 from tests.embedding_test_utils import BaseEmbeddingsTest
 
@@ -323,3 +325,52 @@ class TestTransformerWordEmbeddings(BaseEmbeddingsTest):
         for sent_a, sent_b in zip(normal_sentences, onnx_sentences):
             for token_a, token_b in zip(sent_a, sent_b):
                 assert torch.isclose(token_a.get_embedding(), token_b.get_embedding(), atol=1e-6).all()
+
+    def test_token_subtoken_mapping(self):
+        ### Test Case 1: Normal text
+        # text = "BEST DENTIST EVER -"
+
+        # Token and subtoken offsets
+        # tokens = ["[FLERT]", "BEST", "DENTIST", "EVER", "-", "[FLERT]"]
+        token_offsets = [(0, 7), (8, 12), (13, 20), (21, 25), (26, 27), (27, 34)]
+
+        # subtokens = ["[CLS]", "[FLERT]", "▁BEST", "▁D", "ENT", "IST", "▁EVER", "▁-", "[FLERT]", "[SEP]", ]
+        subtoken_offsets = tensor(
+            [[0, 0], [0, 7], [8, 12], [12, 14], [14, 17], [17, 20], [20, 25], [25, 27], [27, 34], [0, 0]]
+        )
+
+        mapping = map_tokens_to_subtokens(subtoken_offsets=subtoken_offsets, token_offsets=token_offsets)
+
+        assert [None, 0, 1, 2, 2, 2, 3, 4, 5, None] == mapping
+
+        ### Test Case 2: Differing tokenizations
+        # text = "So don't be afraid"
+
+        # Token and subtoken offsets
+        # tokens = ["[FLERT]", "So", "do", "n't", "be", "afraid", "[FLERT]"]
+        token_offsets = [(0, 7), (8, 10), (11, 13), (13, 16), (17, 19), (20, 26), (26, 33)]
+
+        # subtokens = ["[CLS]", "[FLERT]", "▁So", "▁don", "'", "t", "▁be", "▁afraid", "[FLERT]", "[SEP]"]
+        subtoken_offsets = tensor(
+            [[0, 0], [0, 7], [8, 10], [10, 14], [14, 15], [15, 16], [16, 19], [19, 26], [26, 33], [0, 0]]
+        )
+
+        mapping = map_tokens_to_subtokens(subtoken_offsets=subtoken_offsets, token_offsets=token_offsets)
+
+        assert [None, 0, 1, 2, 3, 3, 4, 5, 6, None] == mapping
+
+        ### Test Case 3: Text with punctuation and no whitespaces
+        # text = "this and/or that,"
+
+        # Token and subtoken offsets
+        # tokens = ["[FLERT]", "this", "and", "/", "or", "that", ",", "[FLERT]"]
+        token_offsets = [(0, 7), (8, 12), (13, 16), (16, 17), (17, 19), (20, 24), (24, 25), (25, 32)]
+
+        # subtokens = ["[CLS]", "[FLERT]", "▁this", "▁and", "/", "or", "▁that", ",", "[FLERT]", "[SEP]"]
+        subtoken_offsets = tensor(
+            [[0, 0], [0, 7], [8, 12], [12, 16], [16, 17], [17, 19], [19, 24], [24, 25], [25, 32], [0, 0]]
+        )
+
+        mapping = map_tokens_to_subtokens(subtoken_offsets=subtoken_offsets, token_offsets=token_offsets)
+
+        assert [None, 0, 1, 2, 3, 4, 5, 6, 7, None] == mapping

--- a/tests/embeddings/test_transformer_word_embeddings.py
+++ b/tests/embeddings/test_transformer_word_embeddings.py
@@ -374,3 +374,28 @@ class TestTransformerWordEmbeddings(BaseEmbeddingsTest):
         mapping = map_tokens_to_subtokens(subtoken_offsets=subtoken_offsets, token_offsets=token_offsets)
 
         assert [None, 0, 1, 2, 3, 4, 5, 6, 7, None] == mapping
+
+        ### Test Case 4: Suboptimal tokenization caused by limited vocabulary without whitespace
+        # text = "number of public-diplomacy officers"
+
+        # Token and subtoken offsets
+        # tokens = ['number', 'of', 'public', '-', 'diplomacy', 'officers']
+        token_offsets = [(0, 6), (7, 9), (10, 16), (16, 17), (17, 26), (27, 35)]
+
+        # new_subtokens = ['[CLS]', '▁number', '▁of', '▁public', '-', 'diploma', 'cy', '▁officers', '[SEP]']
+        # old_subtokens = ['[CLS]', '▁number', '▁of', '▁public', '▁-', '▁diplomacy', '▁officers', '[SEP]']
+        subtoken_offsets = tensor([[0, 0], [0, 6], [6, 9], [9, 16], [16, 17], [17, 24], [24, 26], [26, 35], [0, 0]])
+
+        assert [None, 0, 1, 2, 3, 4, 5, 6, 7, None] == mapping
+
+        ### Test Case 5: Suboptimal tokenization in which two tokenizer words become one subtoken ("wan" "na" -> "wanna")
+        # text = "I gotta have it"
+
+        # Token and subtoken offsets
+        # tokens = ['I', 'got', 'ta', 'have', 'it']
+        token_offsets = [(0, 1), (2, 5), (5, 7), (8, 12), (13, 15)]
+
+        # new subtokens = ['[CLS]', '▁I', '▁gotta', '▁have', '▁it', '[SEP]']
+        # old subtokens = ['[CLS]', '▁I', '▁got', '▁ta', '▁have', '▁it', '[SEP]']
+        subtoken_offsets = tensor([[0, 0], [0, 1], [1, 7], [7, 12], [12, 15], [0, 0]])
+        assert [None, 0, 1, 2, 3, 4, 5, 6, 7, None] == mapping


### PR DESCRIPTION
Closes #3400 

This PR adds a new parameter to TransformerWordEmbeddings that optionally allows you to choose to embed the "raw text" of sentences. This means that whitespace information is preserved in the embeddings. 

This is best illustrated with this snippet in which the sentences "`I love Berlin.`" and "`I love Berlin .`" normally get the same embeddings, but with the parameter set get different embeddings, reflecting the inserted whitespace: 

```python
import flair
from flair.data import Sentence
from flair.embeddings import TransformerWordEmbeddings

flair.device = "cpu"
embeddings = TransformerWordEmbeddings("microsoft/deberta-v3-xsmall")

# two example sentences, difference is whether the period is offset with a whitespace
sentence_1 = Sentence("I love Berlin.")
sentence_2 = Sentence("I love Berlin .")

# We embed both and find the embeddings are the same
embeddings.embed([sentence_1, sentence_2])
print(sentence_1[2].embedding[:5])
print(sentence_2[2].embedding[:5])

# repeat this experiment, but this time use raw text (= preserve the whitespace information)
embeddings = TransformerWordEmbeddings("microsoft/deberta-v3-xsmall", use_raw_text_as_input=True)

# two example sentences, difference is whether the period is offset with a whitespace
sentence_1 = Sentence("I love Berlin.")
sentence_2 = Sentence("I love Berlin .")

# Not the two sentences have different embeddings
embeddings.embed([sentence_1, sentence_2])
print(sentence_1[2].embedding[:5])
print(sentence_2[2].embedding[:5])
```

Theoretically, accurately reflecting whitespaces should give us better performance. 

However, in my limited experiments I am finding the opposite to be the case. The reason seems to be twofold: 

1. The vocabulary for tokens that do not follow a whitespace is impoverished. For instance, the above transformer model has an entry for "`▁diplomacy`" (the word "diplomacy" following a whitespace) but no entry for "`diplomacy`", causing the word to be split into `diploma` and `cy` in a sentence like "`number of public-diplomacy officers`". This is suboptimal. 

2. The regular implementation always ensures that the tokenization of the dataset is exactly used, including "unrealistic" tokenization. For instane, in the UD dataset I used to test, the word "`gotta`" ("`I gotta have this`") is tokenized as "`got`" and "`ta`". Our standard implementation uses these tokens as subtokens, while the whitespace-preserving option will subtokenize this as a single subtoken `gotta`, which results in the the two UD tokens getting the same embedding. This will impact evaluation numbers but actually have no impact on practical application, since most tokenizers do not split mid-word. 

My feeling is that these two issues do more harm than the advantage given by accurately reflecting whitespaces. More testing is needed though to confirm.



