### PR TITLE
Fix StaccatoTokenizer Handling of Zero-Width Characters and BOM

### DIFF
--- a/flair/tokenization.py
+++ b/flair/tokenization.py
@@ -365,6 +365,6 @@ class StaccatoTokenizer(Tokenizer):
         # re.findall returns a list of tuples, where each tuple corresponds to the capturing groups.
         # For a match, only one group will be non-empty. We extract that non-empty group.
         # Example match: ('word', '', '', '') or ('', '123', '', '') or ('', '', '好', '') or ('', '', '', '.')
-        tokens = [next(filter(None, match_tuple)) for match_tuple in matches]
+        tokens: list[str] = [next(filter(None, match_tuple)) for match_tuple in matches]
 
         return tokens

--- a/tests/test_tokenize_sentence.py
+++ b/tests/test_tokenize_sentence.py
@@ -380,25 +380,25 @@ def test_print_sentence_plain(tasks_base_path):
     sentence = corpus.train[0]
     sentence.infer_space_after()
     assert (
-            sentence.to_tokenized_string() == 'Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in '
-                                              "einer Weise aufgetreten , "
-                                              'die alles andere als überzeugend war " .'
+        sentence.to_tokenized_string() == 'Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in '
+        "einer Weise aufgetreten , "
+        'die alles andere als überzeugend war " .'
     )
     assert (
-            sentence.to_plain_string() == 'Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer '
-                                          "Weise aufgetreten, die "
-                                          'alles andere als überzeugend war".'
+        sentence.to_plain_string() == 'Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer '
+        "Weise aufgetreten, die "
+        'alles andere als überzeugend war".'
     )
 
     sentence = corpus.train[1]
     sentence.infer_space_after()
     assert (
-            sentence.to_tokenized_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
-                                              "Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf ."
+        sentence.to_tokenized_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
+        "Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf ."
     )
     assert (
-            sentence.to_plain_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
-                                          "Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf."
+        sentence.to_plain_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
+        "Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf."
     )
 
 
@@ -613,6 +613,7 @@ def test_create_sentence_difficult_encoding():
     )
     sentence = Sentence(text, use_tokenizer=StaccatoTokenizer())
     assert len(sentence) == 40
+
 
 def test_sentence_retokenize():
     # Create a sentence with default tokenization

--- a/tests/test_tokenize_sentence.py
+++ b/tests/test_tokenize_sentence.py
@@ -48,29 +48,6 @@ def test_create_sentence_with_extra_whitespace():
     assert sentence.get_token(4).text == "."
 
 
-@pytest.mark.skip(reason="Fix these issues for StaccatoTokenizer in future PR")
-def test_create_sentence_difficult_encoding():
-    text = "so out of the norm ❤ ️ enjoyed every moment️"
-    sentence = Sentence(text)
-    assert len(sentence) == 9
-
-    text = (
-        "equivalently , accumulating the logs as :( 6 ) sl = 1N ∑ t = 1Nlogp "
-        "( Ll | xt \u200b , θ ) where "
-        "p ( Ll | xt \u200b , θ ) represents the class probability output"
-    )
-    sentence = Sentence(text)
-    assert len(sentence) == 37
-
-    text = "This guy needs his own show on Discivery Channel ! ﻿"
-    sentence = Sentence(text)
-    assert len(sentence) == 10
-
-    text = "n't have new vintages."
-    sentence = Sentence(text, use_tokenizer=True)
-    assert len(sentence) == 5
-
-
 def test_create_sentence_word_by_word():
     token1: Token = Token("Munich")
     token2: Token = Token("and")
@@ -403,25 +380,25 @@ def test_print_sentence_plain(tasks_base_path):
     sentence = corpus.train[0]
     sentence.infer_space_after()
     assert (
-        sentence.to_tokenized_string() == 'Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in '
-        "einer Weise aufgetreten , "
-        'die alles andere als überzeugend war " .'
+            sentence.to_tokenized_string() == 'Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in '
+                                              "einer Weise aufgetreten , "
+                                              'die alles andere als überzeugend war " .'
     )
     assert (
-        sentence.to_plain_string() == 'Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer '
-        "Weise aufgetreten, die "
-        'alles andere als überzeugend war".'
+            sentence.to_plain_string() == 'Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer '
+                                          "Weise aufgetreten, die "
+                                          'alles andere als überzeugend war".'
     )
 
     sentence = corpus.train[1]
     sentence.infer_space_after()
     assert (
-        sentence.to_tokenized_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
-        "Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf ."
+            sentence.to_tokenized_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
+                                              "Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf ."
     )
     assert (
-        sentence.to_plain_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
-        "Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf."
+            sentence.to_plain_string() == "Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als "
+                                          "Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf."
     )
 
 
@@ -615,6 +592,27 @@ def test_staccato_tokenizer_with_multilingual_text():
     arabic_sentence = Sentence("مرحبا بالعالم! 123", use_tokenizer=StaccatoTokenizer())
     assert [token.text for token in arabic_sentence.tokens] == ["مرحبا", "بالعالم", "!", "123"]
 
+
+def test_create_sentence_difficult_encoding():
+    text = "so out of the norm ❤ ️ enjoyed every moment️"
+    sentence = Sentence(text, use_tokenizer=StaccatoTokenizer())
+    assert len(sentence) == 9
+
+    text = "This guy needs his own show on Discivery Channel ! ﻿"
+    sentence = Sentence(text, use_tokenizer=StaccatoTokenizer())
+    assert len(sentence) == 10
+
+    text = "n't have new vintages."
+    sentence = Sentence(text, use_tokenizer=True)
+    assert len(sentence) == 5
+
+    text = (
+        "equivalently , accumulating the logs as :( 6 ) sl = 1N ∑ t = 1Nlogp "
+        "( Ll | xt \u200b , θ ) where "
+        "p ( Ll | xt \u200b , θ ) represents the class probability output"
+    )
+    sentence = Sentence(text, use_tokenizer=StaccatoTokenizer())
+    assert len(sentence) == 40
 
 def test_sentence_retokenize():
     # Create a sentence with default tokenization


### PR DESCRIPTION
This pull request addresses issues in the `StaccatoTokenizer` related to the handling of certain non-printing Unicode characters, specifically zero-width characters like variation selectors (e.g., U+FE0F) and the Byte Order Mark (BOM, U+FEFF).

**Problem:**

The previous implementation could incorrectly split tokens or generate spurious empty/single-character tokens when encountering:
1.  Zero-width variation selectors often used with emojis (e.g., `❤` + `️` U+FE0F).
2.  The Byte Order Mark (U+FEFF), which is sometimes present at the beginning of files or incorrectly used as a zero-width space within text.

This resulted in unexpected tokenization outputs like `['norm', '❤', '️', 'enjoyed']` instead of `['norm', '❤', 'enjoyed']` or adding an empty token at the end of a sentence if it contained a BOM.

**Solution:**

1.  **Refactored Tokenization Logic:** The `tokenize` method was changed from using `re.split` followed by whitespace splitting to using `re.findall`. A comprehensive regex pattern (`self.token_pattern`) was constructed to directly find and extract valid tokens based on defined categories: sequences of letters (across various scripts), sequences of digits, individual Kanji characters, and individual punctuation/symbol characters.
2.  **Excluded Non-Printing Characters:** The regex pattern used to identify punctuation/symbols (`self.punctuation`) was modified to explicitly *exclude* common zero-width characters (\uFE00-\uFE0F, \u200B-\u200D, \u2060-\u206F) and the BOM (\uFEFF) by adding them to the negated character set `[^...]`.

**Impact:**

*   The `StaccatoTokenizer` now correctly ignores these non-printing characters during tokenization, preventing spurious splits and unwanted tokens.
*   Tokenization results are more robust and align better with the intended behavior of preserving contiguous letter/number sequences while splitting off meaningful punctuation and symbols.
*   Fixes issues observed with specific text examples containing emojis with variation selectors and trailing BOM characters.

Closes #3652 