### PR TITLE
Prevent error if not all metrics are present for a task

### DIFF
--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -198,7 +198,8 @@ class MultitaskModel(flair.nn.Classifier):
             # Add metrics so they will be available to _publish_eval_result.
             for avg_type in ("micro avg", "macro avg"):
                 for metric_type in ("f1-score", "precision", "recall"):
-                    scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
+                    if result.classification_report.get(avg_type) and result.classification_report["avg_type"].get(metric_type):
+                        scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
         scores["loss"] = loss.item() / len(batch_split)
 


### PR DESCRIPTION
Recently per-task metrics were added to multitask_model, however we ran into an error where some task may not have all these metrics. So this is a one-line fix to prevent errors in that case.