### PR TITLE
Add JSON-based serialization logic and deepcopy implementation for Sentence object

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -2059,7 +2059,7 @@ class Sentence(DataPoint):
             end_char = span_info["end_char"]
 
             target_tokens: list[Token] = []
-            if self._tokens is not None:                
+            if self._tokens is not None:
                 for token in self._tokens:
                     # FIX: Make token positions relative to sentence for comparison
                     token_start_in_sentence = token.start_position - self.start_position

--- a/flair/data.py
+++ b/flair/data.py
@@ -1251,9 +1251,13 @@ class Sentence(DataPoint):
                 for token in text:
                     self._add_token(token)
 
+                # The last token of a sentence should not have trailing whitespace.
+                if len(self._tokens) > 0:
+                    self._tokens[-1].whitespace_after = 0
+
                 # reconstruct text from tokens
-                if len(self.tokens) > 0:
-                    self._text = "".join([t.text + t.whitespace_after * " " for t in self.tokens]).strip()
+                if len(self._tokens) > 0:
+                    self._text = "".join([t.text + t.whitespace_after * " " for t in self._tokens]).strip()
                 else:
                     self._text = ""
 
@@ -1505,7 +1509,7 @@ class Sentence(DataPoint):
 
         # clear token embeddings if sentence is tokenized
         if self._is_tokenized():
-            for token in self.tokens:
+            for token in self._tokens:
                 token.clear_embeddings(embedding_names)
 
     def left_context(self, context_length: int, respect_document_boundaries: bool = True) -> list[Token]:
@@ -1893,7 +1897,7 @@ class Sentence(DataPoint):
         # only access tokens if already tokenized
         if self._is_tokenized():
             # labels also need to be deleted at all tokens
-            for token in self.tokens:
+            for token in self._tokens:
                 token.remove_labels(typename)
 
             # labels also need to be deleted at all known spans

--- a/flair/data.py
+++ b/flair/data.py
@@ -1509,8 +1509,9 @@ class Sentence(DataPoint):
 
         # clear token embeddings if sentence is tokenized
         if self._is_tokenized():
-            for token in self._tokens:
-                token.clear_embeddings(embedding_names)
+            if self._tokens is not None:
+                for token in self._tokens:
+                    token.clear_embeddings(embedding_names)
 
     def left_context(self, context_length: int, respect_document_boundaries: bool = True) -> list[Token]:
         sentence = self
@@ -1897,8 +1898,9 @@ class Sentence(DataPoint):
         # only access tokens if already tokenized
         if self._is_tokenized():
             # labels also need to be deleted at all tokens
-            for token in self._tokens:
-                token.remove_labels(typename)
+            if self._tokens is not None:
+                for token in self._tokens:
+                    token.remove_labels(typename)
 
             # labels also need to be deleted at all known spans
             for span in self._known_spans.values():
@@ -2057,8 +2059,8 @@ class Sentence(DataPoint):
             end_char = span_info["end_char"]
 
             target_tokens: list[Token] = []
-            if self._tokens:
-                for token in self.tokens:
+            if self._tokens is not None:                
+                for token in self._tokens:
                     # FIX: Make token positions relative to sentence for comparison
                     token_start_in_sentence = token.start_position - self.start_position
                     token_end_in_sentence = token.end_position - self.start_position

--- a/tests/test_sentence_serialization.py
+++ b/tests/test_sentence_serialization.py
@@ -1,0 +1,111 @@
+import copy
+from flair.data import Sentence, Relation
+from flair.tokenization import SegtokTokenizer, SpaceTokenizer
+
+
+def _create_annotated_sentence() -> Sentence:
+    """
+    Creates a complexly annotated sentence for testing.
+    "George Washington went to Washington."
+    - Sentence-level label
+    - "George Washington" is a PERSON
+    - "Washington" is a LOCATION
+    - Relation: (George Washington)-[went_to]->(Washington)
+    """
+    sentence = Sentence(
+        "George Washington went to Washington.",
+        use_tokenizer=SegtokTokenizer(),
+    )
+
+    # Add sentence-level label
+    sentence.add_label("category", "HISTORICAL_EVENT")
+
+    # Add span labels
+    sentence[0:2].add_label("ner", "PERSON")  # "George Washington"
+    sentence[4:5].add_label("ner", "LOCATION")  # "Washington"
+
+    # Add relation label
+    person_span = sentence[0:2]
+    location_span = sentence[4:5]
+
+    relation = Relation(person_span, location_span)
+    relation.add_label("relation", "WENT_TO")
+
+    return sentence
+
+
+def _assert_sentences_equal(s1: Sentence, s2: Sentence):
+    """Helper method to assert equality between two sentences."""
+    # 1. Check basic properties
+    assert s1.to_original_text() == s2.to_original_text()
+    assert s1.tokenizer.name == s2.tokenizer.name
+    assert len(s1) == len(s2)
+
+    # 2. Check tokens
+    for t1, t2 in zip(s1.tokens, s2.tokens):
+        assert t1.text == t2.text
+        assert t1.start_position == t2.start_position
+
+    # 3. Check sentence-level labels
+    s1_sent_labels = {(label.value, label.score) for label in s1.get_labels("category")}
+    s2_sent_labels = {(label.value, label.score) for label in s2.get_labels("category")}
+    assert s1_sent_labels == s2_sent_labels
+
+    # 4. Check spans
+    s1_spans = {(span.text, span.tag) for span in s1.get_spans("ner")}
+    s2_spans = {(span.text, span.tag) for span in s2.get_spans("ner")}
+    assert s1_spans == s2_spans
+    assert len(s1.get_spans("ner")) == len(s2.get_spans("ner"))
+
+    # 5. Check relations
+    s1_relations = {label.value for label in s1.get_labels("relation")}
+    s2_relations = {label.value for label in s2.get_labels("relation")}
+    assert s1_relations == s2_relations
+
+
+def test_deepcopy_preserves_annotations():
+    """Tests that copy.deepcopy() creates a true, independent copy."""
+    original_sentence = _create_annotated_sentence()
+
+    # Perform deepcopy
+    copied_sentence = copy.deepcopy(original_sentence)
+
+    # Assert they are different objects in memory
+    assert id(original_sentence) != id(copied_sentence)
+    assert id(original_sentence.tokens[0]) != id(copied_sentence.tokens[0])
+
+    # Assert content is identical
+    _assert_sentences_equal(original_sentence, copied_sentence)
+
+
+def test_json_serialization_preserves_annotations():
+    """Tests the to_dict() -> from_dict() cycle."""
+    original_sentence = _create_annotated_sentence()
+
+    # Serialize and deserialize
+    sentence_dict = original_sentence.to_dict()
+    recreated_sentence = Sentence.from_dict(sentence_dict)
+
+    # Assert they are different objects in memory
+    assert id(original_sentence) != id(recreated_sentence)
+
+    # Assert content is identical
+    _assert_sentences_equal(
+        original_sentence,
+        recreated_sentence,
+    )
+
+
+def test_serialization_preserves_tokenizer():
+    """Tests that a non-default tokenizer is preserved."""
+    # Use a non-default tokenizer
+    sentence = Sentence("A simple test.", use_tokenizer=SpaceTokenizer())
+    sentence.add_label("topic", "testing")
+
+    # Serialize and deserialize
+    recreated_sentence = Sentence.from_dict(sentence.to_dict())
+
+    # Check that the tokenizer is of the correct type
+    assert isinstance(recreated_sentence.tokenizer, SpaceTokenizer)
+    assert sentence.tokenizer.name == recreated_sentence.tokenizer.name
+    assert len(sentence.tokens) == len(recreated_sentence.tokens)


### PR DESCRIPTION
This pull request introduces a comprehensive solution for serializing and deep-copying Flair's Sentence objects, addressing a long-standing issue where standard methods like copy.deepcopy() and pickle would fail.

Closes #3245 

This PR implements two key mechanisms to solve this problem:

1.  **JSON Serialization (`to_dict` / `from_dict`):**
    -   A new `sentence.to_dict()` method serializes the entire `Sentence` object—including its text, tokenizer, and all annotations (spans, relations, and labels at all levels)—into a clean, JSON-compatible dictionary.
    -   A corresponding class method, `Sentence.from_dict()`, fully reconstructs the `Sentence` object from this dictionary, correctly restoring all annotations and the original tokenizer.
    -   The core logic is encapsulated in two powerful private helpers, `_capture_annotations()` and `_reapply_annotations()`, which use character offsets to robustly map annotations between different tokenizations. This also allowed for a significant simplification of the existing `retokenize()` logic.

2.  **Custom Deep Copy (`__deepcopy__`):**
    -   A custom `__deepcopy__` method has been implemented for the `Sentence` class.
    -   This method intelligently navigates the object graph, manually recreating tokens, spans, and relations while respecting the caching mechanism of `Span` and `Relation`.
    -   This makes `Sentence` objects fully compatible with Python's `copy.deepcopy()`, resolving the original `TypeError`.

#### Key Changes

-   **New Public Methods:** Added `Sentence.to_dict()`, `Sentence.from_dict()`, and `Sentence.__deepcopy__()`.
-   **Refactoring:**
    -   Refactored the `Sentence` constructor (`__init__`) to correctly handle initialization from raw text, a list of strings, and a list of pre-made `Token` objects, which was critical for the deserialization logic.
    -   Simplified the `retokenize()` implementation by reusing the new annotation helper methods.
    -   Made the `_add_token()` method more robust in calculating token start positions.
-   **Testing:**
    -   Created a new test file, `tests/test_sentence_serialization.py`, with comprehensive unit tests.
    -   These tests verify that both deep-copying and the JSON serialization cycle perfectly preserve complex annotations (including multi-word spans and relations) and the sentence's tokenizer configuration.
-   **Bug Fixes:** Addressed several `mypy` type-checking errors that arose during the refactoring to ensure the new code is robust and maintainable.