### PR TITLE
GH-3633: add option to add license information to Flair models

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -112,7 +112,7 @@ class SequenceTagger(flair.nn.Classifier[Sentence]):
         self.predict_spans = self._determine_if_span_prediction_problem(self.label_dictionary)
 
         self.tagset_size = len(self.label_dictionary)
-        log.info(f"SequenceTagger predicts: {self.label_dictionary}")
+        log.info(f"- Predicts {len(self.label_dictionary)} classes: {self.label_dictionary.get_items()[:20]}")
 
         # ----- Embeddings -----
         self.embeddings = embeddings


### PR DESCRIPTION
This PR adds the ability to set and retrieve license information for Flair models. License information is stored in the model card and is automatically displayed when loading a model.

## Changes
- Added `license_info` property to Model class with getter and setter methods
- License information is stored in the model's model_card
- Added automatic display of license information when loading models
- Improved model loading messages to show model type and predicted tags
- Added unit test for license functionality

## Example Usage
```python
# Set a license for a model
model = Model.load('ner')
model.license_info = "MIT License - Copyright (c) 2024"
model.save('model.pt')

# Load model - automatically shows license
loaded_model = Model.load('model.pt')
# Output:
# --------------------------------------------------
# Loading SequenceTagger model
# Model license: MIT License - Copyright (c) 2024
# --------------------------------------------------
```

## Testing
Added test case that verifies:
- Setting and getting license information
- License persistence through save/load cycles
- Default behavior for models without license

Closes #3633 